### PR TITLE
[ARQ-1880] Arquillian core relies on TCCL to load infra

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -58,7 +59,10 @@ public class RemoteExtensionLoader implements ExtensionLoader
    public Collection<LoadableExtension> load()
    {
       List<LoadableExtension> extensions = new ArrayList<LoadableExtension>();
-      Collection<RemoteLoadableExtension> loaded = all(SecurityActions.getThreadContextClassLoader(), RemoteLoadableExtension.class);
+      Collection<RemoteLoadableExtension> loaded = Collections.emptyList();      
+      if (SecurityActions.getThreadContextClassLoader() != null) {
+          loaded = all(SecurityActions.getThreadContextClassLoader(), RemoteLoadableExtension.class);
+      }
       if(loaded.size() == 0)
       {
          loaded = all(RemoteExtensionLoader.class.getClassLoader(), RemoteLoadableExtension.class);

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/SecurityActions.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/SecurityActions.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/SecurityActions.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
@@ -18,6 +18,7 @@
 package org.jboss.arquillian.core.impl.loadable;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -120,8 +121,10 @@ public class LoadableExtensionLoader
     */
    private ExtensionLoader locateExtensionLoader()
    {
-      //Collection<ExtensionLoader> loaders = serviceLoader.all(LoadableExtensionLoader.class.getClassLoader(), ExtensionLoader.class);
-      Collection<ExtensionLoader> loaders = serviceLoader.all(SecurityActions.getThreadContextClassLoader(), ExtensionLoader.class);
+      Collection<ExtensionLoader> loaders = Collections.emptyList();      
+      if (SecurityActions.getThreadContextClassLoader() != null) {
+          loaders = serviceLoader.all(SecurityActions.getThreadContextClassLoader(), ExtensionLoader.class);
+      }
       if(loaders.size() == 0)
       {
          loaders = serviceLoader.all(LoadableExtensionLoader.class.getClassLoader(), ExtensionLoader.class);

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/SecurityActions.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/SecurityActions.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/SecurityActions.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/SecurityActions.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/SecurityActions.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+      @SuppressWarnings("unchecked")
+      Class<T> implClass = (Class<T>) loadClass(className);
+      if (!expectedType.isAssignableFrom(implClass)) {
+          throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+      }
+      return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
@@ -70,12 +70,13 @@ public class ResourceInjectionEnricher implements TestEnricher
      return new Object[method.getParameterTypes().length];
    }
 
+   @SuppressWarnings("unchecked")
    protected void injectClass(Object testCase) 
    {
       try 
       {
-         @SuppressWarnings("unchecked")
-         Class<? extends Annotation> resourceAnnotation = (Class<? extends Annotation>)SecurityActions.getThreadContextClassLoader().loadClass(ANNOTATION_NAME);
+         ClassLoader classLoader = ResourceInjectionEnricher.class.getClassLoader();
+         Class<? extends Annotation> resourceAnnotation = (Class<? extends Annotation>)classLoader.loadClass(ANNOTATION_NAME);
          
          List<Field> annotatedFields = SecurityActions.getFieldsWithAnnotation(
                testCase.getClass(), 

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
@@ -94,7 +94,12 @@ final class SecurityActions
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType)
    {
-      return newInstance(className, argumentTypes, arguments, expectedType, getThreadContextClassLoader());
+       @SuppressWarnings("unchecked")
+       Class<T> implClass = (Class<T>) loadClass(className);
+       if (!expectedType.isAssignableFrom(implClass)) {
+           throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+       }
+       return newInstance(implClass, argumentTypes, arguments);
    }
 
    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments, final Class<T> expectedType, ClassLoader classLoader)


### PR DESCRIPTION
https://issues.jboss.org/browse/ARQ-1880

The idea of this PR is to make loading from TCCL optional. If it is set, it still takes precedence. If not set, we use the CL from respective ARQ types 