### PR TITLE
ARQ-715 Add a getter for ProtocolMetaData.contexts

### DIFF
--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.container.spi.client.protocol.metadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,6 +60,13 @@ public class ProtocolMetaData
       return this;
    }
 
+   /**
+    * @return unmodifiable list of contexts
+    */
+   public List<Object> getContexts() {
+       return Collections.unmodifiableList(contexts);
+   }
+   
    @Override
    public String toString()
    {


### PR DESCRIPTION
This would help to safely clone (and rewrite) metadata in extensions.
Without that method, we could forget some contexts.

For example : 
        for (Object context : metadata.getContexts()) {
            if (! (context instanceof HTTPContext) ) {
                newMetadata.addContext(context);
            }
        }

would be better than
        newMetadata.addContext(metadata.getContext(JMXContext.class));
        newMetadata.addContext(metadata.getContext(RMIContext.class));

Especially if a new context type is added in the future.
