### PR TITLE
ARQ-2034 Added JUnitRemoteExtension containing RulesEnricher into the deployment archive and registered

### DIFF
--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.arquillian.junit.container;
 
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.TestRunner;
 import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.arquillian.junit.Arquillian;
@@ -45,7 +46,11 @@ public class JUnitDeploymentAppender extends CachedAuxilliaryArchiveAppender
                               Arquillian.class.getPackage().getName())
                         .addAsServiceProvider(
                               TestRunner.class, 
-                              JUnitTestRunner.class);
+                              JUnitTestRunner.class)
+                        .addClass(JUnitRemoteExtension.class)
+                        .addAsServiceProvider(
+                              RemoteLoadableExtension.class,
+                              JUnitRemoteExtension.class);
       return archive;
    }
 

--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitRemoteExtension.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitRemoteExtension.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.junit.container;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.junit.RulesEnricher;
+
+/**
+ * JUnitRemoteExtension
+ *
+ * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
+ * @version $Revision: $
+ */
+public class JUnitRemoteExtension implements RemoteLoadableExtension
+{
+   @Override
+   public void register(ExtensionBuilder builder)
+   {
+         builder.observer(RulesEnricher.class);
+   }
+}


### PR DESCRIPTION
Now, the injection into the `@Rule` should work also on the container side

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-core/110)

<!-- Reviewable:end -->
