### PR TITLE
ARQ-1287 Fixed invalid dependencies scope at arquillian-testng-standalone

### DIFF
--- a/testng/standalone/pom.xml
+++ b/testng/standalone/pom.xml
@@ -39,25 +39,19 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.config</groupId>
-            <artifactId>arquillian-config-impl-base</artifactId>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-impl-base</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <!-- Test -->
-
         <dependency>
             <groupId>org.jboss.arquillian.test</groupId>
             <artifactId>arquillian-test-impl-base</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.core</groupId>
-            <artifactId>arquillian-core-impl-base</artifactId>
+        </dependency>        
+	<dependency>
+            <groupId>org.jboss.arquillian.config</groupId>
+            <artifactId>arquillian-config-impl-base</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- External Projects -->


### PR DESCRIPTION
There were invalid dependencies at arquillian-testng-standlone which lead to behavior described at https://community.jboss.org/message/820175.
Dependencies were synchronized the same way as they are defined at arquillian-junit-standalone
