### PR TITLE
Minor BeanManagerProducer Refactoring

### DIFF
--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
@@ -10,12 +10,14 @@
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,  
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package org.jboss.arquillian.testenricher.cdi.container;
+
+import java.util.logging.Logger;
 
 import javax.enterprise.inject.spi.BeanManager;
 import javax.naming.Context;
@@ -34,16 +36,25 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 public class BeanManagerProducer
 {
    private static final String STANDARD_BEAN_MANAGER_JNDI_NAME = "java:comp/BeanManager";
-   private static final String SERVLET_BEAN_MANAGER_JNDI_NAME = "java:comp/env/BeanManager";
-   private static final String JBOSSAS_BEAN_MANAGER_JNDI_NAME = "java:global/test/arquillian-protocol/BeanManager";
 
-   @Inject @ApplicationScoped
+   private static final String SERVLET_BEAN_MANAGER_JNDI_NAME = "java:comp/env/BeanManager";
+
+   // TODO: Hack until BeanManager binding fixed in JBoss AS
+   private static final String JBOSSAS_BEAN_MANAGER_JNDI_NAME = "BeanManager";
+
+   private static final String[] BEAN_MANAGER_JNDI_NAMES =
+   {STANDARD_BEAN_MANAGER_JNDI_NAME, SERVLET_BEAN_MANAGER_JNDI_NAME, JBOSSAS_BEAN_MANAGER_JNDI_NAME};
+
+   private static final Logger log = Logger.getLogger(BeanManagerProducer.class.getName());
+
+   @Inject
+   @ApplicationScoped
    private InstanceProducer<BeanManager> beanManagerProducer;
-   
+
    public void findBeanManager(@Observes Context context)
    {
       BeanManager manager = lookup(context);
-      if(manager != null)
+      if (manager != null)
       {
          beanManagerProducer.set(manager);
       }
@@ -51,27 +62,20 @@ public class BeanManagerProducer
 
    private BeanManager lookup(Context context)
    {
-      try 
-      {
-         return (BeanManager) context.lookup(STANDARD_BEAN_MANAGER_JNDI_NAME);
-      }
-      catch (Exception e) 
+      for (String beanManagerJndiName : BEAN_MANAGER_JNDI_NAMES)
       {
          try
          {
-            return (BeanManager) context.lookup(SERVLET_BEAN_MANAGER_JNDI_NAME);
+            return (BeanManager) context.lookup(beanManagerJndiName);
          }
-         catch (Exception se) {}
-
-         // TODO: hack until BeanManager binding fixed in JBoss AS
-         try 
+         catch (Exception e)
          {
-            return (BeanManager) context.lookup(JBOSSAS_BEAN_MANAGER_JNDI_NAME);
-         } 
-         catch (Exception je)
-         {
-            return null;
+            log.fine("Tried to lookup the BeanManager with name " + beanManagerJndiName + " but caught exception: "
+                  + e.getMessage());
          }
       }
+
+      log.info("BeanManager not found.");
+      return null;
    }
 }


### PR DESCRIPTION
BeanManagerProducer now loops over possible JNDI names rather than recursively try/catching.
