### PR TITLE
Allow the additional processing of deployment descriptions on deployment methods

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
@@ -69,6 +69,16 @@ public class AnnotationDeploymentScenarioGenerator implements DeploymentScenario
       return deployments;
    }
 
+    /**
+     * Allows extensions to process or override parts of the deployment description.
+     *
+     * @param deploymentMethod      the method being processed
+     * @param deploymentDescription the current deployment description
+     */
+   protected void addtionalProcessing(Method deploymentMethod, DeploymentDescription deploymentDescription) {
+      // do nothing by default
+   }
+
    private void validate(Method deploymentMethod)
    {
       if(!Modifier.isStatic(deploymentMethod.getModifiers()))
@@ -125,7 +135,8 @@ public class AnnotationDeploymentScenarioGenerator implements DeploymentScenario
          deployment.setExpectedException(deploymentMethod.getAnnotation(ShouldThrowException.class).value());
          deployment.shouldBeTestable(false); // can't test against failing deployments
       }
-      
+
+      addtionalProcessing(deploymentMethod, deployment);
       return deployment;
    }
 


### PR DESCRIPTION
I can file a JIRA for this, but just wanted to see if something like this seems okay first.

Currently the wildfly-arquillian-managed-container-domain requires the use of a `@TargetsContainer` annotation where the name is the name of the server group for deployments. This seems a bit odd to me since the `@TargetsContainer` documentation indicates that the value should be derived from a container defined in the `arquillian.xml` file.

I wanted to add a new annotation `@TargersServerGroup` to be more explicit and also, possibly, allow the `@TargetsContainer` to work as designed. I haven't looked at the second part yet. Anyway a change like this would allow me to keep normal processing of a deployment, but override the `TargetDescription` to be the name of the server group.

I'm not sure if this is the best approach so maybe there's something better. What would be ideal is if I could somehow get the value of the annotation in the [deploy](https://github.com/jamezp/wildfly-arquillian/blob/master/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainDeployableContainer.java#L176-L179) method though I'm not sure how that would work.

Let me know if you have any other ideas on how this might be accomplished.