### PR TITLE
WFLY-2641 - fix NPE that could occur intermittently

### DIFF
--- a/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
@@ -287,7 +287,7 @@ public class Arquillian extends BlockJUnit4ClassRunner
                   return test;
                }
             });
-            if(result.getThrowable() != null)
+            if (result != null && result.getThrowable() != null)
             {
                throw result.getThrowable();
             }


### PR DESCRIPTION
With this fix WildFly testsuite is much more stable.

I know this fix is not proper solution, but until we have one, lets keep this.

I could track down that root cause has to do with Expected Exception handling but could not narrow it down where exactly should it be fixed.
It could as well be related to bug/change in junit 4.11 for more see https://github.com/junit-team/junit/pull/711
