### PR TITLE
Adds vetoed feature for services

### DIFF
--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
@@ -17,13 +17,18 @@
 package org.jboss.arquillian.core.impl.loadable;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.StringTokenizer;
 
 import org.jboss.arquillian.core.spi.ExtensionLoader;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -42,7 +47,8 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
    //-------------------------------------------------------------------------------------||
 
    private static final String SERVICES = "META-INF/services";
-   
+   private static final String EXCLUSIONS = "META-INF/exclusions";
+
    //-------------------------------------------------------------------------------------||
    // Required Implementations - ExtensionLoader -----------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -52,7 +58,12 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
    {
       return all(JavaSPIExtensionLoader.class.getClassLoader(), LoadableExtension.class);
    }
-   
+
+   @Override
+   public Map<Class<?>, Set<Class<?>>> loadVetoed() {
+      return loadVetoed(JavaSPIExtensionLoader.class.getClassLoader());
+   }
+
    //-------------------------------------------------------------------------------------||
    // General JDK SPI Loader -------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -61,23 +72,119 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
    {
       Validate.notNull(classLoader, "ClassLoader must be provided");
       Validate.notNull(serviceClass, "ServiceClass must be provided");
-      
+
       return createInstances(
-            serviceClass, 
+            serviceClass,
             load(serviceClass, classLoader));
    }
-   
+
+    /**
+     * This method first finds all files that are in claspath placed at META-INF/exclusions
+     * Each of this file has a name that represents the service type that needs to veto.
+     * The content of this file is a list of real implementations that you want to veto.
+     * @return List of vetos
+     */
+   public Map<Class<?>, Set<Class<?>>> loadVetoed(ClassLoader classLoader) {
+
+      Validate.notNull(classLoader, "ClassLoader must be provided");
+
+      final Map<Class<?>, Set<Class<?>>> vetoed = new LinkedHashMap<Class<?>, Set<Class<?>>>();
+
+      try {
+         final Enumeration<URL> exclusions = classLoader.getResources(EXCLUSIONS);
+
+         while (exclusions.hasMoreElements())
+         {
+            URL exclusion = exclusions.nextElement();
+            Properties vetoedElements = new Properties();
+            final InputStream inStream = exclusion.openStream();
+
+            try
+            {
+               vetoedElements.load(inStream);
+
+               final Set<Map.Entry<Object, Object>> entries = vetoedElements.entrySet();
+
+               for (Map.Entry<Object, Object> entry : entries)
+               {
+                  String service = (String) entry.getKey();
+                  String serviceImpls = (String) entry.getValue();
+
+                  addVetoedClasses(service, serviceImpls, classLoader, vetoed);
+
+               }
+
+            }
+            finally
+            {
+               if (inStream != null)
+               {
+                  inStream.close();
+               }
+            }
+         }
+      } catch (IOException e) {
+         throw new RuntimeException("Could not load exclusions from " + EXCLUSIONS, e);
+      }
+
+      return vetoed;
+   }
+
    //-------------------------------------------------------------------------------------||
    // Internal Helper Methods - Service Loading ------------------------------------------||
    //-------------------------------------------------------------------------------------||
 
