### PR TITLE
[ARQ-700] Support for multiline configuration entries.

### DIFF
--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
@@ -41,7 +41,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
    //-------------------------------------------------------------------------------------||
 
    private Node model;
-   
+
    //-------------------------------------------------------------------------------------||
    // Constructor ------------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -53,7 +53,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
          .attribute("xmlns", "http://jboss.org/schema/arquillian")
          .attribute("xsi:schemaLocation", "http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd"));
    }
-   
+
    public ArquillianDescriptorImpl(String descirptorName, Node model)
    {
       super(descirptorName);
@@ -72,7 +72,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
    {
       return new DefaultProtocolDefImpl(getDescriptorName(), model, model.getOrCreate("defaultProtocol")).setType(type);
    }
-   
+
    /* (non-Javadoc)
     * @see org.jboss.arquillian.impl.configuration.api.ArquillianDescriptor#getDefaultProtocol()
     */
@@ -85,7 +85,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
       }
       return null;
    }
-   
+
    /* (non-Javadoc)
     * @see org.jboss.arquillian.impl.configuration.api.ArquillianDescriptor#engine()
     */
@@ -94,8 +94,8 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
    {
       return new EngineDefImpl(getDescriptorName(), model, model.getOrCreate("engine"));
    }
-   
-   public ContainerDef container(String name) 
+
+   public ContainerDef container(String name)
    {
       return new ContainerDefImpl(getDescriptorName(), model, model.getOrCreate("container@qualifier=" + name));
    }
@@ -108,7 +108,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
    {
       return new GroupDefImpl(getDescriptorName(), model, model.getOrCreate("group@qualifier=" + name));
    }
-   
+
    @Override
    public ExtensionDef extension(String name)
    {
@@ -128,7 +128,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
       }
       return containers;
    }
-   
+
    /* (non-Javadoc)
     * @see org.jboss.arquillian.impl.configuration.api.ArquillianDescriptor#getGroups()
     */
@@ -142,7 +142,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
       }
       return groups;
    }
-   
+
    @Override
    public List<ExtensionDef> getExtensions()
    {
@@ -153,7 +153,7 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
       }
       return extensions;
    }
-   
+
    //-------------------------------------------------------------------------------------||
    // Required Implementations - SchemaDescriptorProvider --------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -166,5 +166,5 @@ public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements 
    public Node getRootNode()
    {
       return model;
-   }   
+   }
 }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.arquillian.config.impl.extension;
 
+import static org.jboss.arquillian.config.impl.extension.ConfigurationValuesTrimmer.trim;
+import static org.jboss.arquillian.config.impl.extension.ConfigurationSysPropResolver.resolveSystemProperties;
+
 import java.io.InputStream;
 
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
@@ -47,19 +50,19 @@ public class ConfigurationRegistrar
    public void loadConfiguration(@Observes ManagerStarted event)
    {
       ArquillianDescriptor descriptor;
-      
-      InputStream input = FileUtils.loadArquillianXml(ARQUILLIAN_XML_PROPERTY, ARQUILLIAN_XML_DEFAULT);
+
+      final InputStream input = FileUtils.loadArquillianXml(ARQUILLIAN_XML_PROPERTY, ARQUILLIAN_XML_DEFAULT);
       if(input != null)
       {
          descriptor = Descriptors.importAs(ArquillianDescriptor.class)
-                                          .from(input);
+                                          .fromStream(input);
       }
-      else 
+      else
       {
          descriptor = Descriptors.create(ArquillianDescriptor.class);
       }
-      
-      final ArquillianDescriptor resolvedDesc = ConfigurationSysPropResolver.resolveSystemProperties(descriptor);
+
+      final ArquillianDescriptor resolvedDesc = trim(resolveSystemProperties(descriptor));
 
       new PropertiesParser().addProperties(
             resolvedDesc,
@@ -67,5 +70,5 @@ public class ConfigurationRegistrar
 
       descriptorInst.set(resolvedDesc);
    }
-   
+
 }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationSysPropResolver.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationSysPropResolver.java
@@ -24,10 +24,10 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
  * replacing any sysprop EL expressions with a proper value or default,
  * and returning a new instance of the {@link ArquillianDescriptor}.
  * Fulfills ARQ-148.
- * 
+ *
  * TODO To eventually become part of a chain-based event mechanism
  * as defined by ARQ-284.
- * 
+ *
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
  */
 class ConfigurationSysPropResolver
@@ -46,13 +46,13 @@ class ConfigurationSysPropResolver
     * values or defaults
     * @param descriptor The input to resolve, required
     * @return
-    * @throws IllegalArgumentException 
+    * @throws IllegalArgumentException
     */
    static ArquillianDescriptor resolveSystemProperties(final ArquillianDescriptor descriptor)
          throws IllegalArgumentException
    {
       final String descrStr = descriptor.exportAsString();
-      final ArquillianDescriptor newArqDescriptor = Descriptors.importAs(ArquillianDescriptor.class).from(
+      final ArquillianDescriptor newArqDescriptor = Descriptors.importAs(ArquillianDescriptor.class).fromString(
             StringPropertyReplacer.replaceProperties(descrStr));
 
       return newArqDescriptor;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationValuesTrimmer.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationValuesTrimmer.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.config.impl.extension;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+/**
+ * @author <a href="mailto:bartosz.majsak@gmail.com">Bartosz Majsak</a>
+ *
+ */
+public class ConfigurationValuesTrimmer
+{
+
+   private static final String NEW_LINES = "(?m)\r?\n|(?m)\r*";
+   private static final String LEADING_AND_TRAILING_WHITESPACES = "(?m)^[ \t]+|(?m)[\t ]+$";
+
+   public static ArquillianDescriptor trim(ArquillianDescriptor descriptor)
+   {
+      final String exportedDescriptor = descriptor.exportAsString().replaceAll(LEADING_AND_TRAILING_WHITESPACES, " ").replaceAll(NEW_LINES, "");
+      return Descriptors.importAs(ArquillianDescriptor.class).fromString(exportedDescriptor);
+   }
+
+}

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
@@ -291,6 +291,26 @@ public class ConfigurationRegistrarTestCase extends AbstractManagerTestBase
             });
    }
 
+   @Test
+   public void shouldBeAbleToLoadConfiguredXMLWithNewLinesFileResource() throws Exception
+   {
+      validate(
+            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+            "src/test/resources/registrar_tests/arquillian_multiple_line_properties.xml",
+            new AssertCallback()
+            {
+               @Override
+               public void validate()
+               {
+                  registrar.loadConfiguration(new ManagerStarted());
+                  ArquillianDescriptor desc = descInst.get();
+
+                  Assert.assertEquals(1, desc.getExtensions().size());
+                  Assert.assertEquals(" new value surrounded with new lines ", desc.getExtensions().get(0).getExtensionProperties().get("multiline-test"));
+               }
+            });
+   }
+
    static void validate(String property, String value, AssertCallback callback)
    {
       try

--- a/config/impl-base/src/test/resources/registrar_tests/arquillian_multiple_line_properties.xml
+++ b/config/impl-base/src/test/resources/registrar_tests/arquillian_multiple_line_properties.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  <container qualifier="${arquillian.container:default}" />
+  <extension qualifier="jboss">
+  	<property name="multiline-test">
+
+  		new value
+  		surrounded
+  		with
+  		new lines
+
+
+  	</property>
+  </extension>
+</arquillian>


### PR DESCRIPTION
Supports configuration entries spanning more than one line. Implemented on the Arquillian Descriptor logic level, as for Shrinkwrap Nodes (bare bones) this might not be relevant at all (eg. <![CDATA[]]> entries).
