### PR TITLE
[ARQ-77] Support for @EJBs beanName attribute and JNDI resolution tests.

### DIFF
--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.testenricher.ejb;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -28,187 +29,224 @@ import javax.naming.NamingException;
 
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
 import org.jboss.arquillian.test.spi.TestEnricher;
 
 /**
- * Enricher that provide EJB class and setter method injection. 
- *
+ * Enricher that provide EJB class and setter method injection.
+ * 
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
  */
-public class EJBInjectionEnricher implements TestEnricher
-{
-   private static final String ANNOTATION_NAME = "javax.ejb.EJB";
+public class EJBInjectionEnricher implements TestEnricher {
+    private static final String ANNOTATION_NAME = "javax.ejb.EJB";
 
-   private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
-   
-   @Inject
-   private Instance<Context> contextInst;
-   
-   /* (non-Javadoc)
-    * @see org.jboss.arquillian.spi.TestEnricher#enrich(org.jboss.arquillian.spi.Context, java.lang.Object)
-    */
-   public void enrich(Object testCase)
-   {
-      if(SecurityActions.isClassPresent(ANNOTATION_NAME) && contextInst.get() != null) 
-      {
-         injectClass(testCase);
-      }
-   }
+    private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
 
-   /* (non-Javadoc)
-    * @see org.jboss.arquillian.spi.TestEnricher#resolve(org.jboss.arquillian.spi.Context, java.lang.reflect.Method)
-    */
-   public Object[] resolve(Method method) 
-   {
-     return new Object[method.getParameterTypes().length];
-   }
-   
-   /**
-    * Obtains all field in the specified class which contain the specified annotation
-    * @param clazz
-    * @param annotation
-    * @return
-    * @throws IllegalArgumentException If either argument is not specified
-    */
-   //TODO Hack, this leaks out privileged operations outside the package.  Extract out properly.
-   protected List<Field> getFieldsWithAnnotation(final Class<?> clazz, final Class<? extends Annotation> annotation)
-         throws IllegalArgumentException
-   {
-      // Precondition checks
-      if (clazz == null)
-      {
-         throw new IllegalArgumentException("clazz must be specified");
-      }
-      if (annotation == null)
-      {
-         throw new IllegalArgumentException("annotation must be specified");
-      }
+    @Inject
+    private Instance<Context> contextInst;
 
-      // Delegate to the privileged operations
-      return SecurityActions.getFieldsWithAnnotation(clazz, annotation);
-   }
-   
-   protected void injectClass(Object testCase) 
-   {
-      try 
-      {
-         @SuppressWarnings("unchecked")
-         Class<? extends Annotation> ejbAnnotation = (Class<? extends Annotation>)SecurityActions.getThreadContextClassLoader().loadClass(ANNOTATION_NAME);
-         
-         List<Field> annotatedFields = SecurityActions.getFieldsWithAnnotation(
-               testCase.getClass(), 
-               ejbAnnotation);
-         
-         for(Field field : annotatedFields) 
-         {
-            if(field.get(testCase) == null) // only try to lookup fields that are not already set
-            {
-               EJB fieldAnnotation = (EJB) field.getAnnotation(ejbAnnotation);
-               try
-               {
-                  Object ejb = lookupEJB(field.getType(), fieldAnnotation.mappedName());
-                  field.set(testCase, ejb);
-               }
-               catch (Exception e) 
-               {
-                  log.fine("Could not lookup " + fieldAnnotation + ", other Enrichers might, move on. Exception: " + e.getMessage());
-               }
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jboss.arquillian.spi.TestEnricher#enrich(org.jboss.arquillian.spi .Context, java.lang.Object)
+     */
+    public void enrich(Object testCase) {
+        if (SecurityActions.isClassPresent(ANNOTATION_NAME) && contextInst.get() != null) {
+            injectClass(testCase);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.jboss.arquillian.spi.TestEnricher#resolve(org.jboss.arquillian.spi .Context, java.lang.reflect.Method)
+     */
+    public Object[] resolve(Method method) {
+        return new Object[method.getParameterTypes().length];
+    }
+
+    /**
+     * Obtains all field in the specified class which contain the specified annotation
+     * 
+     * @param clazz
+     * @param annotation
+     * @return
+     * @throws IllegalArgumentException If either argument is not specified
+     */
+    // TODO Hack, this leaks out privileged operations outside the package.
+    // Extract out properly.
+    protected List<Field> getFieldsWithAnnotation(final Class<?> clazz, final Class<? extends Annotation> annotation)
+            throws IllegalArgumentException {
+        // Precondition checks
+        if (clazz == null) {
+            throw new IllegalArgumentException("clazz must be specified");
+        }
+        if (annotation == null) {
+            throw new IllegalArgumentException("annotation must be specified");
+        }
+
+        // Delegate to the privileged operations
+        return SecurityActions.getFieldsWithAnnotation(clazz, annotation);
+    }
+
+    protected void injectClass(Object testCase) {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<? extends Annotation> ejbAnnotation = (Class<? extends Annotation>) SecurityActions
+                    .getThreadContextClassLoader().loadClass(ANNOTATION_NAME);
+
+            List<Field> annotatedFields = SecurityActions.getFieldsWithAnnotation(testCase.getClass(), ejbAnnotation);
+
+            for (Field field : annotatedFields) {
+                if (field.get(testCase) == null) // only try to lookup fields
+                                                 // that are not already set
+                {
+                    EJB fieldAnnotation = (EJB) field.getAnnotation(ejbAnnotation);
+                    try {
+                        String[] jndiNames = resolveJNDINames(field.getType(), fieldAnnotation.mappedName(),
+                                fieldAnnotation.beanName());
+                        Object ejb = lookupEJB(jndiNames);
+                        field.set(testCase, ejb);
+                    } catch (Exception e) {
+                        log.fine("Could not lookup " + fieldAnnotation + ", other Enrichers might, move on. Exception: "
+                                + e.getMessage());
+                    }
+                }
             }
-         }
-         
-         List<Method> methods = SecurityActions.getMethodsWithAnnotation(
-               testCase.getClass(), 
-               ejbAnnotation);
-         
-         for(Method method : methods) 
-         {
-            if(method.getParameterTypes().length != 1) 
-            {
-               throw new RuntimeException("@EJB only allowed on single argument methods");
+
+            List<Method> methods = SecurityActions.getMethodsWithAnnotation(testCase.getClass(), ejbAnnotation);
+
+            for (Method method : methods) {
+                if (method.getParameterTypes().length != 1) {
+                    throw new RuntimeException("@EJB only allowed on single argument methods");
+                }
+                if (!method.getName().startsWith("set")) {
+                    throw new RuntimeException("@EJB only allowed on 'set' methods");
+                }
+                EJB parameterAnnotation = null; // method.getParameterAnnotations()[0]
+                for (Annotation annotation : method.getParameterAnnotations()[0]) {
+                    if (EJB.class.isAssignableFrom(annotation.annotationType())) {
+                        parameterAnnotation = (EJB) annotation;
+                    }
+                }
+
+                // Default values of the annotation attributes.
+                String mappedName = null;
+                String beanName = null;
+
+                if (parameterAnnotation != null) {
+                    mappedName = parameterAnnotation.mappedName();
+                    beanName = parameterAnnotation.beanName();
+                }
+
+                String[] jndiNames = resolveJNDINames(method.getParameterTypes()[0], mappedName, beanName);
+                Object ejb = lookupEJB(jndiNames);
+                method.invoke(testCase, ejb);
             }
-            if(!method.getName().startsWith("set")) 
-            {
-               throw new RuntimeException("@EJB only allowed on 'set' methods");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not inject members", e);
+        }
+    }
+
+    /**
+     * Resolves the JNDI name of the given field.
+     * 
+     * If <tt>mappedName</tt> or <tt>beanName</tt> are specified, they're used to resolve JNDI name. Otherwise, default policy
+     * applies.
+     * 
+     * If both, the <tt>mappedName</tt> and <tt>beanName</tt>, are specified at the same time, an {@link IllegalStateException}
+     * will be thrown.
+     * 
+     * @param fieldType annotated field which JNDI name should be resolved.
+     * @param mappedName Value of {@link EJB}'s <tt>mappedName</tt> attribute.
+     * @param beanName Value of {@link EJB}'s <tt>beanName</tt> attribute.
+     * 
+     * @return possible JNDI names which should be looked up to access the proper object.
+     */
+    protected String[] resolveJNDINames(Class<?> fieldType, String mappedName, String beanName) {
+
+        MessageFormat msg = new MessageFormat(
+                "Trying to resolve JNDI name for field \"{0}\" with mappedName=\"{1}\" and beanName=\"{2}\"");
+        log.finer(msg.format(new Object[] { fieldType, mappedName, beanName }));
+
+        Validate.notNull(fieldType, "EJB enriched field cannot to be null.");
+
+        boolean isMappedNameSet = hasValue(mappedName);
+        boolean isBeanNameSet = hasValue(beanName);
+
+        if (isMappedNameSet && isBeanNameSet) {
+            throw new IllegalStateException(
+                    "@EJB annotation attributes 'mappedName' and 'beanName' cannot be specified at the same time.");
+        }
+
+        String[] jndiNames;
+
+        // If set, use only mapped name or bean name to lookup the EJB.
+        if (isMappedNameSet) {
+            jndiNames = new String[] { mappedName };
+        } else if (isBeanNameSet) {
+            jndiNames = new String[] { "java:module/" + beanName + "!" + fieldType.getName() };
+        } else {
+            // TODO: These names are not spec compliant; fieldType needs to be a
+            // bean type here,
+            // but usually is just an interface of a bean. These seldom work.
+            jndiNames = new String[] { "java:global/test.ear/test/" + fieldType.getSimpleName() + "Bean",
+                    "java:global/test.ear/test/" + fieldType.getSimpleName(), "java:global/test/" + fieldType.getSimpleName(),
+                    "java:global/test/" + fieldType.getSimpleName() + "Bean",
+                    "java:global/test/" + fieldType.getSimpleName() + "/no-interface",
+                    "test/" + fieldType.getSimpleName() + "Bean/local", "test/" + fieldType.getSimpleName() + "Bean/remote",
+                    "test/" + fieldType.getSimpleName() + "/no-interface", fieldType.getSimpleName() + "Bean/local",
+                    fieldType.getSimpleName() + "Bean/remote", fieldType.getSimpleName() + "/no-interface",
+                    // WebSphere Application Server Local EJB default binding
+                    "ejblocal:" + fieldType.getCanonicalName(),
+                    // WebSphere Application Server Remote EJB default binding
+                    fieldType.getCanonicalName() };
+        }
+
+        return jndiNames;
+    }
+
+    protected Object lookupEJB(String[] jndiNames) throws Exception {
+        // TODO: figure out test context ?
+        Context initcontext = createContext();
+
+        for (String jndiName : jndiNames) {
+            try {
+                return initcontext.lookup(jndiName);
+            } catch (NamingException e) {
+                // no-op, try next
             }
-            EJB parameterAnnotation = null; //method.getParameterAnnotations()[0]
-            for (Annotation annotation : method.getParameterAnnotations()[0])
-            {
-               if (EJB.class.isAssignableFrom(annotation.annotationType()))
-               {
-                  parameterAnnotation = (EJB) annotation;
-               }
-            }
-            String mappedName = parameterAnnotation == null ? null : parameterAnnotation.mappedName();
-            Object ejb = lookupEJB(method.getParameterTypes()[0], mappedName);
-            method.invoke(testCase, ejb);
-         }
-         
-      } 
-      catch (Exception e) 
-      {
-         throw new RuntimeException("Could not inject members", e);
-      }
-   }
-   
-   protected Object lookupEJB(Class<?> fieldType, String mappedName) throws Exception 
-   {
-      // TODO: figure out test context ? 
-      Context initcontext = createContext();
-      
-      // TODO: These names are not spec compliant; fieldType needs to be a bean type here,
-      //       but usually is just an interface of a bean.  These seldom work.
-      String[] jndiNames = {
-            "java:global/test.ear/test/" + fieldType.getSimpleName() + "Bean",
-            "java:global/test.ear/test/" + fieldType.getSimpleName(),
-            "java:global/test/" + fieldType.getSimpleName(),
-            "java:global/test/" + fieldType.getSimpleName() + "Bean",
-            "java:global/test/" + fieldType.getSimpleName() + "/no-interface",
-            "test/" + fieldType.getSimpleName() + "Bean/local",
-            "test/" + fieldType.getSimpleName() + "Bean/remote",
-            "test/" + fieldType.getSimpleName() + "/no-interface",
-            fieldType.getSimpleName() + "Bean/local",
-            fieldType.getSimpleName() + "Bean/remote",
-            fieldType.getSimpleName() + "/no-interface",
-            // WebSphere Application Server Local EJB default binding
-            "ejblocal:" + fieldType.getCanonicalName(),
-            // WebSphere Application Server Remote EJB default binding
-            fieldType.getCanonicalName()
-      };
-      if ((mappedName != null) && (!mappedName.equals("")))
-      {
-         // Use only the mapped name to lookup this EJB
-         jndiNames = new String[]{ mappedName };
-      }
-      
-      for(String jndiName : jndiNames)
-      {
-         try 
-         {
-            return initcontext.lookup(jndiName);
-         } 
-         catch (NamingException e) 
-         {
-            // no-op, try next
-         }
-      }
-      throw new NamingException("No EJB found in JNDI, tried the following names: " + joinJndiNames(jndiNames));
-   }
-   
-   protected Context createContext() throws Exception
-   {
-      return contextInst.get();
-   }
-   
-   // Simple helper for printing the jndi names
-   private String joinJndiNames(String[] strings)
-   {
-      StringBuilder sb = new StringBuilder();
-      
-      for(String string: strings)
-      {
-         sb.append(string).append(", ");
-      }
-      return sb.toString();
-   }
+        }
+        throw new NamingException("No EJB found in JNDI, tried the following names: " + joinJndiNames(jndiNames));
+    }
+
+    protected Context createContext() throws Exception {
+        return contextInst.get();
+    }
+
+    // Simple helper for printing the jndi names
+    private String joinJndiNames(String[] strings) {
+        StringBuilder sb = new StringBuilder();
+
+        for (String string : strings) {
+            sb.append(string).append(", ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Helper method that checks if the given String has a non-empty value.
+     * 
+     * @param string String to be checked.
+     * @return true if <tt>string</tt> is not null and has non-empty value; false otherwise.
+     */
+    private boolean hasValue(String string) {
+        if (string != null && (!string.trim().equals(""))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricherTestCase.java
+++ b/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricherTestCase.java
@@ -1,0 +1,196 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import javax.ejb.EJB;
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EJBInjectionEnricher}.
+ * 
+ * These tests doesn't use embedded container, as they're just simple unit tests.
+ * 
+ * @author PedroKowalski
+ * 
+ */
+public class EJBInjectionEnricherTestCase {
+
+    private EJBInjectionEnricher cut;
+    private EJBEnrichedClass enrichedClass;
+
+    @Before
+    public void before() {
+        cut = new EJBInjectionEnricher();
+        enrichedClass = new EJBEnrichedClass();
+    }
+
+    @Test
+    public void testResolveJNDIName() {
+        List<Field> injectionPoints = SecurityActions.getFieldsWithAnnotation(enrichedClass.getClass(), EJB.class);
+
+        Field simpleEJBField = getField(injectionPoints, "simpleInjection");
+
+        // Should invoke default JNDI names resolution.
+        String[] r = cut.resolveJNDINames(simpleEJBField.getType(), null, null);
+
+        // TODO: change to something more appropriate (test default JNDI names).
+        assertThat(r.length > 5, is(true));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testResolveJNDINameMappedNameAndBeanNameSpecified() {
+
+        // What field doesn't matter for this test case.
+        Field anyField = enrichedClass.getClass().getDeclaredFields()[0];
+
+        // Specifying both: mappedName and beanName is not allowed.
+        cut.resolveJNDINames(anyField.getType(), "anyString()", "anyString()");
+    }
+
+    @Test
+    public void testResolveJNDINameMappedNameSpecified() {
+        List<Field> injectionPoints = SecurityActions.getFieldsWithAnnotation(enrichedClass.getClass(), EJB.class);
+
+        Field mappedNameEJBField = getField(injectionPoints, "mappedNameInjection");
+
+        EJB fieldAnnotation = (EJB) mappedNameEJBField.getAnnotation(EJB.class);
+
+        String[] r = cut.resolveJNDINames(mappedNameEJBField.getType(), fieldAnnotation.mappedName(), null);
+
+        /*
+         * When 'mappedName' is set, the only JNDI name to check is the exact value specified in the annotation.
+         */
+        assertThat(r, is(notNullValue()));
+        assertThat(r.length, is(1));
+        assertThat(r[0], is(fieldAnnotation.mappedName()));
+    }
+
+    @Test
+    public void testResolveJNDINameBeanNameSpecified() {
+        List<Field> injectionPoints = SecurityActions.getFieldsWithAnnotation(enrichedClass.getClass(), EJB.class);
+
+        Field beanNameEJBField = getField(injectionPoints, "beanNameInjection");
+
+        EJB fieldAnnotation = (EJB) beanNameEJBField.getAnnotation(EJB.class);
+
+        String[] r = cut.resolveJNDINames(beanNameEJBField.getType(), null, fieldAnnotation.beanName());
+
+        // Expected: java:module/<bean-name>[!<fully-qualified-interface-name>]
+        String expected = "java:module/" + ExemplaryEJBMockImpl.class.getSimpleName() + "!"
+                + beanNameEJBField.getType().getName();
+
+        assertThat(r, is(notNullValue()));
+        assertThat(r.length, is(1));
+        assertThat(r[0], is(expected));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveJNDINameFieldNotSet() {
+
+        // Annotated field must be set.
+        cut.resolveJNDINames(null, "anyString()", null);
+    }
+
+    /**
+     * Helper method which returns the {@link Field} object with the given <tt>name</tt>.
+     * 
+     * Object's fields fetched using Java Reflection doesn't have any particular order, so to fetch the appropriate field this
+     * method can be used.
+     * 
+     * @param fields fields that will be iterated.
+     * @param name name of the searched field.
+     * 
+     * @return {@link Field} with the given <tt>name</tt> or null if the name couldn't be found.
+     */
+    private Field getField(List<Field> fields, String name) {
+        for (Field field : fields) {
+            if (field.getName().equals(name)) {
+                return field;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Exemplary class with EJB annotations which will be tested for JNDI resolution.
+     * 
+     * Note: As a field type this class uses the interface which has two implementations. Appropriate implementation injection
+     * should also be tested.
+     * 
+     * @author PedroKowalski
+     * 
+     */
+    public static final class EJBEnrichedClass {
+
+        @EJB
+        ExemplaryEJB simpleInjection;
+
+        @EJB(mappedName = "java:module/org/arquillian/Test")
+        ExemplaryEJB mappedNameInjection;
+
+        @EJB(beanName = "ExemplaryEJBMockImpl")
+        ExemplaryEJB beanNameInjection;
+    }
+
+    /**
+     * Exemplary EJB's local interface.
+     * 
+     * @author PedroKowalski
+     * 
+     */
+    @Local
+    public static interface ExemplaryEJB {
+
+    }
+
+    /**
+     * Exemplary implementation of the EJB's local interface.
+     * 
+     * @author PedroKowalski
+     * 
+     */
+    @Stateless
+    public static class ExemplaryEJBMockImpl implements ExemplaryEJB {
+
+    }
+
+    /**
+     * Exemplary implementation of the EJB's local interface.
+     * 
+     * This class is here only to be sure that despite more than one implementation of the interface, only the one pointed by
+     * <tt>beanName</tt> attribute of the {@link EJB} annotation will be used.
+     * 
+     * @author PedroKowalski
+     * 
+     */
+    @Stateless
+    public static class ExemplaryEJBProductionImpl implements ExemplaryEJB {
+
+    }
+}


### PR DESCRIPTION
Related with https://issues.jboss.org/browse/ARQ-77?focusedCommentId=12626115&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12626115

Hope it's acceptable.

PS. I guess the wrongly counted insertions/deletions for EJBInjectionEnricher comes from the code auto-formatter. I've used this one: https://github.com/jbossas/jboss-as/blob/master/ide-configs/eclipse/as7formatter.xml
