### PR TITLE
ARQ-1954 Added support of @Rule enrichment

### DIFF
--- a/junit/core/pom.xml
+++ b/junit/core/pom.xml
@@ -56,6 +56,20 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-impl-base</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-impl-base</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
@@ -307,14 +307,18 @@ public class Arquillian extends BlockJUnit4ClassRunner
                    final AtomicInteger integer = new AtomicInteger();
                    List<Throwable> exceptions = new ArrayList<Throwable>();
 
-                   try {
-                       adaptor.fireCustomLifecycle(new BeforeRules(test, method.getMethod(), new LifecycleMethodExecutor() {
-                           @Override
-                           public void invoke() throws Throwable {
-                               integer.incrementAndGet();
-                               stmtWithRules.evaluate();
-                           }
-                       }));
+                   try
+                   {
+                       adaptor.fireCustomLifecycle(new BeforeRules(test, getTestClass(), stmtWithRules, method.getMethod(),
+                           new LifecycleMethodExecutor()
+                           {
+                               @Override
+                               public void invoke() throws Throwable
+                               {
+                                   integer.incrementAndGet();
+                                   stmtWithRules.evaluate();
+                               }
+                           }));
                        // If AroundRules (includes lifecycles) were not executed, invoke only lifecycles+test
                        if(integer.get() == 0) {
                            try {

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/RulesEnricher.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/RulesEnricher.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.junit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.junit.event.BeforeRules;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.event.enrichment.AfterEnrichment;
+import org.jboss.arquillian.test.spi.event.enrichment.BeforeEnrichment;
+import org.jboss.arquillian.test.spi.event.enrichment.EnrichmentEvent;
+import org.junit.Rule;
+import org.junit.rules.MethodRule;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
+
+/**
+ * Enriches instance of the Rule that has been applied; of the Statement that is about to be taken; and of the Test that is
+ * about to be executed<br/>
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ * @version $Revision: $
+ */
+public class RulesEnricher
+{
+    @Inject
+    private Instance<ServiceLoader> serviceLoader;
+
+    @Inject
+    private Event<EnrichmentEvent> enrichmentEvent;
+
+    private static Logger log = Logger.getLogger(RulesEnricher.class.getName());
+
+    public void enrich(@Observes BeforeRules event) throws Exception
+    {
+        List<Object> toEnrich = getRuleInstances(event);
+        if (toEnrich == null)
+        {
+            return;
+        }
+
+        toEnrich.add(event.getTestInstance());
+
+        if (RunRules.class.isInstance(event.getStatementInstance()))
+        {
+            toEnrich.add(SecurityActions.getField(RunRules.class, "statement").get(event.getStatementInstance()));
+        } else
+        {
+            toEnrich.add(event.getStatementInstance());
+        }
+
+        enrichmentEvent.fire(new BeforeEnrichment());
+
+        Collection<TestEnricher> testEnrichers = serviceLoader.get().all(TestEnricher.class);
+        for (TestEnricher enricher : testEnrichers)
+        {
+            for (Object instance : toEnrich)
+            {
+                enricher.enrich(instance);
+            }
+
+        }
+        enrichmentEvent.fire(new AfterEnrichment());
+    }
+
+    /**
+     * Retrieves instances of the TestRule and MethodRule classes
+     */
+    private List<Object> getRuleInstances(BeforeRules event) throws Exception
+    {
+        Object testInstance = event.getTestInstance();
+        List<Object> ruleInstances = new ArrayList<Object>();
+
+        List<Field> fieldsWithRuleAnnotation = SecurityActions.getFieldsWithAnnotation(testInstance.getClass(), Rule.class);
+        if (fieldsWithRuleAnnotation.isEmpty())
+        {
+            List<Method> methodsWithAnnotation = SecurityActions.getMethodsWithAnnotation(testInstance.getClass(), Rule.class);
+            if (methodsWithAnnotation.isEmpty())
+            {
+                // there isn't any rule in the test class
+                return null;
+            }
+            else
+            {
+                log.warning("Please note that methods annotated with @Rule are not fully supported in Arquillian. "
+                    + "Specificaly, if you want to enrich a field in your Rule implementation class.");
+                
+                return ruleInstances;
+            }
+        } else
+        {
+            for (Field field : fieldsWithRuleAnnotation)
+            {
+                Object fieldInstance = field.get(event.getTestInstance());
+                if (isRule(fieldInstance))
+                {
+                    ruleInstances.add(fieldInstance);
+                }
+            }
+        }
+        return ruleInstances;
+    }
+
+    /**
+     * Decides whether the instance is a Rule or not
+     */
+    private boolean isRule(Object instance)
+    {
+        return MethodRule.class.isInstance(instance) || TestRule.class.isInstance(instance);
+    }
+}

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
@@ -291,6 +291,36 @@ final class SecurityActions
       });
       return declaredAccessableFields;
    }
+   
+    public static Field getField(final Class<?> source, final String name)
+    {
+        Field declaredAccessibleField = AccessController.doPrivileged(new PrivilegedAction<Field>()
+        {
+            public Field run()
+            {
+                Field foundField = null;
+                Class<?> nextSource = source;
+                while (nextSource != Object.class)
+                {
+                    try
+                    {
+                        foundField = nextSource.getDeclaredField(name);
+                        if (!foundField.isAccessible())
+                        {
+                            foundField.setAccessible(true);
+                        }
+                        break;
+                    } catch (NoSuchFieldException e)
+                    {
+                        // Nothing to do - just scan the super class
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundField;
+            }
+        });
+        return declaredAccessibleField;
+    }
 
    public static List<Method> getMethodsWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) 
    {

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/event/BeforeRules.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/event/BeforeRules.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 
 import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.event.suite.BeforeTestLifecycleEvent;
+import org.junit.runners.model.TestClass;
 
 /**
  *
@@ -13,14 +14,31 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeTestLifecycleEvent;
  */
 public class BeforeRules extends BeforeTestLifecycleEvent {
 
+    private Object statementInstance;
+    private TestClass testClassInstance;
+
     /**
      * @param testInstance The test case instance being tested
+     * @param testClassInstance The {@link TestClass} instance representing the test case
+     * @param statementInstance The statement that is about to be taken at runtime in the course of running a JUnit test suite.
      * @param testMethod The test method that is about to be executed
      * @param executor A call back when the LifecycleMethod represented by this event should be invoked
      */
-    public BeforeRules(Object testInstance, Method testMethod, LifecycleMethodExecutor executor)
+    public BeforeRules(Object testInstance, TestClass testClassInstance, Object statementInstance, Method testMethod,
+        LifecycleMethodExecutor executor)
     {
-       super(testInstance, testMethod, executor);
+        super(testInstance, testMethod, executor);
+        this.statementInstance = statementInstance;
+        this.testClassInstance = testClassInstance;
     }
 
+    public Object getStatementInstance()
+    {
+        return statementInstance;
+    }
+
+    public TestClass getTestClassInstance()
+    {
+        return testClassInstance;
+    }
 }

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/extension/JUnitCoreExtension.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/extension/JUnitCoreExtension.java
@@ -17,12 +17,14 @@
 package org.jboss.arquillian.junit.extension;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.junit.RulesEnricher;
 
 class JUnitCoreExtension implements LoadableExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
         builder.observer(UpdateTestResultBeforeAfter.class);
+        builder.observer(RulesEnricher.class);
     }
 
 }

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/AbstractRuleStatementEnrichment.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/AbstractRuleStatementEnrichment.java
@@ -1,0 +1,17 @@
+package org.jboss.arquillian.junit.rules;
+
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public abstract class AbstractRuleStatementEnrichment
+{
+    public abstract void verifyEnrichment();
+
+    public abstract TestRule getTestRule();
+
+    public abstract MethodRule getMethodRule();
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/InnerRuleInnerStatementEnrichment.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/InnerRuleInnerStatementEnrichment.java
@@ -1,0 +1,103 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * Uses Rule and Statement as inner anonymous classes.
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ * 
+ */
+public class InnerRuleInnerStatementEnrichment extends AbstractRuleStatementEnrichment
+{
+    @ArquillianResource
+    private ResourcesImpl testResources;
+
+    @Rule
+    public TestRule testRule = new TestRule()
+    {
+        @ArquillianResource
+        private ResourcesImpl ruleResources;
+
+        @Override
+        public Statement apply(final Statement base, Description description)
+        {
+            return new Statement()
+            {
+                @ArquillianResource
+                private ResourcesImpl statementResources;
+
+                @Override
+                public void evaluate() throws Throwable
+                {
+                    assertNotNull(testResources);
+                    assertNotNull(ruleResources);
+                    assertNotNull(statementResources);
+
+                    Assert.assertNotEquals(testResources, ruleResources);
+                    Assert.assertNotEquals(testResources, statementResources);
+                    Assert.assertNotEquals(statementResources, ruleResources);
+
+                    base.evaluate();
+                }
+            };
+        }
+    };
+
+    @Rule
+    public MethodRule methodRule = new MethodRule()
+    {
+        @ArquillianResource
+        private ResourcesImpl ruleResources;
+
+        @Override
+        public Statement apply(final Statement base, FrameworkMethod method, Object target)
+        {
+            return new Statement()
+            {
+                @ArquillianResource
+                private ResourcesImpl statementResources;
+
+                @Override
+                public void evaluate() throws Throwable
+                {
+                    assertNotNull(testResources);
+                    assertNotNull(ruleResources);
+                    assertNotNull(statementResources);
+
+                    Assert.assertNotEquals(testResources, ruleResources);
+                    Assert.assertNotEquals(testResources, statementResources);
+                    Assert.assertNotEquals(statementResources, ruleResources);
+                    
+                    base.evaluate();
+                }
+            };
+        }
+    };
+
+    public TestRule getTestRule()
+    {
+        return testRule;
+    }
+
+    public MethodRule getMethodRule()
+    {
+        return methodRule;
+    }
+
+    @Test
+    public void verifyEnrichment()
+    {
+        assertNotNull(testResources);
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/OuterRuleInnerStatementEnrichment.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/OuterRuleInnerStatementEnrichment.java
@@ -1,0 +1,43 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+
+/**
+ * Uses Rule as normal outer java class and Statement as inner anonymous class defined within the Rule
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class OuterRuleInnerStatementEnrichment extends AbstractRuleStatementEnrichment
+{
+    @ArquillianResource
+    private ResourcesImpl resources;
+
+    @Rule
+    public TestingTestRuleInnerStatement testRuleInnerStatement = new TestingTestRuleInnerStatement();
+
+    @Rule
+    public TestingMethodRuleInnerStatement methodRuleInnerStatement = new TestingMethodRuleInnerStatement();
+
+    public TestRule getTestRule()
+    {
+        return testRuleInnerStatement;
+    }
+
+    public MethodRule getMethodRule()
+    {
+        return methodRuleInnerStatement;
+    }
+
+    @Test
+    public void verifyEnrichment()
+    {
+        assertNotNull(resources);
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/OuterRuleOuterStatementEnrichment.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/OuterRuleOuterStatementEnrichment.java
@@ -1,0 +1,43 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+
+/**
+ * Uses Rule and Statement as normal outer java classes.
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class OuterRuleOuterStatementEnrichment extends AbstractRuleStatementEnrichment
+{
+    @ArquillianResource
+    private ResourcesImpl resources;
+
+    @Rule
+    public TestingTestRule testRule = new TestingTestRule();
+
+    @Rule
+    public TestingMethodRule methodRule = new TestingMethodRule();
+
+    public TestRule getTestRule()
+    {
+        return testRule;
+    }
+
+    public MethodRule getMethodRule()
+    {
+        return methodRule;
+    }
+
+    @Test
+    public void verifyEnrichment()
+    {
+        assertNotNull(resources);
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/ResourcesImpl.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/ResourcesImpl.java
@@ -1,0 +1,10 @@
+package org.jboss.arquillian.junit.rules;
+
+/**
+ * An class representing some kind of resources
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class ResourcesImpl {
+    
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/ResourcesProvider.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/ResourcesProvider.java
@@ -1,0 +1,27 @@
+package org.jboss.arquillian.junit.rules;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * Provides to test class an instance of the class {@link ResourcesImpl}.
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ */
+public class ResourcesProvider implements ResourceProvider
+{
+
+    @Override
+    public boolean canProvide(Class<?> type)
+    {
+        return type.equals(ResourcesImpl.class);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers)
+    {
+        return new ResourcesImpl();
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/RulesEnrichmentTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/RulesEnrichmentTestCase.java
@@ -1,0 +1,157 @@
+package org.jboss.arquillian.junit.rules;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.impl.InjectorImpl;
+import org.jboss.arquillian.core.impl.loadable.ServiceRegistry;
+import org.jboss.arquillian.core.impl.loadable.ServiceRegistryLoader;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.junit.RulesEnricher;
+import org.jboss.arquillian.junit.event.BeforeRules;
+import org.jboss.arquillian.test.impl.enricher.resource.ArquillianResourceTestEnricher;
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+import org.jboss.arquillian.test.spi.event.enrichment.AfterEnrichment;
+import org.jboss.arquillian.test.spi.event.enrichment.BeforeEnrichment;
+import org.jboss.arquillian.test.test.AbstractTestTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RulesEnrichmentTestCase extends AbstractTestTestBase
+{
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions)
+    {
+        extensions.add(RulesEnricher.class);
+    }
+
+    @Before
+    public void prepare()
+    {
+        Injector injector = InjectorImpl.of(getManager());
+        ServiceRegistry registry = new ServiceRegistry(injector);
+
+        registry.addService(ResourceProvider.class, ResourcesProvider.class);
+        registry.addService(TestEnricher.class, ArquillianResourceTestEnricher.class);
+
+        ServiceRegistryLoader serviceLoader = new ServiceRegistryLoader(injector, registry);
+        bind(SuiteScoped.class, ServiceLoader.class, serviceLoader);
+    }
+
+    @Test
+    public void shouldEnrichInnerTestRuleInnerStatement() throws Throwable
+    {
+        testTestRuleEnrichment(new InnerRuleInnerStatementEnrichment());
+    }
+
+    @Test
+    public void shouldEnrichInnerMethodRuleInnerStatement() throws Throwable
+    {
+        testMethodRuleEnrichment(new InnerRuleInnerStatementEnrichment());
+    }
+
+    @Test
+    public void shouldEnrichOuterTestRuleInnerStatement() throws Throwable
+    {
+        testTestRuleEnrichment(new OuterRuleInnerStatementEnrichment());
+    }
+
+    @Test
+    public void shouldEnrichOuterMethodRuleInnerStatement() throws Throwable
+    {
+        testMethodRuleEnrichment(new OuterRuleInnerStatementEnrichment());
+    }
+    
+    @Test
+    public void shouldEnrichOuterTestRuleOuterStatement() throws Throwable
+    {
+        testTestRuleEnrichment(new OuterRuleOuterStatementEnrichment());
+    }
+
+    @Test
+    public void shouldEnrichOuterMethodRuleOuterStatement() throws Throwable
+    {
+        testMethodRuleEnrichment(new OuterRuleOuterStatementEnrichment());
+    }
+
+    private void testTestRuleEnrichment(AbstractRuleStatementEnrichment test) throws Throwable
+    {
+        Statement invokeStatement = getInvokingStatement(test);
+
+        TestClass testClass = new TestClass(test.getClass());
+
+        Description desc = Description.createTestDescription(test.getClass(), "verifyEnrichment");
+        final Statement statement = test.getTestRule().apply(invokeStatement, desc);
+
+        LifecycleMethodExecutor testLifecycleMethodExecutor = getTestLifecycleMethodExecutor(statement);
+
+        fire(new BeforeRules(test, testClass, statement, test.getClass().getMethod("verifyEnrichment"), testLifecycleMethodExecutor));
+        testLifecycleMethodExecutor.invoke();
+
+        verifyEventFired();
+    }
+
+    private void testMethodRuleEnrichment(AbstractRuleStatementEnrichment test) throws Throwable
+    {
+        Statement invokeStatement = getInvokingStatement(test);
+
+        Method testMethod = test.getClass().getMethod("verifyEnrichment");
+
+        TestClass testClass = new TestClass(test.getClass());
+        FrameworkMethod method = testClass.getAnnotatedMethods(Test.class).get(0);
+        final Statement statement = test.getMethodRule().apply(invokeStatement, method, test);
+
+        LifecycleMethodExecutor testLifecycleMethodExecutor = getTestLifecycleMethodExecutor(statement);
+
+        fire(new BeforeRules(test, testClass, statement, testMethod, testLifecycleMethodExecutor));
+        testLifecycleMethodExecutor.invoke();
+
+        verifyEventFired();
+    }
+
+    private void verifyEventFired()
+    {
+        assertEventFired(BeforeEnrichment.class, 1);
+        assertEventFired(AfterEnrichment.class, 1);
+    }
+
+    private Statement getInvokingStatement(final AbstractRuleStatementEnrichment test)
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                test.verifyEnrichment();
+            }
+        };
+    }
+
+    private LifecycleMethodExecutor getTestLifecycleMethodExecutor(final Statement statement)
+    {
+        return new LifecycleMethodExecutor()
+        {
+            @Override
+            public void invoke() throws Throwable
+            {
+                statement.evaluate();
+            }
+        };
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingMethodRule.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingMethodRule.java
@@ -1,0 +1,21 @@
+package org.jboss.arquillian.junit.rules;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * An implementation of MethodRule
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class TestingMethodRule implements MethodRule
+{
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target)
+    {
+        return new TestingStatement(base);
+    }
+
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingMethodRuleInnerStatement.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingMethodRuleInnerStatement.java
@@ -1,0 +1,42 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * An Implementation of MethodRule with Statement declared as inner anonymous class
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class TestingMethodRuleInnerStatement implements MethodRule
+{
+    @ArquillianResource
+    private ResourcesImpl ruleResources;
+
+    @Override
+    public Statement apply(final Statement base, FrameworkMethod method, Object target)
+    {
+        return new Statement()
+        {
+            @ArquillianResource
+            private ResourcesImpl statementResources;
+            
+            @Override
+            public void evaluate() throws Throwable
+            {
+                assertNotNull(ruleResources);
+                assertNotNull(statementResources);
+                Assert.assertNotEquals(statementResources, ruleResources);
+                
+                base.evaluate();
+            }
+        };
+    }
+
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingStatement.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingStatement.java
@@ -1,0 +1,32 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.runners.model.Statement;
+
+/**
+ * An implementation of Statement
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class TestingStatement extends Statement
+{
+    @ArquillianResource
+    private ResourcesImpl resources;
+
+    private Statement base;
+
+    public TestingStatement(Statement base)
+    {
+        this.base = base;
+    }
+
+    @Override
+    public void evaluate() throws Throwable
+    {
+        assertNotNull(resources);
+        base.evaluate();
+    }
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingTestRule.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingTestRule.java
@@ -1,0 +1,21 @@
+package org.jboss.arquillian.junit.rules;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * An Implementation of TestRule
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class TestingTestRule implements TestRule
+{
+    @Override
+    public Statement apply(Statement base, Description description)
+    {
+        return new TestingStatement(base);
+    }
+
+}

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingTestRuleInnerStatement.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/TestingTestRuleInnerStatement.java
@@ -1,0 +1,41 @@
+package org.jboss.arquillian.junit.rules;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * An Implementation of TestRule with Statement declared as inner anonymous class
+ * 
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ *
+ */
+public class TestingTestRuleInnerStatement implements TestRule
+{
+    @ArquillianResource
+    private ResourcesImpl ruleResources;
+
+    @Override
+    public Statement apply(final Statement base, Description description)
+    {
+        return new Statement()
+        {
+            @ArquillianResource
+            private ResourcesImpl statementResources;
+            
+            @Override
+            public void evaluate() throws Throwable
+            {
+                assertNotNull(ruleResources);
+                assertNotNull(statementResources);
+                Assert.assertNotEquals(statementResources, ruleResources);
+                base.evaluate();
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
I've added support of @Rule enrichment [ARQ-1954]. 
According to the javadoc http://junit.org/apidocs/org/junit/Rule.html, there can be both the fields and the methods annotated with @Rule. This implementation fully supports the fields, however, in the case of methods there is one problem - specifically, the fields declared in the Rule implementation are not enriched. The cause is that I haven't found any meaningful/save way how to retrieve reference to the instance of the Rule implementation.
I've created also tests for it.