### PR TITLE
Allow for setting the protocol in ServletProtocolConfiguration

### DIFF
--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletProtocolConfiguration.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletProtocolConfiguration.java
@@ -28,10 +28,27 @@ import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfigura
  */
 public class ServletProtocolConfiguration implements ProtocolConfiguration
 {
+   private String scheme = null;
    private String host = null;
    private Integer port = null;
    private String contextRoot = null;;
    private Integer pullInMilliSeconds = 100;
+   
+   /**
+    * @return the scheme
+    */
+   public String getScheme()
+   {
+      return scheme;
+   }
+
+   /**
+    * @param scheme the scheme to set
+    */
+   public void setScheme(String scheme)
+   {
+      this.scheme = scheme;
+   }
    
    /**
     * @return the host
@@ -83,7 +100,7 @@ public class ServletProtocolConfiguration implements ProtocolConfiguration
 
    public URI getBaseURI()
    {
-      return URI.create("http://" + host + ":" + port + "/" + contextRoot);
+      return URI.create(scheme + "://" + host + ":" + port + "/" + contextRoot);
    }
 
    /**

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletUtil.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletUtil.java
@@ -39,7 +39,8 @@ public final class ServletUtil
    
    public static URI determineBaseURI(ServletProtocolConfiguration config, HTTPContext context, String servletName)
    {
-      String address = config.getHost();
+	  String scheme = config.getScheme();
+      String host = config.getHost();
       Integer port = config.getPort();
 
       // TODO: can not set contextRoot in config, change to prefixContextRoot
@@ -49,9 +50,13 @@ public final class ServletUtil
       if(servlet != null)
       {
          // use the context where the Arquillian servlet is found
-         if(address == null)
+         if(scheme == null)
          {
-            address = context.getHost();
+            scheme = "http";
+         }
+         if(host == null)
+         {
+            host = context.getHost();
          }
          if(port == null)
          {
@@ -65,7 +70,7 @@ public final class ServletUtil
               servletName + " not found. " +
               "Could not determine ContextRoot from ProtocolMetadata, please contact DeployableContainer developer.");
       }
-      return URI.create("http://" + address + ":" + port + contextRoot);
+      return URI.create(scheme + "://" + host + ":" + port + contextRoot);
    }
 
    public static String calculateContextRoot(String archiveName)

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocolTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocolTestCase.java
@@ -58,6 +58,7 @@ public class BaseServletProtocolTestCase
    public void shouldOverrideMetadata() throws Exception
    {
       ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+      config.setScheme("https");
       config.setHost("10.10.10.1");
       config.setPort(90);
       
@@ -69,7 +70,7 @@ public class BaseServletProtocolTestCase
       ServletURIHandler handler = new ServletURIHandler(config, to(testContext));
       URI result = handler.locateTestServlet(testMethod);
 
-      Assert.assertEquals("http://10.10.10.1:90/test", result.toString());
+      Assert.assertEquals("https://10.10.10.1:90/test", result.toString());
    }
    
    @Test
@@ -95,6 +96,7 @@ public class BaseServletProtocolTestCase
    public void shouldOverrideMatchNamedTargetedContext() throws Exception
    {
       ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+      config.setScheme("https");
       config.setHost("10.10.10.1");
       config.setPort(90);
       
@@ -109,7 +111,7 @@ public class BaseServletProtocolTestCase
       ServletURIHandler handler = new ServletURIHandler(config, to(testContextOne, testContextTwo));
       URI result = handler.locateTestServlet(testMethod);
 
-      Assert.assertEquals("http://10.10.10.1:90/testX", result.toString());
+      Assert.assertEquals("https://10.10.10.1:90/testX", result.toString());
    }
    
    @Test(expected = IllegalArgumentException.class)
@@ -149,7 +151,6 @@ public class BaseServletProtocolTestCase
    @SuppressWarnings("unused")
    private void testNoAnnotations() {}
 
-   @SuppressWarnings("unused")
    @TargetsContainer("X")
    private void testTargeted() {}
 }


### PR DESCRIPTION
This pull request allows setting the protocol in ServletProtocolConfiguration. This way users can deploy using https and not have potentially sensitive data be send over http to the internet.