### PR TITLE
ARQ-148 Support EL-like expressions for sysprops and env variables in arq

### DIFF
--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
@@ -25,6 +25,7 @@ import org.jboss.arquillian.config.descriptor.api.DefaultProtocolDef;
 import org.jboss.arquillian.config.descriptor.api.EngineDef;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
 import org.jboss.arquillian.config.descriptor.api.GroupDef;
+import org.jboss.shrinkwrap.descriptor.api.DescriptorExportException;
 import org.jboss.shrinkwrap.descriptor.spi.DescriptorExporter;
 import org.jboss.shrinkwrap.descriptor.spi.Node;
 import org.jboss.shrinkwrap.descriptor.spi.NodeProviderImplBase;
@@ -60,6 +61,7 @@ public class ArquillianDescriptorImpl extends NodeProviderImplBase implements Ar
    {
       super(descirptorName);
       this.model = model;
+      NodePropertiesReplacer.walkAndReplace(this.model);
    }
 
    //-------------------------------------------------------------------------------------||
@@ -177,5 +179,14 @@ public class ArquillianDescriptorImpl extends NodeProviderImplBase implements Ar
    protected DescriptorExporter getExporter()
    {
       return new XmlDomExporter();
+   }
+   
+   /* (non-Javadoc)
+    * @see org.jboss.shrinkwrap.descriptor.api.Descriptor#exportAsString()
+    */
+   @Override
+   public String exportAsString() throws DescriptorExportException
+   {      
+      return StringPropertyReplacer.replaceProperties(super.exportAsString());
    }
 }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
@@ -51,6 +51,7 @@ public class ContainerDefImpl extends ArquillianDescriptorImpl implements Contai
    {
       super(descirptorName, model);
       this.container = container;
+      NodePropertiesReplacer.walkAndReplace(this.container);
    }
    
    //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
@@ -37,6 +37,7 @@ public class DefaultProtocolDefImpl extends ArquillianDescriptorImpl implements 
    {
       super(descirptorName, model);
       this.protocol = protocol;
+      NodePropertiesReplacer.walkAndReplace(this.protocol);
    }
 
    //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/EngineDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/EngineDefImpl.java
