### PR TITLE
ARQ-455 Fix resource lookup prefix

### DIFF
--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
@@ -42,7 +42,7 @@ import org.jboss.arquillian.test.spi.TestEnricher;
  */
 public class ResourceInjectionEnricher implements TestEnricher
 {
-   private static final String RESOURCE_LOOKUP_PREFIX = "java:/comp/env";
+   private static final String RESOURCE_LOOKUP_PREFIX = "java:comp/env";
    private static final String ANNOTATION_NAME = "javax.annotation.Resource";
    
    


### PR DESCRIPTION
Updated resource lookup prefix to "java:comp/env".
