### PR TITLE
Report first exception instead of last one

### DIFF
--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
@@ -108,6 +108,10 @@ public class JUnitTestRunner implements TestRunner
 
       @Override
       public void testFailure(Failure failure) throws Exception {
+          if (exception != null) {
+              // In case of multiple errors only keep the first exception
+              return;
+          }
           exception = State.getTestException();
           Test test = failure.getDescription().getAnnotation(Test.class);
           if ( !(test != null && test.expected() != Test.None.class))


### PR DESCRIPTION
In particular when testing with the Arquillian Persistence extension it can be very difficult to diagnose problems in a test:
Usually when seeding of the database fails some other After event listener fails as well, e.g. evaluation of `@ShouldMatchDataSet`.
Then Arquillian only reports the last error that the actual result differs from the expected one.
This makes fixing the test very hard.

This PR changes the JUnitTestRunner so that it keeps the first exception that passes by `ExpectedExceptionHolder.testFailure()` instead of the last one.