### PR TITLE
ARQ-2012 Limited warnings when test runs as client without @RunAsClient

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ClientTestInstanceEnricher.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ClientTestInstanceEnricher.java
@@ -43,7 +43,7 @@ public class ClientTestInstanceEnricher extends TestInstanceEnricher
    {
       boolean runAsClient = RunModeUtils.isRunAsClient(
             this.deployment.get(),
-            event.getTestClass().getJavaClass(), 
+            event.getTestClass(),
             event.getTestMethod());
       
       if(runAsClient || RunModeUtils.isLocalContainer(container.get()))

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientBeforeAfterLifecycleEventExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientBeforeAfterLifecycleEventExecuter.java
@@ -85,7 +85,7 @@ public class ClientBeforeAfterLifecycleEventExecuter
    {
       return RunModeUtils.isRunAsClient(
             deployment.get(),
-            event.getTestClass().getJavaClass(), 
+            event.getTestClass(),
             event.getTestMethod());
    }
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuter.java
@@ -43,10 +43,10 @@ public class ClientTestExecuter
 
    public void execute(@Observes Test event) throws Exception
    {
-      boolean runAsClient = RunModeUtils.isRunAsClient(
-            this.deployment.get(),
-            event.getTestClass().getJavaClass(), 
-            event.getTestMethod());
+      boolean runAsClient = RunModeUtils.isRunAsClientAndCheck(
+          this.deployment.get(),
+          event.getTestClass(),
+          event.getTestMethod());
 
       if(runAsClient) 
       {


### PR DESCRIPTION
The warning is logged only when all following are true:
the test will be run as a client test
the test is NOT marked as a client test
there is defined a deployment in the test case
the deployment the test is tied to is testable

In addition, the warning is logged only when the test is about to be executed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-core/106)

<!-- Reviewable:end -->
