### PR TITLE
[ARQ-1298] BOM updated to use ShrinkWrap Resolver 2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,7 +44,7 @@
 
         <version.shrinkwrap_shrinkwrap>1.0.1</version.shrinkwrap_shrinkwrap>
         <version.shrinkwrap_descriptors>2.0.0-alpha-3</version.shrinkwrap_descriptors>
-        <version.shrinkwrap_resolver>1.0.0-beta-7</version.shrinkwrap_resolver>
+        <version.shrinkwrap_resolver>2.0.0-beta-2</version.shrinkwrap_resolver>
 
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>


### PR DESCRIPTION
https://issues.jboss.org/browse/ARQ-1298
Compatibility with OSGi container was not checked.
