### PR TITLE
ARQ-1458 Fixing the 'Could not inject members' issue

### DIFF
--- a/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
@@ -50,7 +50,7 @@ public class State
     * A instance of all TestCases are created before the first one is started, so we keep track of which one
     * was the last one created. The last one created is the only one allowed to call AfterSuite.
     */
-   private static ThreadLocal<Integer> lastCreatedRunner = new InheritableThreadLocal<Integer>()
+   private static ThreadLocal<Integer> lastCreatedRunner = new ThreadLocal<Integer>()
    {
       @Override
       protected Integer initialValue()


### PR DESCRIPTION
This bug was introduced by ARQ-1071 (https://issues.jboss.org/browse/ARQ-1071) in 1.0.4.Final and persists in current version (1.1.1.Final). The reason is that all ThreadLocal occurences were replaced by InheritableThreadLocal to fix a NPE on @Timeout usages.

This proposed fix consists on revert just one occurence of InheritableThreadLocal to ThreadLocal.