-   private <T> Set<Class<? extends T>> load(Class<T> serviceClass, ClassLoader loader) 
+   private void addVetoedClasses(String serviceName, String serviceImpls, ClassLoader classLoader, Map<Class<?>, Set<Class<?>>> vetoed)
+   {
+       try
+       {
+          final Class<?> serviceClass = classLoader.loadClass(serviceName);
+          final Set<Class<?>> classes = loadVetoedServiceImpl(serviceImpls, classLoader);
+
+          final Set<Class<?>> registeredVetoedClasses = vetoed.get(serviceClass);
+          if (registeredVetoedClasses == null) {
+             vetoed.put(serviceClass, classes);
+          }
+          else
+          {
+             registeredVetoedClasses.addAll(classes);
+          }
+
+       }
+       catch (ClassNotFoundException e)
+       {
+           // ignores since this is a veto that it is not applicable
+       }
+   }
+
+   private Set<Class<?>> loadVetoedServiceImpl(String serviceImpls, ClassLoader classLoader)
+   {
+
+      final StringTokenizer serviceImplsSeparator = new StringTokenizer(serviceImpls, ",");
+      final Set<Class<?>> serviceImplsClass = new LinkedHashSet<Class<?>>();
+
+      while (serviceImplsSeparator.hasMoreTokens())
+      {
+         try
+         {
+            serviceImplsClass.add(classLoader.loadClass(serviceImplsSeparator.nextToken().trim()));
+         }
+         catch (ClassNotFoundException e)
+         {
+            // ignores since this is a veto that it is not applicable
+         }
+      }
+
+      return serviceImplsClass;
+   }
+
+   private <T> Set<Class<? extends T>> load(Class<T> serviceClass, ClassLoader loader)
    {
       String serviceFile = SERVICES + "/" + serviceClass.getName();
 
-      LinkedHashSet<Class<? extends T>> providers = new LinkedHashSet<Class<? extends T>>();      
-      LinkedHashSet<Class<? extends T>> vetoedProviders = new LinkedHashSet<Class<? extends T>>();      
-      
+      LinkedHashSet<Class<? extends T>> providers = new LinkedHashSet<Class<? extends T>>();
+      LinkedHashSet<Class<? extends T>> vetoedProviders = new LinkedHashSet<Class<? extends T>>();
+
       try
       {
          Enumeration<URL> enumeration = loader.getResources(serviceFile);
@@ -86,7 +193,7 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
             final URL url = enumeration.nextElement();
             final InputStream is = url.openStream();
             BufferedReader reader = null;
-            
+
             try
             {
                reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
@@ -94,7 +201,7 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
                while (null != line)
                {
                   line = skipCommentAndTrim(line);
-   
+
                   if (line.length() > 0)
                   {
                      try
@@ -104,13 +211,13 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
                         {
                            line = line.substring(1);
                         }
-                        
+
                         Class<? extends T> provider = loader.loadClass(line).asSubclass(serviceClass);
-                    
+
                         if (mustBeVetoed) {
                            vetoedProviders.add(provider);
                         }
-                        
+
                         if (vetoedProviders.contains(provider)) {
                            providers.remove(provider);
                         } else {
@@ -128,7 +235,7 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
             }
             finally
             {
-               if (reader != null) 
+               if (reader != null)
                {
                   reader.close();
                }
@@ -149,7 +256,7 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
       {
          line = line.substring(0, comment);
       }
-  
+
       line = line.trim();
       return line;
    }
@@ -166,9 +273,9 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
 
    /**
     * Create a new instance of the found Service. <br/>
-    * 
+    *
     * Verifies that the found ServiceImpl implements Service.
-    * 
+    *
     * @param <T>
     * @param serviceType The Service interface
     * @param className The name of the implementation class
@@ -182,7 +289,7 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
       {
          return SecurityActions.newInstance(serviceImplClass, new Class<?>[0], new Object[0]);
       }
-      catch (Exception e) 
+      catch (Exception e)
       {
          throw new RuntimeException("Could not create a new instance of Service implementation " + serviceImplClass.getName(), e);
       }

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
@@ -182,8 +182,8 @@ public class JavaSPIExtensionLoader implements ExtensionLoader
    {
       String serviceFile = SERVICES + "/" + serviceClass.getName();
 
-      LinkedHashSet<Class<? extends T>> providers = new LinkedHashSet<Class<? extends T>>();
-      LinkedHashSet<Class<? extends T>> vetoedProviders = new LinkedHashSet<Class<? extends T>>();
+      Set<Class<? extends T>> providers = new LinkedHashSet<Class<? extends T>>();
+      Set<Class<? extends T>> vetoedProviders = new LinkedHashSet<Class<? extends T>>();
 
       try
       {

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
@@ -69,7 +69,7 @@ public class LoadableExtensionLoader
    {
       ExtensionLoader extensionLoader = locateExtensionLoader();
       
-      final ServiceRegistry registry = new ServiceRegistry(injector.get());
+      final ServiceRegistry registry = new ServiceRegistry(injector.get(), extensionLoader.loadVetoed());
       
       Collection<LoadableExtension> extensions = extensionLoader.load();
 

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistry.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistry.java
@@ -38,10 +38,10 @@ public class ServiceRegistry
    private final Map<Class<?>, Set<Class<?>>> registry;
    private final Map<Class<?>, Set<Class<?>>> vetoed;
    
-   public ServiceRegistry(Injector injector)
+   public ServiceRegistry(Injector injector, Map<Class<?>, Set<Class<?>>> vetoed)
    {
       this.registry = new HashMap<Class<?>, Set<Class<?>>>();
-      this.vetoed = new HashMap<Class<?>, Set<Class<?>>>();
+      this.vetoed = new HashMap<Class<?>, Set<Class<?>>>(vetoed);
       this.injector = injector;
    }
    
@@ -78,6 +78,10 @@ public class ServiceRegistry
    {
       synchronized (registry)
       {
+
+         if(isImplementationVetoed(service, newServiceImpl))
+            return;
+
          Set<Class<?>> vetoedImpls = vetoed.get(service);
          if(vetoedImpls == null)
          {

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoaderTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoaderTestCase.java
@@ -18,6 +18,8 @@
 package org.jboss.arquillian.core.impl.loadable;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Set;
 
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
@@ -44,7 +46,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @Test
    public void shouldBeAbleToLoadAll() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeExcluded.class);
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       
@@ -66,7 +68,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @Test
    public void shouldBeAbleToLoadAllEvenIfNonRegistered() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       
       Collection<FakeService> services = registry.getServiceLoader().all(FakeService.class);
       
@@ -79,7 +81,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @Test
    public void shouldBeAbleToLoadOnlyOne() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       
       FakeService service = registry.getServiceLoader().onlyOne(FakeService.class);
@@ -93,7 +95,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @Test(expected = IllegalStateException.class)
    public void shouldThrowExceptionIfMultipleFoundWhenTryingOnlyOne() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       registry.addService(FakeService.class, ShouldBeExcluded.class);
       
@@ -104,7 +106,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @Test
    public void shouldBeAbleToLoadDefaultIfNoneFound() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       
       Assert.assertNull(registry.getServiceLoader().onlyOne(FakeService.class));
       
@@ -120,7 +122,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    {
       bind(ApplicationScoped.class, String.class, "TEST");
       
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       
       FakeService service = registry.getServiceLoader().onlyOne(FakeService.class);
@@ -137,7 +139,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    {
       bind(ApplicationScoped.class, String.class, "TEST");
       
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
 
       Assert.assertNull(registry.getServiceLoader().onlyOne(FakeService.class));
 
@@ -153,7 +155,7 @@ public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase
    @SuppressWarnings("unchecked")
    @Test
    public void shouldBeAbleToLoadProtectedServices() throws Exception {
-      ServiceRegistry registry = new ServiceRegistry(injector.get());
+      ServiceRegistry registry = new ServiceRegistry(injector.get(), new LinkedHashMap<Class<?>, Set<Class<?>>>());
       registry.addService(
             FakeService.class, (Class<FakeService>)Class.forName("org.jboss.arquillian.core.impl.loadable.util.PackageProtectedService"));
    

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
@@ -18,6 +18,7 @@ package org.jboss.arquillian.core.impl.loadable;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.jboss.arquillian.core.impl.loadable.util.FakeService;
@@ -76,8 +77,8 @@ public class ServiceRegistryTestCase
    @Test
    public void shouldBeAbleToNotAddVetoedServices() throws Exception
    {
-      final HashMap<Class<?>, Set<Class<?>>> vetoed = new HashMap<Class<?>, Set<Class<?>>>();
-      final LinkedHashSet<Class<?>> vetoedServiceImpls = new LinkedHashSet<Class<?>>();
+      final Map<Class<?>, Set<Class<?>>> vetoed = new HashMap<Class<?>, Set<Class<?>>>();
+      final Set<Class<?>> vetoedServiceImpls = new LinkedHashSet<Class<?>>();
       vetoedServiceImpls.add(ShouldBeExcluded.class);
       vetoed.put(FakeService.class, vetoedServiceImpls);
 

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.arquillian.core.impl.loadable;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.jboss.arquillian.core.impl.loadable.util.FakeService;
@@ -35,7 +37,7 @@ public class ServiceRegistryTestCase
    @Test
    public void shouldBeAbleToAddImplementations() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(null);
+      ServiceRegistry registry = new ServiceRegistry(null, new HashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeExcluded.class);
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       Set<Class<? extends FakeService>> serviceImpls = registry.getServiceImpls(FakeService.class);
@@ -48,7 +50,7 @@ public class ServiceRegistryTestCase
    @Test
    public void shouldBeAbleToRemoveImplementation() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(null);
+      ServiceRegistry registry = new ServiceRegistry(null, new HashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeExcluded.class);
       registry.addService(FakeService.class, ShouldBeIncluded.class);
       registry.removeService(FakeService.class, ShouldBeExcluded.class);
@@ -61,7 +63,7 @@ public class ServiceRegistryTestCase
    @Test
    public void shouldBeAbleToOverrideImplementation() throws Exception
    {
-      ServiceRegistry registry = new ServiceRegistry(null);
+      ServiceRegistry registry = new ServiceRegistry(null, new HashMap<Class<?>, Set<Class<?>>>());
       registry.addService(FakeService.class, ShouldBeExcluded.class);
       registry.overrideService(FakeService.class, ShouldBeExcluded.class, ShouldBeIncluded.class);
       registry.addService(FakeService.class, ShouldBeExcluded.class);
@@ -69,6 +71,23 @@ public class ServiceRegistryTestCase
       
       Assert.assertEquals("Unexpected number of service implementations registered", 1, serviceImpls.size());
       Assert.assertEquals("Should contain ShouldBeIncluded class", ShouldBeIncluded.class, serviceImpls.iterator().next());
+   }
+
+   @Test
+   public void shouldBeAbleToNotAddVetoedServices() throws Exception
+   {
+      final HashMap<Class<?>, Set<Class<?>>> vetoed = new HashMap<Class<?>, Set<Class<?>>>();
+      final LinkedHashSet<Class<?>> vetoedServiceImpls = new LinkedHashSet<Class<?>>();
+      vetoedServiceImpls.add(ShouldBeExcluded.class);
+      vetoed.put(FakeService.class, vetoedServiceImpls);
+
+      ServiceRegistry registry = new ServiceRegistry(null, vetoed);
+      registry.addService(FakeService.class, ShouldBeExcluded.class);
+      registry.addService(FakeService.class, ShouldBeIncluded.class);
+      Set<Class<? extends FakeService>> serviceImpls = registry.getServiceImpls(FakeService.class);
+
+      Assert.assertEquals("Unexpected number of service implementations registered", 1, serviceImpls.size());
+      Assert.assertTrue("Should contain ShouldBeIncluded class", serviceImpls.contains(ShouldBeIncluded.class));
    }
 
 }

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/ExtensionLoader.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/ExtensionLoader.java
@@ -18,6 +18,8 @@
 package org.jboss.arquillian.core.spi;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Extension point used to load the boot strap extensions.
@@ -28,4 +30,5 @@ import java.util.Collection;
 public interface ExtensionLoader
 {
    Collection<LoadableExtension> load();
+   Map<Class<?>, Set<Class<?>>> loadVetoed();
 }

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/rules/RulesEnrichmentTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/rules/RulesEnrichmentTestCase.java
@@ -17,7 +17,9 @@
 package org.jboss.arquillian.junit.rules;
 
 import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.impl.InjectorImpl;
@@ -61,7 +63,7 @@ public class RulesEnrichmentTestCase extends AbstractTestTestBase
     public void prepare()
     {
         Injector injector = InjectorImpl.of(getManager());
-        ServiceRegistry registry = new ServiceRegistry(injector);
+        ServiceRegistry registry = new ServiceRegistry(injector, new LinkedHashMap<Class<?>, Set<Class<?>>>());
 
         registry.addService(ResourceProvider.class, ResourcesProvider.class);
         registry.addService(TestEnricher.class, ArquillianResourceTestEnricher.class);


### PR DESCRIPTION
#### Short description of what this resolves:

Allow Arquillian Core to define a way to veto services so extensions can control which services are added and which are not allows so they can add their own. Typical example are ResourceProviders.


#### Changes proposed in this pull request:

With Arquillian Extensions you are able to override a service that was previously registered by Arquillian Core or by other extensions. 

The problem is that if if there two extensions that override the same service, it will depend on the order of the registration of the extension that will define which version of the service will be the one used at the end.

To avoid this problem the best way would be to be able to set a priority in extension registry so you can set which one is going to be the last one.

The best none invasive approach we have found is by providing a SPI so any extension can vetoed any `service /ResourceProvider/TestEnricher/...` to be registered by an extension. This SPI is a file present at `META-INF` directory and called exclusions. The file is a properties file where key is the service type you want to veto such as (`org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider`) and inside all the implementations you want to veto of this kind, each one separated by comma.

So before starting registering the extensions, the vetoed list will be loaded into service registry so they cannot be registered.

- Create a method to load from `META-INF/exclusions` the vetoed services
- Add to ServiceRegistry when is started which services are vetoed.

**Fixes**: Issue: https://issues.jboss.org/browse/ARQ-2053

