### PR TITLE
Treating compiler synthetic bridge methods as potential event injection methods creates ClassCastException

### DIFF
--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/Reflections.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/Reflections.java
@@ -218,6 +218,10 @@ final class Reflections
       {
          return false;
       }
+      if (method.isBridge())
+      {
+         return false;
+      }
       if(containsAnnotation(Observes.class, method.getParameterAnnotations()[0]))
       {
          return true;


### PR DESCRIPTION
The Java Compiler was changed with regards to synthetic methods and Annotations.
Before, annotations on parameters of the original generic methods were NOT copied on to the synthetic bridge method.
Now, the original annotation is present in 2 places: the generic method (with the actual type replaced in place of the type parameter) and the synthetic method.

When it comes to the @Observes annotation, Arquillian will try to call the synthetic method (which receives Object) with any kind of event, leading to a ClassCastException (because the bridge method does an implicit cast to the actual type and calls the real generic method)

The commit makes Arquillian ignore synthetic methods when searching for potential  event listeners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-core/109)
<!-- Reviewable:end -->