@@ -39,6 +39,7 @@ public class EngineDefImpl extends ArquillianDescriptorImpl implements EngineDef
    {
       super(descriptorName, model);
       this.engine = engine;
+      NodePropertiesReplacer.walkAndReplace(this.engine);
    }
    
    /* (non-Javadoc)

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
@@ -49,6 +49,7 @@ public class ExtensionDefImpl extends ArquillianDescriptorImpl implements Extens
    {
       super(descirptorName, model);
       this.extension = extension;
+      NodePropertiesReplacer.walkAndReplace(this.extension);
    }
 
    // -------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupContainerDefImpl.java
@@ -37,6 +37,7 @@ public class GroupContainerDefImpl extends ContainerDefImpl implements GroupDef
    {
       super(descirptorName, model, container);
       this.group = group;
+      NodePropertiesReplacer.walkAndReplace(this.group);
    }
 
    //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupDefImpl.java
@@ -37,6 +37,7 @@ public class GroupDefImpl extends ArquillianDescriptorImpl implements GroupDef
    {
       super(descirptorName, model);
       this.group = group;
+      NodePropertiesReplacer.walkAndReplace(this.group);
    }
    
    //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/NodePropertiesReplacer.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/NodePropertiesReplacer.java
@@ -1,0 +1,33 @@
+package org.jboss.arquillian.config.descriptor.impl;
+
+import org.jboss.shrinkwrap.descriptor.spi.Node;
+
+public class NodePropertiesReplacer
+{
+   public static void walkAndReplace(Node node)
+   {
+      // check the own attributes for system properties replacement
+      for (String key: node.getAttributes().keySet())
+      {
+         String attrValue = node.getAttribute(key);
+         node.attribute(key, StringPropertyReplacer.replaceProperties(attrValue));
+      }
+      
+      // walk through all child nodes
+      for (Node child: node.getChildren())
+      {
+         for (String key: child.getAttributes().keySet())
+         {
+            String attrValue = child.getAttribute(key);
+            child.attribute(key, StringPropertyReplacer.replaceProperties(attrValue));
+         }
+         
+         String textValue = child.getText();
+         if (textValue != null && !textValue.isEmpty())
+         {
+            child.text(StringPropertyReplacer.replaceProperties(textValue));
+         }
+      }      
+   }
+
+}

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
@@ -37,6 +37,7 @@ public class ProtocolDefImpl extends ContainerDefImpl implements ProtocolDef
    {
       super(descriptorName, model, container);
       this.protocol = protocol;
+      NodePropertiesReplacer.walkAndReplace(this.protocol);
    }
    
    //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/StringPropertyReplacer.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/StringPropertyReplacer.java
@@ -1,0 +1,265 @@
+/*
+  * JBoss, Home of Professional Open Source
+  * Copyright 2005, JBoss Inc., and individual contributors as indicated
+  * by the @authors tag. See the copyright.txt in the distribution for a
+  * full listing of individual contributors.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  */
+package org.jboss.arquillian.config.descriptor.impl;
+
+import java.util.Properties;
+import java.io.File;
+
+/**
+ * A utility class for replacing properties in strings. 
+ * 
+ * NOTE: Copied from jboss-common-core.jar
+ *
+ * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
+ * @author <a href="Scott.Stark@jboss.org">Scott Stark</a>
+ * @author <a href="claudio.vesco@previnet.it">Claudio Vesco</a>
+ * @author <a href="mailto:adrian@jboss.com">Adrian Brock</a>
+ * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
+ * @version <tt>$Revision: 2898 $</tt> 
+ */
+public final class StringPropertyReplacer
+{
+   /** New line string constant */
+   public static final String NEWLINE = SysPropertyActions.getProperty("line.separator", "\n");
+
+   /** File separator value */
+   private static final String FILE_SEPARATOR = File.separator;
+
+   /** Path separator value */
+   private static final String PATH_SEPARATOR = File.pathSeparator;
+
+   /** File separator alias */
+   private static final String FILE_SEPARATOR_ALIAS = "/";
+
+   /** Path separator alias */
+   private static final String PATH_SEPARATOR_ALIAS = ":";
+
+   // States used in property parsing
+   private static final int NORMAL = 0;
+   private static final int SEEN_DOLLAR = 1;
+   private static final int IN_BRACKET = 2;
+
+   /**
+    * Go through the input string and replace any occurance of ${p} with
+    * the System.getProperty(p) value. If there is no such property p defined,
+    * then the ${p} reference will remain unchanged.
+    * 
+    * If the property reference is of the form ${p:v} and there is no such property p,
+    * then the default value v will be returned.
+    * 
+    * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then
+    * the primary and the secondary properties will be tried in turn, before
+    * returning either the unchanged input, or the default value.
+    * 
+    * The property ${/} is replaced with System.getProperty("file.separator")
+    * value and the property ${:} is replaced with System.getProperty("path.separator").
+    * 
+    * @param string - the string with possible ${} references
+    * @return the input string with all property references replaced if any.
+    *    If there are no valid references the input string will be returned.
+    */
+   public static String replaceProperties(final String string)
+   {
+      return replaceProperties(string, null);
+   }
+
+   /**
+    * Go through the input string and replace any occurance of ${p} with
+    * the props.getProperty(p) value. If there is no such property p defined,
+    * then the ${p} reference will remain unchanged.
+    * 
+    * If the property reference is of the form ${p:v} and there is no such property p,
+    * then the default value v will be returned.
+    * 
+    * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then
+    * the primary and the secondary properties will be tried in turn, before
+    * returning either the unchanged input, or the default value.
+    * 
+    * The property ${/} is replaced with System.getProperty("file.separator")
+    * value and the property ${:} is replaced with System.getProperty("path.separator").
+    *
+    * @param string - the string with possible ${} references
+    * @param props - the source for ${x} property ref values, null means use System.getProperty()
+    * @return the input string with all property references replaced if any.
+    *    If there are no valid references the input string will be returned.
+    */
+   public static String replaceProperties(final String string, final Properties props)
+   {
+      final char[] chars = string.toCharArray();
+      StringBuffer buffer = new StringBuffer();
+      boolean properties = false;
+      int state = NORMAL;
+      int start = 0;
+      for (int i = 0; i < chars.length; ++i)
+      {
+         char c = chars[i];
+
+         // Dollar sign outside brackets
+         if (c == '$' && state != IN_BRACKET)
+            state = SEEN_DOLLAR;
+
+         // Open bracket immediatley after dollar
+         else if (c == '{' && state == SEEN_DOLLAR)
+         {
+            buffer.append(string.substring(start, i - 1));
+            state = IN_BRACKET;
+            start = i - 1;
+         }
+
+         // No open bracket after dollar
+         else if (state == SEEN_DOLLAR)
+            state = NORMAL;
+
+         // Closed bracket after open bracket
+         else if (c == '}' && state == IN_BRACKET)
+         {
+            // No content
+            if (start + 2 == i)
+            {
+               buffer.append("${}"); // REVIEW: Correct?
+            }
+            else // Collect the system property
+            {
+               String value = null;
+
+               String key = string.substring(start + 2, i);
+               
+               // check for alias
+               if (FILE_SEPARATOR_ALIAS.equals(key))
+               {
+                  value = FILE_SEPARATOR;
+               }
+               else if (PATH_SEPARATOR_ALIAS.equals(key))
+               {
+                  value = PATH_SEPARATOR;
+               }
+               else
+               {
+                  // check from the properties
+                  if (props != null)
+                     value = props.getProperty(key);
+                  else
+                     value = System.getProperty(key);
+                  
+                  if (value == null)
+                  {
+                     // Check for a default value ${key:default}
+                     int colon = key.indexOf(':');
+                     if (colon > 0)
+                     {
+                        String realKey = key.substring(0, colon);
+                        if (props != null)
+                           value = props.getProperty(realKey);
+                        else
+                           value = System.getProperty(realKey);
+
+                        if (value == null)
+                        {
+                           // Check for a composite key, "key1,key2"                           
+                           value = resolveCompositeKey(realKey, props);
+                        
+                           // Not a composite key either, use the specified default
+                           if (value == null)
+                              value = key.substring(colon+1);
+                        }
+                     }
+                     else
+                     {
+                        // No default, check for a composite key, "key1,key2"
+                        value = resolveCompositeKey(key, props);
+                     }
+                  }
+               }
+
+               if (value != null)
+               {
+                  properties = true; 
+                  buffer.append(value);
+               }
+               else
+               {
+                  buffer.append("${");
+                  buffer.append(key);
+                  buffer.append('}');
+               }
+               
+            }
+            start = i + 1;
+            state = NORMAL;
+         }
+      }
+
+      // No properties
+      if (properties == false)
+         return string;
+
+      // Collect the trailing characters
+      if (start != chars.length)
+         buffer.append(string.substring(start, chars.length));
+
+      // Done
+      return buffer.toString();
+   }
+   
+   /**
+    * Try to resolve a "key" from the provided properties by
+    * checking if it is actually a "key1,key2", in which case
+    * try first "key1", then "key2". If all fails, return null.
+    * 
+    * It also accepts "key1," and ",key2".
+    * 
+    * @param key the key to resolve
+    * @param props the properties to use
+    * @return the resolved key or null
+    */
+   private static String resolveCompositeKey(String key, Properties props)
+   {
+      String value = null;
+      
+      // Look for the comma
+      int comma = key.indexOf(',');
+      if (comma > -1)
+      {
+         // If we have a first part, try resolve it
+         if (comma > 0)
+         {  
+            // Check the first part
+            String key1 = key.substring(0, comma);
+            if (props != null)
+               value = props.getProperty(key1);            
+            else
+               value = System.getProperty(key1);
+         }
+         // Check the second part, if there is one and first lookup failed
+         if (value == null && comma < key.length() - 1)
+         {
+            String key2 = key.substring(comma + 1);
+            if (props != null)
+               value = props.getProperty(key2);
+            else
+               value = System.getProperty(key2);
+         }         
+      }
+      // Return whatever we've found or null
+      return value;
+   }
+}

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/SysPropertyActions.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/SysPropertyActions.java
@@ -1,0 +1,70 @@
+/*
+  * JBoss, Home of Professional Open Source
+  * Copyright 2005, JBoss Inc., and individual contributors as indicated
+  * by the @authors tag. See the copyright.txt in the distribution for a
+  * full listing of individual contributors.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  */
+package org.jboss.arquillian.config.descriptor.impl;
+
+import java.security.PrivilegedAction;
+import java.security.AccessController;
+
+/**
+ * Priviledged actions for the package
+ * @author Scott.Stark@jboss.org
+ * @version $Revision: 2787 $
+ */
+@SuppressWarnings("unchecked")
+class SysPropertyActions
+{
+   interface SysProps
+   {
+      SysProps NON_PRIVILEDGED = new SysProps()
+      {
+         public String getProperty(final String name, final String defaultValue)
+         {
+            return System.getProperty(name, defaultValue);
+         }
+      };
+      SysProps PRIVILEDGED = new SysProps()
+      {
+         public String getProperty(final String name, final String defaultValue)
+         {
+            PrivilegedAction action = new PrivilegedAction()
+            {
+               public Object run()
+               {
+                  return System.getProperty(name, defaultValue);
+               }
+            };
+            return (String) AccessController.doPrivileged(action);
+         }
+      };
+      String getProperty(String name, String defaultValue);
+   }
+
+   public static String getProperty(String name, String defaultValue)
+   {
+      String prop;
+      if( System.getSecurityManager() == null )
+         prop = SysProps.NON_PRIVILEDGED.getProperty(name, defaultValue);
+      else
+         prop = SysProps.PRIVILEDGED.getProperty(name, defaultValue);
+      return prop;
+   }
+}

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorPropertiesTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorPropertiesTestCase.java
@@ -1,0 +1,595 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.config.descriptor.impl;
+
+import static org.jboss.arquillian.config.descriptor.impl.AssertXPath.assertXPath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+
+/**
+ * ArquillianDescriptorTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
+ * @version $Revision: $
+ */
+public class ArquillianDescriptorPropertiesTestCase
+{
+   private static final String CONTAINER_NAME_1 = "jbossas-remote";
+   private static final String CONTAINER_NAME_2 = "jbossas-embedded";
+   private static final String CONTAINER_NAME_3 = "jbossas-managed";
+   private static final String CONTAINER_NAME_4 = "jbossas-cloud";
+   private static final String PROTOCOL_TYPE_1 = "Servlet 3.0";
+   private static final String PROTOCOL_TYPE_2 = "Servlet 2.5";
+   private static final String PROTOCOL_TYPE_3 = "EJB 3.0";
+   private static final String GROUP_NAME_1 = "jbossas-remote-group";
+   private static final String GROUP_NAME_2 = "jbossas-embedded-group";
+   private static final String DEPENDENCY_1 = "org.test:test";
+   private static final String DEPENDENCY_2 = "org.test:test2";
+   private static final String EXTENSION_NAME_1 = "selenium";
+   private static final String EXTENSION_NAME_2 = "performance";
+   private static final String PROPERTY_NAME_1 = "test-name";
+   private static final String PROPERTY_VALUE_1 = "test-value";
+   private static final String PROPERTY_NAME_2 = "test2-name";
+   private static final String PROPERTY_VALUE_2 = "test2-value";
+   private static final String PROPERTY_NAME_3 = "test3-name";
+   private static final String PROPERTY_VALUE_3 = "test3-value";   
+   
+   private static final Integer PROPERTY_INT_VALUE_1 = 10;
+   
+   // properties keys
+   private static final String KEY_PROPERTY_VALUE_1 	= "property.value.1";
+   private static final String KEY_PROPERTY_VALUE_2     = "property.value.2";
+   private static final String KEY_PROPERTY_VALUE_3     = "property.value.3";
+   private static final String KEY_PROPERTY_NAME_1      = "property.name.1";
+   private static final String KEY_PROPERTY_NAME_2      = "property.name.2";
+   private static final String KEY_CONTAINER_NAME_1 	= "container.name.1";
+   private static final String KEY_CONTAINER_NAME_2 	= "container.name.2";
+   private static final String KEY_CONTAINER_NAME_3     = "container.name.3";
+   private static final String KEY_CONTAINER_NAME_4     = "container.name.4";
+   
+   private static final String KEY_DEPENDENCY_1         = "dependency.1";
+   private static final String KEY_DEPENDENCY_2         = "dependency.2";
+   
+   private String desc;
+   
+   @After
+   public void print() 
+   {
+      System.out.println(desc);
+   }
+
+   @Test
+   public void shouldBeAbleToGenerateEmpty() throws Exception
+   {
+      desc = create().exportAsString();
+   }
+
+   @Test
+   public void shouldBeAbleToSetEngineProperties() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      
+      // add multiple times to see only one property added
+      desc = create()
+               .engine()
+                  .deploymentExportPath(setPropKey(KEY_PROPERTY_VALUE_1))
+                  .deploymentExportPath(setPropKey(KEY_PROPERTY_VALUE_1))
+                  .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
+                  .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
+             .exportAsString(); 
+
+      assertXPath(desc, "/arquillian/engine/property[@name='deploymentExportPath']/text()", PROPERTY_VALUE_1);
+      assertXPath(desc, "/arquillian/engine/property[@name='maxTestClassesBeforeRestart']/text()", PROPERTY_INT_VALUE_1);   
+   
+      ArquillianDescriptor descriptor = create(desc);
+      
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.engine().getDeploymentExportPath());
+      Assert.assertEquals(PROPERTY_INT_VALUE_1, descriptor.engine().getMaxTestClassesBeforeRestart());
+   }
+   
+   @Test
+   public void shouldReturnNullOnEnginePropertiesIfNotSet() throws Exception
+   {
+      // add multiple times to see only one property added
+      desc = create()
+               .engine()
+             .exportAsString(); 
+
+      ArquillianDescriptor descriptor = create(desc);
+      
+      Assert.assertNull(descriptor.engine().getDeploymentExportPath());
+      Assert.assertNull(descriptor.engine().getMaxTestClassesBeforeRestart());
+   }
+
+   
+   @Test
+   public void shouldBeAbleToAddContainer() throws Exception
+   {
+	  System.setProperty(KEY_CONTAINER_NAME_1, CONTAINER_NAME_1);
+	  System.setProperty(KEY_CONTAINER_NAME_2, CONTAINER_NAME_2);
+	   
+      desc = create()
+            .container(setPropKey(KEY_CONTAINER_NAME_1)).setDefault()
+            .container(setPropKey(KEY_CONTAINER_NAME_2)).exportAsString();
+      
+      assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1, CONTAINER_NAME_2);
+      assertXPath(desc, "/arquillian/container[1]/@default", "true");
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(2, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      Assert.assertTrue(descriptor.getContainers().get(0).isDefault());
+      Assert.assertEquals(CONTAINER_NAME_2, descriptor.getContainers().get(1).getContainerName());
+   }
+
+   @Test
+   public void shouldBeAbleToAddContainerAndOverwrite() throws Exception
+   {
+	  System.setProperty(KEY_CONTAINER_NAME_1, CONTAINER_NAME_1);
+	  System.setProperty(KEY_CONTAINER_NAME_2, CONTAINER_NAME_2);
+	  
+      desc = create()
+            .container(CONTAINER_NAME_1).setDefault()
+            .container(CONTAINER_NAME_1).setContainerName(setPropKey(KEY_CONTAINER_NAME_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_2);
+      assertXPath(desc, "/arquillian/container/@default", "true");
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_2, descriptor.getContainers().get(0).getContainerName());
+      Assert.assertTrue(descriptor.getContainers().get(0).isDefault());
+   }
+
+   @Test
+   public void shouldBeAbleToAddDefaultProtocol() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      
+      desc = create()
+            .defaultProtocol(PROTOCOL_TYPE_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/defaultProtocol/@type", PROTOCOL_TYPE_1);
+      assertXPath(desc, "/arquillian/defaultProtocol/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/defaultProtocol/property/text()", PROPERTY_VALUE_1);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertNotNull(descriptor.getDefaultProtocol());
+      Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getDefaultProtocol().getType());
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getDefaultProtocol().getProperties().get(PROPERTY_NAME_1));
+   }
+
+  
+   @Test
+   public void shouldBeAbleToAddDefaultProtocolAndOverwriteProperty() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .defaultProtocol(PROTOCOL_TYPE_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/defaultProtocol/@type", PROTOCOL_TYPE_1);
+      assertXPath(desc, "/arquillian/defaultProtocol/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/defaultProtocol/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertNotNull(descriptor.getDefaultProtocol());
+      Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getDefaultProtocol().getType());
+      Assert.assertEquals(1, descriptor.getDefaultProtocol().getProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getDefaultProtocol().getProperties().get(PROPERTY_NAME_1));
+   }
+
+   @Test
+   public void shouldBeAbleToAddContainerWithDependencies() throws Exception
+   {
+      System.setProperty(KEY_DEPENDENCY_1, DEPENDENCY_1);
+      System.setProperty(KEY_DEPENDENCY_2, DEPENDENCY_2);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+            .dependency(setPropKey(KEY_DEPENDENCY_1))
+            .dependency(setPropKey(KEY_DEPENDENCY_2)).exportAsString();
+      
+      assertXPath(desc, "/arquillian/container/dependencies/dependency", DEPENDENCY_1, DEPENDENCY_2);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      
+      Assert.assertEquals(DEPENDENCY_1, descriptor.getContainers().get(0).getDependencies().get(0));
+      Assert.assertEquals(DEPENDENCY_2, descriptor.getContainers().get(0).getDependencies().get(1));
+   }
+
+   @Test
+   public void shouldBeAbleToAddContainerWithDependenciesAndOverwrite() throws Exception
+   {
+      System.setProperty(KEY_DEPENDENCY_1, DEPENDENCY_1);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+            .dependency(setPropKey(KEY_DEPENDENCY_1))
+            .dependency(setPropKey(KEY_DEPENDENCY_1)).exportAsString();
+      
+      assertXPath(desc, "/arquillian/container/dependencies/dependency", DEPENDENCY_1);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      Assert.assertEquals(1, descriptor.getContainers().get(0).getDependencies().size());
+      Assert.assertEquals(DEPENDENCY_1, descriptor.getContainers().get(0).getDependencies().get(0));
+   }
+
+   @Test
+   public void shouldBeAbleToAddContainerWithMultipleProtocols() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+               .protocol(PROTOCOL_TYPE_1)
+                  .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .protocol(PROTOCOL_TYPE_2)
+                  .property(PROPERTY_NAME_2, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+           
+      assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1);
+      assertXPath(desc, "/arquillian/container/protocol[1]/@type", PROTOCOL_TYPE_1);
+      assertXPath(desc, "/arquillian/container/protocol[1]/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/container/protocol[1]/property/text()", PROPERTY_VALUE_1);
+
+      assertXPath(desc, "/arquillian/container/protocol[2]/@type", PROTOCOL_TYPE_2);
+      assertXPath(desc, "/arquillian/container/protocol[2]/property/@name", PROPERTY_NAME_2);
+      assertXPath(desc, "/arquillian/container/protocol[2]/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      
+      Assert.assertEquals(2, descriptor.getContainers().get(0).getProtocols().size());
+      Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+      Assert.assertEquals(PROTOCOL_TYPE_2, descriptor.getContainers().get(0).getProtocols().get(1).getType());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getContainers().get(0).getProtocols().get(1).getProtocolProperties().get(PROPERTY_NAME_2));
+   }
+   
+   @Test
+   public void shouldBeAbleToAddContainerAndOverwriteProtocol() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+               .protocol(PROTOCOL_TYPE_1)
+                  .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .protocol(PROTOCOL_TYPE_1)
+                  .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1);
+      assertXPath(desc, "/arquillian/container/protocol/@type", PROTOCOL_TYPE_1);
+      assertXPath(desc, "/arquillian/container/protocol/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/container/protocol/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(1, descriptor.getContainers().get(0).getProtocols().size());
+      Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+   }
+
+   @Test
+   public void shouldBeAbleToAddContainerWithConfiguration() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+            .container(CONTAINER_NAME_2)
+               .property(PROPERTY_NAME_2, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/container[1]/@qualifier", CONTAINER_NAME_1);
+      
+      assertXPath(desc, "/arquillian/container[1]/configuration/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/container[1]/configuration/property/text()", PROPERTY_VALUE_1);
+
+      assertXPath(desc, "/arquillian/container[2]/@qualifier", CONTAINER_NAME_2);
+      assertXPath(desc, "/arquillian/container[2]/configuration/property/@name", PROPERTY_NAME_2);
+      assertXPath(desc, "/arquillian/container[2]/configuration/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(2, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+      Assert.assertEquals(CONTAINER_NAME_2, descriptor.getContainers().get(1).getContainerName());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getContainers().get(1).getContainerProperties().get(PROPERTY_NAME_2));
+   }
+   
+   @Test
+   public void shouldBeAbleToAddContainerWithConfigurationAndOverwriteProperty() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .container(CONTAINER_NAME_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/container[1]/@qualifier", CONTAINER_NAME_1);
+      
+      assertXPath(desc, "/arquillian/container[1]/configuration/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/container[1]/configuration/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
+      Assert.assertEquals(1, descriptor.getContainers().get(0).getContainerProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+   }
+   
+   @Test
+   public void shouldBeAbleToAddGroupWithContainer() throws Exception
+   {
+      System.setProperty(KEY_CONTAINER_NAME_1, CONTAINER_NAME_1);
+      System.setProperty(KEY_CONTAINER_NAME_2, CONTAINER_NAME_2);
+      System.setProperty(KEY_CONTAINER_NAME_3, CONTAINER_NAME_3);
+      
+      desc = create()
+            .group(GROUP_NAME_1)
+               .setGroupDefault()
+               .container(setPropKey(KEY_CONTAINER_NAME_1))
+               .container(setPropKey(KEY_CONTAINER_NAME_2))
+            .group(GROUP_NAME_2)
+               .container(setPropKey(KEY_CONTAINER_NAME_3)).exportAsString();
+      
+      assertXPath(desc, "/arquillian/group/@qualifier", GROUP_NAME_1, GROUP_NAME_2);
+      assertXPath(desc, "/arquillian/group[1]/@default", true);
+      assertXPath(desc, "/arquillian/group/container/@qualifier", CONTAINER_NAME_1, CONTAINER_NAME_2, CONTAINER_NAME_3);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(2, descriptor.getGroups().size());
+      Assert.assertEquals(2, descriptor.getGroups().get(0).getGroupContainers().size());
+      Assert.assertEquals(1, descriptor.getGroups().get(1).getGroupContainers().size());
+      Assert.assertEquals(GROUP_NAME_1, descriptor.getGroups().get(0).getGroupName());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
+      Assert.assertEquals(CONTAINER_NAME_2, descriptor.getGroups().get(0).getGroupContainers().get(1).getContainerName());
+      Assert.assertEquals(GROUP_NAME_2, descriptor.getGroups().get(1).getGroupName());
+      Assert.assertEquals(CONTAINER_NAME_3, descriptor.getGroups().get(1).getGroupContainers().get(0).getContainerName());
+   }
+   
+   @Test
+   public void shouldBeAbleToAddGroupWithContainerAndOverwriteContainer() throws Exception
+   {
+      System.setProperty(KEY_CONTAINER_NAME_1, CONTAINER_NAME_1);
+      
+      desc = create()
+            .group(GROUP_NAME_1)
+               .container(setPropKey(KEY_CONTAINER_NAME_1))
+               .container(setPropKey(KEY_CONTAINER_NAME_1))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/group/@qualifier", GROUP_NAME_1);
+      assertXPath(desc, "/arquillian/group/container/@qualifier", CONTAINER_NAME_1);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getGroups().size());
+      Assert.assertEquals(1, descriptor.getGroups().get(0).getGroupContainers().size());
+      Assert.assertEquals(CONTAINER_NAME_1, descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
+   }
+
+   @Test
+   public void shouldBeAbleToAddExtension() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      System.setProperty(KEY_PROPERTY_VALUE_3, PROPERTY_VALUE_3);
+      
+      desc = create()
+            .extension(EXTENSION_NAME_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .property(PROPERTY_NAME_2, setPropKey(KEY_PROPERTY_VALUE_2))
+            .extension(EXTENSION_NAME_2)
+               .property(PROPERTY_NAME_3, setPropKey(KEY_PROPERTY_VALUE_3)).exportAsString();
+      
+      assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_1, EXTENSION_NAME_2);
+      assertXPath(desc, "/arquillian/extension[1]/property[1]/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/extension[1]/property[1]/text()", PROPERTY_VALUE_1);
+      assertXPath(desc, "/arquillian/extension[1]/property[2]/@name", PROPERTY_NAME_2);
+      assertXPath(desc, "/arquillian/extension[1]/property[2]/text()", PROPERTY_VALUE_2);
+      
+      assertXPath(desc, "/arquillian/extension[2]/property/@name", PROPERTY_NAME_3);
+      assertXPath(desc, "/arquillian/extension[2]/property/text()", PROPERTY_VALUE_3);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(2, descriptor.getExtensions().size());
+      Assert.assertEquals(EXTENSION_NAME_1, descriptor.getExtensions().get(0).getExtensionName());
+      Assert.assertEquals(2, descriptor.getExtensions().get(0).getExtensionProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_2));
+
+      Assert.assertEquals(EXTENSION_NAME_2, descriptor.getExtensions().get(1).getExtensionName());
+      Assert.assertEquals(1, descriptor.getExtensions().get(1).getExtensionProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_3, descriptor.getExtensions().get(1).getExtensionProperties().get(PROPERTY_NAME_3));
+   }
+   
+   @Test
+   public void shouldBeAbleToRenameExtension() throws Exception
+   {
+      desc = create()
+            .extension(EXTENSION_NAME_1)
+               .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+            .extension(EXTENSION_NAME_1)
+               .setExtensionName(EXTENSION_NAME_2)
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_2);
+      
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getExtensions().size());
+      Assert.assertEquals(EXTENSION_NAME_2, descriptor.getExtensions().get(0).getExtensionName());
+      Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+   }
+
+   @Test
+   public void shouldBeAbleToAddExtensionAndOverwriteProperty() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      
+      desc = create()
+            .extension(EXTENSION_NAME_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+      
+      assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_1);
+      assertXPath(desc, "/arquillian/extension/property/@name", PROPERTY_NAME_1);
+      assertXPath(desc, "/arquillian/extension/property/text()", PROPERTY_VALUE_2);
+
+      ArquillianDescriptor descriptor = create(desc);
+      Assert.assertEquals(1, descriptor.getExtensions().size());
+      Assert.assertEquals(EXTENSION_NAME_1, descriptor.getExtensions().get(0).getExtensionName());
+      Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
+      Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+   }
+
+   @Test
+   public void shouldBeAbleToAddEverything() throws Exception
+   {
+      System.setProperty(KEY_PROPERTY_VALUE_1, PROPERTY_VALUE_1);
+      System.setProperty(KEY_PROPERTY_VALUE_2, PROPERTY_VALUE_2);
+      System.setProperty(KEY_PROPERTY_VALUE_3, PROPERTY_VALUE_3);
+      
+      desc = create()
+            .defaultProtocol(PROTOCOL_TYPE_1)
+               .property(PROPERTY_VALUE_3, setPropKey(KEY_PROPERTY_VALUE_3))
+            .container(CONTAINER_NAME_1)
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+               .dependency(DEPENDENCY_1)
+               .protocol(PROTOCOL_TYPE_1)
+                  .property(PROPERTY_NAME_2, setPropKey(KEY_PROPERTY_VALUE_2))
+            .group(GROUP_NAME_1)
+               .container(CONTAINER_NAME_2)
+                  .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+                  .dependency(DEPENDENCY_2)
+                  .protocol(PROTOCOL_TYPE_2)
+                     .property(PROPERTY_NAME_3, setPropKey(KEY_PROPERTY_VALUE_3))
+            .group(GROUP_NAME_2)
+               .container(CONTAINER_NAME_3)
+                  .protocol(PROTOCOL_TYPE_3)
+                     .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_1))
+            .container(CONTAINER_NAME_4)
+            .extension(EXTENSION_NAME_1) 
+               .property(PROPERTY_NAME_1, setPropKey(KEY_PROPERTY_VALUE_2))
+            .exportAsString();
+   }
+
+   //-------------------------------------------------------------------------------------||
+   // Internal Helper --------------------------------------------------------------------||
+   //-------------------------------------------------------------------------------------||
+
+   private ArquillianDescriptor create()
+   {
+      return Descriptors.create(ArquillianDescriptor.class);
+   }
+
+   private ArquillianDescriptor create(String xml) throws Exception
+   {
+      validateXML(desc);
+      
+      return Descriptors.importAs(ArquillianDescriptor.class).from(xml);
+   }
+
+   private void validateXML(String xml) throws Exception
+   {
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance(); 
+      dbf.setValidating(true); 
+      dbf.setNamespaceAware(true);
+      dbf.setAttribute( 
+          "http://java.sun.com/xml/jaxp/properties/schemaLanguage", 
+          "http://www.w3.org/2001/XMLSchema"); 
+      DocumentBuilder db = dbf.newDocumentBuilder(); 
+      db.setErrorHandler(new ErrorHandler()
+      {
+         @Override
+         public void warning(SAXParseException exception) throws SAXException
+         {
+            throw exception;
+         }
+         
+         @Override
+         public void fatalError(SAXParseException exception) throws SAXException
+         {
+            throw exception;
+         }
+         
+         @Override
+         public void error(SAXParseException exception) throws SAXException
+         {
+            throw exception;
+         }
+      });
+      db.setEntityResolver(new EntityResolver()
+      {
+         @Override
+         public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException
+         {
+            if("http://jboss.org/schema/arquillian/arquillian_1_0.xsd".equals(systemId))
+            {
+               return new InputSource(this.getClass().getClassLoader().getResourceAsStream("arquillian_1_0.xsd"));
+            }
+            return null;
+         }
+      }); 
+      db.parse(new ByteArrayInputStream(xml.getBytes()));
+   }
+   
+   private String setPropKey(String propKey) {
+	   return String.format("${%s}", propKey);
+   }
+}


### PR DESCRIPTION
ARQ-148 Support EL-like expressions for sysprops and env variables in arquillian.xml
## Preview

Hi Aslak

I send you a pull request in order to have a look about ARQ-148. 

What is implemented:
1. System.Properties are replaced when defined, currently when the following tasks are executed:
   a) loaded from source
   b) exported to source
2. All existing ArquillianDescriptorImpl test cases are copied into a new test class and are adjusted using system properties. All test cases are passing except one.

What is not implemented so far:
1. Using System environment variables for replacement.
2. System properties replacement for the getter or setter.

I will work over the weekend for finalizing this. Please have a look. If I am completely on the wrong path and the time is urgent, then it is better that Andrew takes this over. He mentioned this in a tweet.

Regards,
Ralf
