### PR TITLE
Fixed typo in maven artifact name

### DIFF
--- a/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.1.xml
+++ b/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.1.xml
@@ -106,7 +106,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.arquillian.container</groupId>
-			<artifactId>arquillian-weld-se-embedded-1</artifactId>
+			<artifactId>arquillian-weld-se-embedded-1.1</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
There is a typo in the maven artifact identifier for "Weld SE 1.1 - Embedded". The example in the documentation references the maven artifact for "Weld SE 1.0 - Embedded". I got strange ClassNotFoundExceptions due to this. :-)
