### PR TITLE
ARQ-1937 added log warning and modified javadoc

### DIFF
--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
@@ -51,6 +51,10 @@ public interface Deployer
    /**
     * Deploy the named deployment. <br/>
     * The operation will block until deploy is complete.
+    * <p>
+    * NOTE: The test that calls this method will run on the client side even if the annotation {@link RunAsClient} is not 
+    * declared - you cannot deploy any deployment from the container. Please use the annotation {@link RunAsClient} either 
+    * on the test method where the deploy(String name) method is called or on the whole test class.
     * 
     * @param name The name of the deployment
     */

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
  * &#64;ArquillianResource
  * private Deployer deployer;
  *
- * &#64;Test
+ * &#64;Test &#64;RunAsClient
  * public void shouldDeployX() {
  *      deployer.deploy("X");
  * }
@@ -52,9 +52,31 @@ public interface Deployer
     * Deploy the named deployment. <br/>
     * The operation will block until deploy is complete.
     * <p>
-    * NOTE: The test that calls this method will run on the client side even if the annotation {@link RunAsClient} is not 
-    * declared - you cannot deploy any deployment from the container. Please use the annotation {@link RunAsClient} either 
-    * on the test method where the deploy(String name) method is called or on the whole test class.
+    * NOTE: If you want to run a test in a container, you cannot deploy a deployment from this test on the same container that the test is 
+    * running in.
+    * </p>
+    * This is NOT correct for a test running in a container:<br/>
+    * <pre><code>
+    * &#64;Test &#64;OperatesOnDeployment("X")
+    * public void deployTest() {
+    *     deployer.deploy("X");
+    * }
+    * </code></pre>
+    * <p>
+    * If you run the test in this way for the very first deployment the test will be launched on the client side. If you try to redeploy 
+    * a deployment from the container an exception will be thrown. In these cases please use the annotation {@link RunAsClient} either 
+    * on the test method  or on the whole test class to be sure, that the test is running on the client side.
+    * </p>
+    * <p>
+    * NOTE: You can still (re)deploy a deployment on a different container than the test is running in.
+    * </p>
+    * This IS correct for a test running in a container: <br/>
+    * <pre><code>
+    * &#64;Test &#64;OperatesOnDeployment("X")
+    * public void deployTest() {
+    *     deployer.deploy("Y");
+    * }
+    * </code></pre>
     * 
     * @param name The name of the deployment
     */

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RunModeUtils.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RunModeUtils.java
@@ -18,6 +18,7 @@
 package org.jboss.arquillian.container.test.impl;
 
 import java.lang.reflect.Method;
+import java.util.logging.Logger;
 
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.client.deployment.Deployment;
@@ -32,6 +33,8 @@ import org.jboss.arquillian.container.test.impl.client.protocol.local.LocalProto
  */
 public final class RunModeUtils
 {
+   private static Logger log = Logger.getLogger(RunModeUtils.class.getName());
+    
    private RunModeUtils() { }
    
    /**
@@ -46,20 +49,29 @@ public final class RunModeUtils
     */
    public static boolean isRunAsClient(Deployment deployment, Class<?> testClass, Method testMethod)
    {
+      boolean runMethodAsClient = testMethod.isAnnotationPresent(RunAsClient.class);
+      boolean runClassAsClient = testClass.isAnnotationPresent(RunAsClient.class);
+      
       boolean runAsClient = true;
       if(deployment != null)
       {
          runAsClient =  deployment.getDescription().testable() ? false:true;
          runAsClient =  deployment.isDeployed() ? runAsClient:true;
-         
-         if(testMethod.isAnnotationPresent(RunAsClient.class))
+
+         if(runMethodAsClient)
          {
             runAsClient = true;
          }
-         else if(testClass.isAnnotationPresent(RunAsClient.class))
+         else if(runClassAsClient)
          {
             runAsClient = true;
          }
+      }
+      else if (!runMethodAsClient && !runClassAsClient) 
+      {
+          log.warning("The test method \"" + testClass.getCanonicalName() + " " + testMethod.getName()
+              + "\" will run on the client side - there is no running deployment yet. Please use the "
+              + "annotation @RunAsClient");
       }
       return runAsClient;
    }


### PR DESCRIPTION
Hi,
I've modified the javadoc for the Deployer.deploy according to your comment here: https://github.com/MatousJobanek/arquillian-core/commit/42a2528cb65f540c5b6114deec338a1796f58901
I hope that it is OK now. 
If you think that changing the javadoc/adding the log warning is a nonsense in this case, just let me know ;-).