### PR TITLE
Fix for classes of junit not undeploying

### DIFF
--- a/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
@@ -50,7 +50,6 @@ public class Arquillian extends BlockJUnit4ClassRunner
    public Arquillian(Class<?> klass) throws InitializationError
    {
       super(klass);
-      State.runnerStarted();
    }
    
    @Override
@@ -76,6 +75,8 @@ public class Arquillian extends BlockJUnit4ClassRunner
    @Override
    public void run(final RunNotifier notifier)
    {
+      State.runnerStarted();
+
       // first time we're being initialized
       if(!State.hasTestAdaptor())   
       {


### PR DESCRIPTION
- When counting runners started and stopped together with @Category
  annotation of JUnit some runners was added but never finished

This patch is fixing that problem..
