### PR TITLE
ARQ-1896 Make JMX objectname configurable for JMXTestRunner and JMXMethodExecutor

### DIFF
--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXMethodExecutor.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXMethodExecutor.java
@@ -43,11 +43,17 @@ public class JMXMethodExecutor implements ContainerMethodExecutor {
     private static Logger log = Logger.getLogger(JMXMethodExecutor.class.getName());
 
     private final MBeanServerConnection mbeanServer;
+    private final String objectName;
     private final CommandCallback callback;
 
-    public JMXMethodExecutor(MBeanServerConnection mbeanServer, CommandCallback callbac) {
+    public JMXMethodExecutor(MBeanServerConnection mbeanServer, CommandCallback callback) {
+        this(mbeanServer, callback, JMXTestRunnerMBean.OBJECT_NAME);
+    }
+
+    public JMXMethodExecutor(MBeanServerConnection mbeanServer, CommandCallback callback, String objectName) {
         this.mbeanServer = mbeanServer;
-        this.callback = callbac;
+        this.callback = callback;
+        this.objectName = objectName;
     }
 
     public TestResult invoke(TestMethodExecutor testMethodExecutor) {
@@ -62,7 +68,7 @@ public class JMXMethodExecutor implements ContainerMethodExecutor {
         ObjectName objectName = null;
         TestResult result = null;
         try {
-            objectName = new ObjectName(JMXTestRunnerMBean.OBJECT_NAME);
+            objectName = new ObjectName(this.objectName);
             commandListener = new CallbackNotificationListener(objectName);
             mbeanServer.addNotificationListener(objectName, commandListener, null, null);
 

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
@@ -57,14 +57,19 @@ public class JMXTestRunner extends NotificationBroadcasterSupport implements JMX
    private TestRunner mockTestRunner;
 
    private TestClassLoader testClassLoader;
+   
+   private final String objectName;
 
    public interface TestClassLoader
    {
       Class<?> loadTestClass(String className) throws ClassNotFoundException;
    }
-
    public JMXTestRunner(TestClassLoader classLoader)
    {
+      this(classLoader,JMXTestRunnerMBean.OBJECT_NAME);
+   }
+
+   public JMXTestRunner(TestClassLoader classLoader, String objectName) {
       this.testClassLoader = classLoader;
 
       // Initialize the default TestClassLoader
@@ -81,11 +86,12 @@ public class JMXTestRunner extends NotificationBroadcasterSupport implements JMX
       }
       events = new ConcurrentHashMap<String, Command<?>>();
       currentCall = new ThreadLocal<String>();
+      this.objectName = objectName;
    }
 
    public ObjectName registerMBean(MBeanServer mbeanServer) throws JMException
    {
-      ObjectName oname = new ObjectName(JMXTestRunnerMBean.OBJECT_NAME);
+      ObjectName oname = new ObjectName(this.objectName);
       mbeanServer.registerMBean(this, oname);
       log.fine("JMXTestRunner registered: " + oname);
       localMBeanServer = mbeanServer;
@@ -94,7 +100,7 @@ public class JMXTestRunner extends NotificationBroadcasterSupport implements JMX
 
    public void unregisterMBean(MBeanServer mbeanServer) throws JMException
    {
-      ObjectName oname = new ObjectName(JMXTestRunnerMBean.OBJECT_NAME);
+      ObjectName oname = new ObjectName(this.objectName);
       if (mbeanServer.isRegistered(oname))
       {
          mbeanServer.unregisterMBean(oname);


### PR DESCRIPTION
Currently, JMXTestRunner#runTestMethod(String className, String methodName) expects to find the test class and run the test method using the classloader set in the constructor. This is a problem when my tests are expected to run inside different containers (hence different classloaders). One easy work around is to publish one JMXTestRunner per container (hence unique objectname has to be provided to avoid conflict).