### PR TITLE
Fix #78 ARQ-1944 Avoid packaging hamcrest in arquillian-junit.jar

### DIFF
--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
@@ -41,7 +41,6 @@ public class JUnitDeploymentAppender extends CachedAuxilliaryArchiveAppender
                               true, 
                               "junit", 
                               "org.junit",
-                              "org.hamcrest",
                               Arquillian.class.getPackage().getName())
                         .addAsServiceProvider(
                               TestRunner.class, 


### PR DESCRIPTION
#### Short description of what this resolves:
This patch removes the hamcrest classes from arquillian-junit.jar. This way users can chose their own hamcrest version and avoid linkage errors when running with Tomcat. See https://github.com/arquillian/arquillian-core/issues/78

#### Changes proposed in this pull request:

- remove hamcrest from arquillian-junit.jar

**Fixes**: 98, ARQ-1944

This change will not be strictly backwards compatible because users will be required to add the hamcrest dependency explicitly.