### PR TITLE
ARQ-488 Added shrinkwrap-impl-base dependency in arq-testng-container

### DIFF
--- a/testng/container/pom.xml
+++ b/testng/container/pom.xml
@@ -107,6 +107,11 @@
 
         <!-- External Projects -->
         <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Fixed missing dependency.
