### PR TITLE
[ARQ-2058] Updates testNG to use 6.9.10

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -26,7 +26,7 @@
         <version.javax.inject_javax.inject>1</version.javax.inject_javax.inject>
         <version.junit_junit>4.12</version.junit_junit>
         <version.mockito_all>1.8.3</version.mockito_all>
-        <version.testng_testng>5.14.6</version.testng_testng>
+        <version.testng_testng>6.9.10</version.testng_testng>
     </properties>
 
     <!-- Dependency Management -->

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
@@ -60,16 +60,6 @@ public class TestNGTestRunner implements TestRunner
       XmlSuite suite = new XmlSuite();
       suite.setName("Arquillian");
 
-      // TestNG >= 6.3 has removed this method
-      try
-      {
-         Method method = XmlSuite.class.getMethod("setAnnotations", String.class);
-         method.invoke(suite, "JDK");
-      }
-      catch (Exception e) {
-         // no-op
-      }
-
       XmlTest test = new XmlTest(suite);
       test.setName("Arquillian - " + className);
       List<XmlClass> testClasses = new ArrayList<XmlClass>();

--- a/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGTestBaseClass.java
+++ b/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGTestBaseClass.java
@@ -35,7 +35,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
-import org.testng.internal.AnnotationTypeEnum;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
@@ -204,7 +203,7 @@ public class TestNGTestBaseClass
    {
       XmlSuite suite = new XmlSuite();
       suite.setName("Arquillian - TEST");
-      suite.setAnnotations(AnnotationTypeEnum.JDK.getName());
+
       suite.setConfigFailurePolicy("continue");
       XmlTest test = new XmlTest(suite);
       if(groups != null)


### PR DESCRIPTION
#### Short description of what this resolves:
Updating testNg to use 6.9.10

#### Changes proposed in this pull request:
- Updated TestNG version
- Removed Deprecated code for setAnnotation method.

**Fixes**: #117 

