### PR TITLE
ARQ-1976 All ResourceProvider#canProvide implementations could try to inject subtypes

### DIFF
--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
@@ -63,13 +63,13 @@ import java.util.Map;
  */
 public interface ContainerController 
 {
-   public void start(String containerQualifier);
+   void start(String containerQualifier);
    
-   public void start(String containerQualifier, Map<String, String> config);
+   void start(String containerQualifier, Map<String, String> config);
    
-   public void stop(String containerQualifier);
+   void stop(String containerQualifier);
    
-   public void kill(String containerQualifier);
+   void kill(String containerQualifier);
 
-   public boolean isStarted(String containerQualifier);
+   boolean isStarted(String containerQualifier);
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
@@ -51,6 +51,6 @@ public class ContainerControllerProvider implements ResourceProvider
    @Override
    public boolean canProvide(Class<?> type)
    {
-      return ContainerController.class.isAssignableFrom(type);
+      return type.isAssignableFrom(ContainerController.class);
    }
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
@@ -36,18 +36,12 @@ public class ContainerControllerProvider implements ResourceProvider
    @Inject
    private Instance<ContainerController> controller;
    
-   /* (non-Javadoc)
-    * @see org.jboss.arquillian.testenricher.arquillian.ResourceProvider#lookup(org.jboss.arquillian.api.ArquillianResource)
-    */
    @Override
    public Object lookup(ArquillianResource resource, Annotation... qualifiers)
    {
       return controller.get();
    }
 
-   /* (non-Javadoc)
-    * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(java.lang.Class)
-    */
    @Override
    public boolean canProvide(Class<?> type)
    {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/DeployerProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/DeployerProvider.java
@@ -45,6 +45,6 @@ public class DeployerProvider implements ResourceProvider
    @Override
    public boolean canProvide(Class<?> type)
    {
-      return Deployer.class.isAssignableFrom(type);
+      return type.isAssignableFrom(Deployer.class);
    }
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProvider.java
@@ -46,6 +46,6 @@ public class InitialContextProvider extends OperatesOnDeploymentAwareProvider
    @Override
    public boolean canProvide(Class<?> type)
    {
-      return Context.class.isAssignableFrom(type) || InitialContext.class.isAssignableFrom(type);
+      return type.isAssignableFrom(Context.class) || type.isAssignableFrom(InitialContext.class);
    }
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
@@ -38,7 +38,7 @@ public class URIResourceProvider extends URLResourceProvider
       Object object = super.lookup(resource, qualifiers);
       if(object == null)
       {
-         return object;
+         return null;
       }
       try
       {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
@@ -53,6 +53,6 @@ public class URIResourceProvider extends URLResourceProvider
    @Override
    public boolean canProvide(Class<?> type)
    {
-      return URI.class.isAssignableFrom(type);
+      return type.isAssignableFrom(URI.class);
    }
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProvider.java
@@ -46,7 +46,7 @@ public class URLResourceProvider extends OperatesOnDeploymentAwareProvider
    @Override
    public boolean canProvide(Class<?> type)
    {
-      return URL.class.isAssignableFrom(type);
+      return type.isAssignableFrom(URL.class);
    }
 
    @Override

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/enricher/resource/ResourceProvider.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/enricher/resource/ResourceProvider.java
@@ -47,7 +47,7 @@ public interface ResourceProvider
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
-    static @interface ClassInjection
+    @interface ClassInjection
     {
     }
 
@@ -60,7 +60,7 @@ public interface ResourceProvider
      */
     @Documented
     @Retention(RUNTIME)
-    static @interface MethodInjection
+    @interface MethodInjection
     {
     }
 }


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/ARQ-1976

@aslakknutsen this would really need your eyes, this might be problematic.