### PR TITLE
Extract default JNDI names in the EJBInjectionEnricher

### DIFF
--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
@@ -218,25 +218,32 @@ public class EJBInjectionEnricher implements TestEnricher
       }
       else
       {
-         // TODO: These names are not spec compliant; fieldType needs to be a bean type here, but usually is just an interface of a bean. These seldom work.
-         jndiNames = new String[] {
-               "java:global/test.ear/test/" + fieldType.getSimpleName() + "Bean",
-               "java:global/test.ear/test/" + fieldType.getSimpleName(),
-               "java:global/test/" + fieldType.getSimpleName(),
-               "java:global/test/" + fieldType.getSimpleName() + "Bean",
-               "java:global/test/" + fieldType.getSimpleName() + "/no-interface",
-               "test/" + fieldType.getSimpleName() + "Bean/local", "test/" + fieldType.getSimpleName() + "Bean/remote",
-               "test/" + fieldType.getSimpleName() + "/no-interface", fieldType.getSimpleName() + "Bean/local",
-               fieldType.getSimpleName() + "Bean/remote", fieldType.getSimpleName() + "/no-interface",
-               // WebSphere Application Server Local EJB default binding
-               "ejblocal:" + fieldType.getCanonicalName(),
-               // WebSphere Application Server Remote EJB default binding
-               fieldType.getCanonicalName()};
+          jndiNames = getJndiNamesForAnonymousEJB(fieldType);
+
       }
       return jndiNames;
    }
 
-   protected Object lookupEJB(String[] jndiNames) throws Exception
+    protected String[] getJndiNamesForAnonymousEJB(Class<?> fieldType) {
+        String[] jndiNames;
+        // TODO: These names are not spec compliant; fieldType needs to be a bean type here, but usually is just an interface of a bean. These seldom work.
+        jndiNames = new String[] {
+              "java:global/test.ear/test/" + fieldType.getSimpleName() + "Bean",
+              "java:global/test.ear/test/" + fieldType.getSimpleName(),
+              "java:global/test/" + fieldType.getSimpleName(),
+              "java:global/test/" + fieldType.getSimpleName() + "Bean",
+              "java:global/test/" + fieldType.getSimpleName() + "/no-interface",
+              "test/" + fieldType.getSimpleName() + "Bean/local", "test/" + fieldType.getSimpleName() + "Bean/remote",
+              "test/" + fieldType.getSimpleName() + "/no-interface", fieldType.getSimpleName() + "Bean/local",
+              fieldType.getSimpleName() + "Bean/remote", fieldType.getSimpleName() + "/no-interface",
+              // WebSphere Application Server Local EJB default binding
+              "ejblocal:" + fieldType.getCanonicalName(),
+              // WebSphere Application Server Remote EJB default binding
+              fieldType.getCanonicalName()};
+        return jndiNames;
+    }
+
+    protected Object lookupEJB(String[] jndiNames) throws Exception
    {
       // TODO: figure out test context ?
       Context initcontext = createContext();


### PR DESCRIPTION
That could reduce the amount of duplicated code in a specialized EJBInjectionEnricher. Instead of overloading the whole resolveJNDINames method, we could just refine the default JNDI names.
