### PR TITLE
ARQ-2136: Add support to preserve original property value using placeholder in …

### DIFF
--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ContainerDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ContainerDef.java
@@ -46,6 +46,8 @@ public interface ContainerDef extends ArquillianDescriptor {
 
     Map<String, String> getContainerProperties();
 
+    String getProperty(String name);
+
     ProtocolDef protocol(String type);
 
     List<ProtocolDef> getProtocols();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/DefaultProtocolDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/DefaultProtocolDef.java
@@ -32,4 +32,6 @@ public interface DefaultProtocolDef extends ArquillianDescriptor {
     DefaultProtocolDef property(String name, String value);
 
     Map<String, String> getProperties();
+
+    String getProperty(String name);
 }

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ExtensionDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ExtensionDef.java
@@ -32,4 +32,6 @@ public interface ExtensionDef extends ArquillianDescriptor {
     ExtensionDef property(String name, String value);
 
     Map<String, String> getExtensionProperties();
+
+    String getProperty(String name);
 }

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ProtocolDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ProtocolDef.java
@@ -32,4 +32,6 @@ public interface ProtocolDef extends ContainerDef {
     ProtocolDef property(String name, String value);
 
     Map<String, String> getProtocolProperties();
+
+    String getProperty(String name);
 }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
@@ -158,6 +158,20 @@ public class ContainerDefImpl extends ArquillianDescriptorImpl implements Contai
         return properties;
     }
 
+    @Override
+    public String getProperty(String name) {
+        Node props = container.getSingle("configuration");
+        if (props != null)
+        {
+            final Node value = props.getSingle("property@name=" + name);
+            return value != null ? value.getText() : null;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
     /* (non-Javadoc)
      * @see org.jboss.arquillian.impl.configuration.api.ContainerDef#getProtcols()
      */

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.config.descriptor.api.ProtocolDef;
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
@@ -117,10 +118,10 @@ public class ContainerDefImpl extends ArquillianDescriptorImpl implements Contai
     @Override
     public ProtocolDef protocol(String type) {
         return new ProtocolDefImpl(
-            getDescriptorName(),
-            getRootNode(),
-            container,
-            container.getOrCreate("protocol@type=" + type));
+                getDescriptorName(),
+                getRootNode(),
+                container,
+                container.getOrCreate("protocol@type=" + type));
     }
 
     /* (non-Javadoc)
@@ -161,13 +162,10 @@ public class ContainerDefImpl extends ArquillianDescriptorImpl implements Contai
     @Override
     public String getProperty(String name) {
         Node props = container.getSingle("configuration");
-        if (props != null)
-        {
+        if (props != null) {
             final Node value = props.getSingle("property@name=" + name);
             return value != null ? value.getText() : null;
-        }
-        else
-        {
+        } else {
             return null;
         }
     }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
@@ -76,6 +76,12 @@ public class DefaultProtocolDefImpl extends ArquillianDescriptorImpl implements 
         return properties;
     }
 
+    @Override
+    public String getProperty(String name) {
+        final Node value = protocol.getSingle("property@name=" + name);
+        return value != null ? value.getText() : null;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.config.descriptor.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.DefaultProtocolDef;
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
 

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.config.descriptor.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
 

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
@@ -75,6 +75,12 @@ public class ExtensionDefImpl extends ArquillianDescriptorImpl implements Extens
         return properties;
     }
 
+    @Override
+    public String getProperty(String name) {
+        final Node value = extension.getSingle("property@name=" + name);
+        return value != null ? value.getText() : null;
+    }
+
     /*
      * (non-Javadoc)
      *

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.config.descriptor.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.ProtocolDef;
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
 

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
@@ -80,6 +80,12 @@ public class ProtocolDefImpl extends ContainerDefImpl implements ProtocolDef {
         return properties;
     }
 
+    @Override
+    public String getProperty(String name) {
+        final Node value = protocol.getSingle("property@name=" + name);
+        return value != null ? value.getText() : null;
+    }
+
     /* (non-Javadoc)
      * @see org.jboss.arquillian.config.descriptor.impl.ContainerDefImpl#toString()
      */

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
@@ -132,9 +132,9 @@ public class PropertiesParser {
 
          final DefaultProtocolDef defaultProtocolDef = descriptor.defaultProtocol(typeName);
          final String originalValue = defaultProtocolDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            defaultProtocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            defaultProtocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {
@@ -198,9 +198,9 @@ public class PropertiesParser {
 
          final ProtocolDef protocolDef = descriptor.group(groupName).container(containerName).protocol(protocolName);
          final String originalValue = protocolDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {
@@ -222,9 +222,9 @@ public class PropertiesParser {
 
          final ContainerDef containerDef = descriptor.group(groupName).container(containerName);
          final String originalValue = containerDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {
@@ -245,9 +245,9 @@ public class PropertiesParser {
 
          final ExtensionDef extensionDef = descriptor.extension(extensionName);         
          final String originalValue = extensionDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            extensionDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            extensionDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {
@@ -290,9 +290,9 @@ public class PropertiesParser {
 
          final ProtocolDef protocolDef = descriptor.container(containerName).protocol(protocolName);         
          final String originalValue = protocolDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {
@@ -313,9 +313,9 @@ public class PropertiesParser {
 
          final ContainerDef containerDef = descriptor.container(containerName);
          final String originalValue = containerDef.getProperty(propertyName);
-         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         if (value.contains(ORIGINAL_VALUE))
          {
-            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
          }
          else
          {

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.config.descriptor.api.DefaultProtocolDef;
@@ -65,7 +66,7 @@ public class PropertiesParser {
     private static String ARQ_GROUP = "arq\\.group\\.(.*)\\.(.*)";
     private static String ARQ_GROUP_CONTAINER = "arq\\.group\\.(.*)\\.container\\.(.*)\\.(.*)";
     private static String ARQ_GROUP_CONTAINER_CONFIGURATION =
-        "arq\\.group\\.(.*)\\.container\\.(.*)\\.configuration\\.(.*)";
+            "arq\\.group\\.(.*)\\.container\\.(.*)\\.configuration\\.(.*)";
     private static String ARQ_GROUP_CONTAINER_PROTOCOL = "arq\\.group\\.(.*)\\.container\\.(.*)\\.protocol\\.(.*)\\.(.*)";
 
     private static String ARQ_DEFAULT_PROTOCOL = "arq\\.defaultprotocol\\.(.*)\\.(.*)";
@@ -73,17 +74,17 @@ public class PropertiesParser {
 
     private static String ORIGINAL_VALUE = "[ORIGINAL]";
 
-    private Handler[] handlers = new Handler[] {
-        new EngineProperty(ARQ_ENGINE_PROPERTY),
-        new ContainerConfiguration(ARQ_CONTAINER_CONFIGURATION),
-        new ContainerProtocol(ARQ_CONTAINER_PROTOCOL),
-        new Container(ARQ_CONTAINER),
-        new Extension(ARQ_EXTENSION),
-        new GroupContainerConfiguration(ARQ_GROUP_CONTAINER_CONFIGURATION),
-        new GroupContainerProtocol(ARQ_GROUP_CONTAINER_PROTOCOL),
-        new GroupContainer(ARQ_GROUP_CONTAINER),
-        new Group(ARQ_GROUP),
-        new DefaultProtocol(ARQ_DEFAULT_PROTOCOL)
+    private Handler[] handlers = new Handler[]{
+            new EngineProperty(ARQ_ENGINE_PROPERTY),
+            new ContainerConfiguration(ARQ_CONTAINER_CONFIGURATION),
+            new ContainerProtocol(ARQ_CONTAINER_PROTOCOL),
+            new Container(ARQ_CONTAINER),
+            new Extension(ARQ_EXTENSION),
+            new GroupContainerConfiguration(ARQ_GROUP_CONTAINER_CONFIGURATION),
+            new GroupContainerProtocol(ARQ_GROUP_CONTAINER_PROTOCOL),
+            new GroupContainer(ARQ_GROUP_CONTAINER),
+            new Group(ARQ_GROUP),
+            new DefaultProtocol(ARQ_DEFAULT_PROTOCOL)
     };
 
     public void addProperties(ArquillianDescriptor descriptor, Properties properties) {
@@ -130,18 +131,15 @@ public class PropertiesParser {
             String typeName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-         final DefaultProtocolDef defaultProtocolDef = descriptor.defaultProtocol(typeName);
-         final String originalValue = defaultProtocolDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            defaultProtocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            defaultProtocolDef.property(propertyName, value);
-         }
-      }
-   }
+            final DefaultProtocolDef defaultProtocolDef = descriptor.defaultProtocol(typeName);
+            final String originalValue = defaultProtocolDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                defaultProtocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                defaultProtocolDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class Group extends Handler {
         public Group(String expression) {
@@ -157,7 +155,7 @@ public class PropertiesParser {
                 descriptor.group(groupName).setGroupDefault();
             } else {
                 throw new RuntimeException(
-                    "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
+                        "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
             }
         }
     }
@@ -179,7 +177,7 @@ public class PropertiesParser {
                 descriptor.group(groupName).container(containerName).setDefault();
             } else {
                 throw new RuntimeException(
-                    "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
+                        "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
             }
         }
     }
@@ -196,18 +194,15 @@ public class PropertiesParser {
             String protocolName = matcher.group(3);
             String propertyName = matcher.group(4);
 
-         final ProtocolDef protocolDef = descriptor.group(groupName).container(containerName).protocol(protocolName);
-         final String originalValue = protocolDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            protocolDef.property(propertyName, value);
-         }         
-      }
-   }
+            final ProtocolDef protocolDef = descriptor.group(groupName).container(containerName).protocol(protocolName);
+            final String originalValue = protocolDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                protocolDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class GroupContainerConfiguration extends Handler {
         public GroupContainerConfiguration(String expression) {
@@ -220,18 +215,15 @@ public class PropertiesParser {
             String containerName = matcher.group(2);
             String propertyName = matcher.group(3);
 
-         final ContainerDef containerDef = descriptor.group(groupName).container(containerName);
-         final String originalValue = containerDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            containerDef.property(propertyName, value);
-         }
-      }
-   }
+            final ContainerDef containerDef = descriptor.group(groupName).container(containerName);
+            final String originalValue = containerDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                containerDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class Extension extends Handler {
         public Extension(String expression) {
@@ -243,18 +235,15 @@ public class PropertiesParser {
             String extensionName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-         final ExtensionDef extensionDef = descriptor.extension(extensionName);         
-         final String originalValue = extensionDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            extensionDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            extensionDef.property(propertyName, value);
-         }
-      }
-   }
+            final ExtensionDef extensionDef = descriptor.extension(extensionName);
+            final String originalValue = extensionDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                extensionDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                extensionDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class Container extends Handler {
         public Container(String expression) {
@@ -272,7 +261,7 @@ public class PropertiesParser {
                 descriptor.container(containerName).setDefault();
             } else {
                 throw new RuntimeException(
-                    "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
+                        "Unknown arquillian container attribute[" + attributeName + "] with value[" + value + "]");
             }
         }
     }
@@ -288,18 +277,15 @@ public class PropertiesParser {
             String protocolName = matcher.group(2);
             String propertyName = matcher.group(3);
 
-         final ProtocolDef protocolDef = descriptor.container(containerName).protocol(protocolName);         
-         final String originalValue = protocolDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            protocolDef.property(propertyName, value);
-         }
-      }
-   }
+            final ProtocolDef protocolDef = descriptor.container(containerName).protocol(protocolName);
+            final String originalValue = protocolDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                protocolDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class ContainerConfiguration extends Handler {
         public ContainerConfiguration(String expression) {
@@ -311,18 +297,15 @@ public class PropertiesParser {
             String containerName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-         final ContainerDef containerDef = descriptor.container(containerName);
-         final String originalValue = containerDef.getProperty(propertyName);
-         if (value.contains(ORIGINAL_VALUE))
-         {
-            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
-         }
-         else
-         {
-            containerDef.property(propertyName, value);
-         }
-      }
-   }
+            final ContainerDef containerDef = descriptor.container(containerName);
+            final String originalValue = containerDef.getProperty(propertyName);
+            if (value.contains(ORIGINAL_VALUE)) {
+                containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue != null ? originalValue : ""));
+            } else {
+                containerDef.property(propertyName, value);
+            }
+        }
+    }
 
     private class EngineProperty extends Handler {
         public EngineProperty(String expression) {
@@ -338,7 +321,7 @@ public class PropertiesParser {
                 descriptor.engine().maxTestClassesBeforeRestart(Integer.parseInt(value));
             } else {
                 throw new RuntimeException(
-                    "Unknown arquillian engine property[" + propertyName + "] with value[" + value + "]");
+                        "Unknown arquillian engine property[" + propertyName + "] with value[" + value + "]");
             }
         }
     }

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
@@ -24,6 +24,10 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+import org.jboss.arquillian.config.descriptor.api.DefaultProtocolDef;
+import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
+import org.jboss.arquillian.config.descriptor.api.ProtocolDef;
 
 /**
  * Add/Override arquillian.xml based on SystemProperties.
@@ -43,6 +47,8 @@ import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
  * arq.defaultprotocol.[type].[property_name]
  * <p>
  * arq.engine.[property_name]
+ * <p>
+ * You can use magic constant {@value #ORIGINAL_VALUE} to replace placeholder with previous value of properties.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
@@ -64,6 +70,8 @@ public class PropertiesParser {
 
     private static String ARQ_DEFAULT_PROTOCOL = "arq\\.defaultprotocol\\.(.*)\\.(.*)";
     private static String ARQ_EXTENSION = "arq\\.extension\\.(.*)\\.(.*)";
+
+    private static String ORIGINAL_VALUE = "[ORIGINAL]";
 
     private Handler[] handlers = new Handler[] {
         new EngineProperty(ARQ_ENGINE_PROPERTY),
@@ -122,9 +130,18 @@ public class PropertiesParser {
             String typeName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-            descriptor.defaultProtocol(typeName).property(propertyName, value);
-        }
-    }
+         final DefaultProtocolDef defaultProtocolDef = descriptor.defaultProtocol(typeName);
+         final String originalValue = defaultProtocolDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            defaultProtocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            defaultProtocolDef.property(propertyName, value);
+         }
+      }
+   }
 
     private class Group extends Handler {
         public Group(String expression) {
@@ -179,9 +196,18 @@ public class PropertiesParser {
             String protocolName = matcher.group(3);
             String propertyName = matcher.group(4);
 
-            descriptor.group(groupName).container(containerName).protocol(protocolName).property(propertyName, value);
-        }
-    }
+         final ProtocolDef protocolDef = descriptor.group(groupName).container(containerName).protocol(protocolName);
+         final String originalValue = protocolDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            protocolDef.property(propertyName, value);
+         }         
+      }
+   }
 
     private class GroupContainerConfiguration extends Handler {
         public GroupContainerConfiguration(String expression) {
@@ -194,9 +220,18 @@ public class PropertiesParser {
             String containerName = matcher.group(2);
             String propertyName = matcher.group(3);
 
-            descriptor.group(groupName).container(containerName).property(propertyName, value);
-        }
-    }
+         final ContainerDef containerDef = descriptor.group(groupName).container(containerName);
+         final String originalValue = containerDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            containerDef.property(propertyName, value);
+         }
+      }
+   }
 
     private class Extension extends Handler {
         public Extension(String expression) {
@@ -208,9 +243,18 @@ public class PropertiesParser {
             String extensionName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-            descriptor.extension(extensionName).property(propertyName, value);
-        }
-    }
+         final ExtensionDef extensionDef = descriptor.extension(extensionName);         
+         final String originalValue = extensionDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            extensionDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            extensionDef.property(propertyName, value);
+         }
+      }
+   }
 
     private class Container extends Handler {
         public Container(String expression) {
@@ -244,9 +288,18 @@ public class PropertiesParser {
             String protocolName = matcher.group(2);
             String propertyName = matcher.group(3);
 
-            descriptor.container(containerName).protocol(protocolName).property(propertyName, value);
-        }
-    }
+         final ProtocolDef protocolDef = descriptor.container(containerName).protocol(protocolName);         
+         final String originalValue = protocolDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            protocolDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            protocolDef.property(propertyName, value);
+         }
+      }
+   }
 
     private class ContainerConfiguration extends Handler {
         public ContainerConfiguration(String expression) {
@@ -258,9 +311,18 @@ public class PropertiesParser {
             String containerName = matcher.group(1);
             String propertyName = matcher.group(2);
 
-            descriptor.container(containerName).property(propertyName, value);
-        }
-    }
+         final ContainerDef containerDef = descriptor.container(containerName);
+         final String originalValue = containerDef.getProperty(propertyName);
+         if (originalValue != null && value.contains(ORIGINAL_VALUE))
+         {
+            containerDef.property(propertyName, value.replace(ORIGINAL_VALUE, originalValue));
+         }
+         else
+         {
+            containerDef.property(propertyName, value);
+         }
+      }
+   }
 
     private class EngineProperty extends Handler {
         public EngineProperty(String expression) {

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
@@ -156,6 +156,7 @@ public class ArquillianDescriptorTestCase {
         Assert.assertNotNull(descriptor.getDefaultProtocol());
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getDefaultProtocol().getType());
         Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getDefaultProtocol().getProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_1, descriptor.getDefaultProtocol().getProperty(PROPERTY_NAME_1));
     }
 
     @Test
@@ -184,6 +185,7 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getDefaultProtocol().getType());
         Assert.assertEquals(1, descriptor.getDefaultProtocol().getProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getDefaultProtocol().getProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2, descriptor.getDefaultProtocol().getProperty(PROPERTY_NAME_1));
     }
 
     @Test
@@ -248,9 +250,13 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
         Assert.assertEquals(PROPERTY_VALUE_1,
             descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_1, 
+            descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
         Assert.assertEquals(PROTOCOL_TYPE_2, descriptor.getContainers().get(0).getProtocols().get(1).getType());
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getContainers().get(0).getProtocols().get(1).getProtocolProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_2, 
+            descriptor.getContainers().get(0).getProtocols().get(1).getProperty(PROPERTY_NAME_2));
     }
 
     @Test
@@ -274,6 +280,8 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2, 
+            descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
@@ -299,9 +307,13 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
         Assert.assertEquals(PROPERTY_VALUE_1,
             descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_1,
+            descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
         Assert.assertEquals(CONTAINER_NAME_2, descriptor.getContainers().get(1).getContainerName());
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getContainers().get(1).getContainerProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_2, 
+            descriptor.getContainers().get(1).getProperty(PROPERTY_NAME_2));
     }
 
     @Test
@@ -323,6 +335,8 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getContainers().get(0).getContainerProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+            descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
@@ -397,11 +411,17 @@ public class ArquillianDescriptorTestCase {
             descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_1, 
+            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2, 
+            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_2));
 
         Assert.assertEquals(EXTENSION_NAME_2, descriptor.getExtensions().get(1).getExtensionName());
         Assert.assertEquals(1, descriptor.getExtensions().get(1).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_3,
             descriptor.getExtensions().get(1).getExtensionProperties().get(PROPERTY_NAME_3));
+        Assert.assertEquals(PROPERTY_VALUE_3, 
+            descriptor.getExtensions().get(1).getProperty(PROPERTY_NAME_3));
     }
 
     @Test
@@ -421,6 +441,8 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_1,
             descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+       Assert.assertEquals(PROPERTY_VALUE_1, 
+            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
@@ -441,6 +463,8 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_2,
             descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2, 
+            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
@@ -16,10 +16,14 @@
  */
 package org.jboss.arquillian.config.descriptor.impl;
 
+import static org.jboss.arquillian.config.descriptor.impl.AssertXPath.assertXPath;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.junit.After;
@@ -31,8 +35,6 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-
-import static org.jboss.arquillian.config.descriptor.impl.AssertXPath.assertXPath;
 
 /**
  * ArquillianDescriptorTestCase
@@ -79,16 +81,16 @@ public class ArquillianDescriptorTestCase {
     public void shouldBeAbleToSetEngineProperties() throws Exception {
         // add multiple times to see only one property added
         desc = create()
-            .engine()
-            .deploymentExportPath(PROPERTY_VALUE_1)
-            .deploymentExportPath(PROPERTY_VALUE_1)
-            .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
-            .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
-            .exportAsString();
+                .engine()
+                .deploymentExportPath(PROPERTY_VALUE_1)
+                .deploymentExportPath(PROPERTY_VALUE_1)
+                .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
+                .maxTestClassesBeforeRestart(PROPERTY_INT_VALUE_1)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/engine/property[@name='deploymentExportPath']/text()", PROPERTY_VALUE_1);
         assertXPath(desc, "/arquillian/engine/property[@name='maxTestClassesBeforeRestart']/text()",
-            PROPERTY_INT_VALUE_1);
+                PROPERTY_INT_VALUE_1);
 
         ArquillianDescriptor descriptor = create(desc);
 
@@ -100,8 +102,8 @@ public class ArquillianDescriptorTestCase {
     public void shouldReturnNullOnEnginePropertiesIfNotSet() throws Exception {
         // add multiple times to see only one property added
         desc = create()
-            .engine()
-            .exportAsString();
+                .engine()
+                .exportAsString();
 
         ArquillianDescriptor descriptor = create(desc);
 
@@ -112,8 +114,8 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldBeAbleToAddContainer() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1).setDefault()
-            .container(CONTAINER_NAME_2).exportAsString();
+                .container(CONTAINER_NAME_1).setDefault()
+                .container(CONTAINER_NAME_2).exportAsString();
 
         assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1, CONTAINER_NAME_2);
         assertXPath(desc, "/arquillian/container[1]/@default", "true");
@@ -128,9 +130,9 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldBeAbleToAddContainerAndOverwrite() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1).setDefault()
-            .container(CONTAINER_NAME_1).setContainerName(CONTAINER_NAME_2)
-            .exportAsString();
+                .container(CONTAINER_NAME_1).setDefault()
+                .container(CONTAINER_NAME_1).setContainerName(CONTAINER_NAME_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_2);
         assertXPath(desc, "/arquillian/container/@default", "true");
@@ -144,9 +146,9 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldBeAbleToAddDefaultProtocol() throws Exception {
         desc = create()
-            .defaultProtocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .exportAsString();
+                .defaultProtocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/defaultProtocol/@type", PROTOCOL_TYPE_1);
         assertXPath(desc, "/arquillian/defaultProtocol/property/@name", PROPERTY_NAME_1);
@@ -162,7 +164,7 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldReturnNullDefaultProtocolIfNotAdded() throws Exception {
         desc = create()
-            .exportAsString();
+                .exportAsString();
 
         ArquillianDescriptor descriptor = create(desc);
         Assert.assertNull(descriptor.getDefaultProtocol());
@@ -171,10 +173,10 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldBeAbleToAddDefaultProtocolAndOverwriteProperty() throws Exception {
         desc = create()
-            .defaultProtocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
-            .exportAsString();
+                .defaultProtocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/defaultProtocol/@type", PROTOCOL_TYPE_1);
         assertXPath(desc, "/arquillian/defaultProtocol/property/@name", PROPERTY_NAME_1);
@@ -192,9 +194,9 @@ public class ArquillianDescriptorTestCase {
     @Ignore // Dependencies not supported on container level in v. 1.0
     public void shouldBeAbleToAddContainerWithDependencies() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .dependency(DEPENDENCY_1)
-            .dependency(DEPENDENCY_2).exportAsString();
+                .container(CONTAINER_NAME_1)
+                .dependency(DEPENDENCY_1)
+                .dependency(DEPENDENCY_2).exportAsString();
 
         assertXPath(desc, "/arquillian/container/dependencies/dependency", DEPENDENCY_1, DEPENDENCY_2);
 
@@ -210,9 +212,9 @@ public class ArquillianDescriptorTestCase {
     @Ignore // Dependencies not supported on container level in v. 1.0
     public void shouldBeAbleToAddContainerWithDependenciesAndOverwrite() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .dependency(DEPENDENCY_1)
-            .dependency(DEPENDENCY_1).exportAsString();
+                .container(CONTAINER_NAME_1)
+                .dependency(DEPENDENCY_1)
+                .dependency(DEPENDENCY_1).exportAsString();
 
         assertXPath(desc, "/arquillian/container/dependencies/dependency", DEPENDENCY_1);
 
@@ -226,12 +228,12 @@ public class ArquillianDescriptorTestCase {
     @Test
     public void shouldBeAbleToAddContainerWithMultipleProtocols() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .protocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .protocol(PROTOCOL_TYPE_2)
-            .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
-            .exportAsString();
+                .container(CONTAINER_NAME_1)
+                .protocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .protocol(PROTOCOL_TYPE_2)
+                .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1);
         assertXPath(desc, "/arquillian/container/protocol[1]/@type", PROTOCOL_TYPE_1);
@@ -249,25 +251,25 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(2, descriptor.getContainers().get(0).getProtocols().size());
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
         Assert.assertEquals(PROPERTY_VALUE_1,
-            descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
-        Assert.assertEquals(PROPERTY_VALUE_1, 
-            descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_1,
+                descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
         Assert.assertEquals(PROTOCOL_TYPE_2, descriptor.getContainers().get(0).getProtocols().get(1).getType());
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getContainers().get(0).getProtocols().get(1).getProtocolProperties().get(PROPERTY_NAME_2));
-        Assert.assertEquals(PROPERTY_VALUE_2, 
-            descriptor.getContainers().get(0).getProtocols().get(1).getProperty(PROPERTY_NAME_2));
+                descriptor.getContainers().get(0).getProtocols().get(1).getProtocolProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+                descriptor.getContainers().get(0).getProtocols().get(1).getProperty(PROPERTY_NAME_2));
     }
 
     @Test
     public void shouldBeAbleToAddContainerAndOverwriteProtocol() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .protocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .protocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
-            .exportAsString();
+                .container(CONTAINER_NAME_1)
+                .protocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .protocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/container/@qualifier", CONTAINER_NAME_1);
         assertXPath(desc, "/arquillian/container/protocol/@type", PROTOCOL_TYPE_1);
@@ -279,19 +281,19 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getContainers().get(0).getProtocols().size());
         Assert.assertEquals(PROTOCOL_TYPE_1, descriptor.getContainers().get(0).getProtocols().get(0).getType());
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
-        Assert.assertEquals(PROPERTY_VALUE_2, 
-            descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+                descriptor.getContainers().get(0).getProtocols().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
     public void shouldBeAbleToAddContainerWithConfiguration() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .container(CONTAINER_NAME_2)
-            .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
-            .exportAsString();
+                .container(CONTAINER_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .container(CONTAINER_NAME_2)
+                .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/container[1]/@qualifier", CONTAINER_NAME_1);
 
@@ -306,23 +308,23 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(2, descriptor.getContainers().size());
         Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
         Assert.assertEquals(PROPERTY_VALUE_1,
-            descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
         Assert.assertEquals(PROPERTY_VALUE_1,
-            descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
         Assert.assertEquals(CONTAINER_NAME_2, descriptor.getContainers().get(1).getContainerName());
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getContainers().get(1).getContainerProperties().get(PROPERTY_NAME_2));
-        Assert.assertEquals(PROPERTY_VALUE_2, 
-            descriptor.getContainers().get(1).getProperty(PROPERTY_NAME_2));
+                descriptor.getContainers().get(1).getContainerProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+                descriptor.getContainers().get(1).getProperty(PROPERTY_NAME_2));
     }
 
     @Test
     public void shouldBeAbleToAddContainerWithConfigurationAndOverwriteProperty() throws Exception {
         desc = create()
-            .container(CONTAINER_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
-            .exportAsString();
+                .container(CONTAINER_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/container[1]/@qualifier", CONTAINER_NAME_1);
 
@@ -334,20 +336,20 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(CONTAINER_NAME_1, descriptor.getContainers().get(0).getContainerName());
         Assert.assertEquals(1, descriptor.getContainers().get(0).getContainerProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getContainerProperties().get(PROPERTY_NAME_1));
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getContainers().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
     public void shouldBeAbleToAddGroupWithContainer() throws Exception {
         desc = create()
-            .group(GROUP_NAME_1)
-            .setGroupDefault()
-            .container(CONTAINER_NAME_1)
-            .container(CONTAINER_NAME_2)
-            .group(GROUP_NAME_2)
-            .container(CONTAINER_NAME_3).exportAsString();
+                .group(GROUP_NAME_1)
+                .setGroupDefault()
+                .container(CONTAINER_NAME_1)
+                .container(CONTAINER_NAME_2)
+                .group(GROUP_NAME_2)
+                .container(CONTAINER_NAME_3).exportAsString();
 
         assertXPath(desc, "/arquillian/group/@qualifier", GROUP_NAME_1, GROUP_NAME_2);
         assertXPath(desc, "/arquillian/group[1]/@default", true);
@@ -359,21 +361,21 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getGroups().get(1).getGroupContainers().size());
         Assert.assertEquals(GROUP_NAME_1, descriptor.getGroups().get(0).getGroupName());
         Assert.assertEquals(CONTAINER_NAME_1,
-            descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
+                descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
         Assert.assertEquals(CONTAINER_NAME_2,
-            descriptor.getGroups().get(0).getGroupContainers().get(1).getContainerName());
+                descriptor.getGroups().get(0).getGroupContainers().get(1).getContainerName());
         Assert.assertEquals(GROUP_NAME_2, descriptor.getGroups().get(1).getGroupName());
         Assert.assertEquals(CONTAINER_NAME_3,
-            descriptor.getGroups().get(1).getGroupContainers().get(0).getContainerName());
+                descriptor.getGroups().get(1).getGroupContainers().get(0).getContainerName());
     }
 
     @Test
     public void shouldBeAbleToAddGroupWithContainerAndOverwriteContainer() throws Exception {
         desc = create()
-            .group(GROUP_NAME_1)
-            .container(CONTAINER_NAME_1)
-            .container(CONTAINER_NAME_1)
-            .exportAsString();
+                .group(GROUP_NAME_1)
+                .container(CONTAINER_NAME_1)
+                .container(CONTAINER_NAME_1)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/group/@qualifier", GROUP_NAME_1);
         assertXPath(desc, "/arquillian/group/container/@qualifier", CONTAINER_NAME_1);
@@ -382,17 +384,17 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(1, descriptor.getGroups().size());
         Assert.assertEquals(1, descriptor.getGroups().get(0).getGroupContainers().size());
         Assert.assertEquals(CONTAINER_NAME_1,
-            descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
+                descriptor.getGroups().get(0).getGroupContainers().get(0).getContainerName());
     }
 
     @Test
     public void shouldBeAbleToAddExtension() throws Exception {
         desc = create()
-            .extension(EXTENSION_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
-            .extension(EXTENSION_NAME_2)
-            .property(PROPERTY_NAME_3, PROPERTY_VALUE_3).exportAsString();
+                .extension(EXTENSION_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
+                .extension(EXTENSION_NAME_2)
+                .property(PROPERTY_NAME_3, PROPERTY_VALUE_3).exportAsString();
 
         assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_1, EXTENSION_NAME_2);
         assertXPath(desc, "/arquillian/extension[1]/property[1]/@name", PROPERTY_NAME_1);
@@ -408,30 +410,30 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(EXTENSION_NAME_1, descriptor.getExtensions().get(0).getExtensionName());
         Assert.assertEquals(2, descriptor.getExtensions().get(0).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_1,
-            descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+                descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_2));
-        Assert.assertEquals(PROPERTY_VALUE_1, 
-            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
-        Assert.assertEquals(PROPERTY_VALUE_2, 
-            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_2));
+                descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_2));
+        Assert.assertEquals(PROPERTY_VALUE_1,
+                descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+                descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_2));
 
         Assert.assertEquals(EXTENSION_NAME_2, descriptor.getExtensions().get(1).getExtensionName());
         Assert.assertEquals(1, descriptor.getExtensions().get(1).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_3,
-            descriptor.getExtensions().get(1).getExtensionProperties().get(PROPERTY_NAME_3));
-        Assert.assertEquals(PROPERTY_VALUE_3, 
-            descriptor.getExtensions().get(1).getProperty(PROPERTY_NAME_3));
+                descriptor.getExtensions().get(1).getExtensionProperties().get(PROPERTY_NAME_3));
+        Assert.assertEquals(PROPERTY_VALUE_3,
+                descriptor.getExtensions().get(1).getProperty(PROPERTY_NAME_3));
     }
 
     @Test
     public void shouldBeAbleToRenameExtension() throws Exception {
         desc = create()
-            .extension(EXTENSION_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .extension(EXTENSION_NAME_1)
-            .setExtensionName(EXTENSION_NAME_2)
-            .exportAsString();
+                .extension(EXTENSION_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .extension(EXTENSION_NAME_1)
+                .setExtensionName(EXTENSION_NAME_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_2);
 
@@ -440,18 +442,18 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(EXTENSION_NAME_2, descriptor.getExtensions().get(0).getExtensionName());
         Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_1,
-            descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
-       Assert.assertEquals(PROPERTY_VALUE_1, 
-            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_1,
+                descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
     public void shouldBeAbleToAddExtensionAndOverwriteProperty() throws Exception {
         desc = create()
-            .extension(EXTENSION_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
-            .exportAsString();
+                .extension(EXTENSION_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
+                .exportAsString();
 
         assertXPath(desc, "/arquillian/extension/@qualifier", EXTENSION_NAME_1);
         assertXPath(desc, "/arquillian/extension/property/@name", PROPERTY_NAME_1);
@@ -462,35 +464,35 @@ public class ArquillianDescriptorTestCase {
         Assert.assertEquals(EXTENSION_NAME_1, descriptor.getExtensions().get(0).getExtensionName());
         Assert.assertEquals(1, descriptor.getExtensions().get(0).getExtensionProperties().size());
         Assert.assertEquals(PROPERTY_VALUE_2,
-            descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
-        Assert.assertEquals(PROPERTY_VALUE_2, 
-            descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
+                descriptor.getExtensions().get(0).getExtensionProperties().get(PROPERTY_NAME_1));
+        Assert.assertEquals(PROPERTY_VALUE_2,
+                descriptor.getExtensions().get(0).getProperty(PROPERTY_NAME_1));
     }
 
     @Test
     public void shouldBeAbleToAddEverything() throws Exception {
         desc = create()
-            .defaultProtocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_VALUE_3, PROPERTY_VALUE_3)
-            .container(CONTAINER_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .dependency(DEPENDENCY_1)
-            .protocol(PROTOCOL_TYPE_1)
-            .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
-            .group(GROUP_NAME_1)
-            .container(CONTAINER_NAME_2)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .dependency(DEPENDENCY_2)
-            .protocol(PROTOCOL_TYPE_2)
-            .property(PROPERTY_NAME_3, PROPERTY_VALUE_3)
-            .group(GROUP_NAME_2)
-            .container(CONTAINER_NAME_3)
-            .protocol(PROTOCOL_TYPE_3)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
-            .container(CONTAINER_NAME_4)
-            .extension(EXTENSION_NAME_1)
-            .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
-            .exportAsString();
+                .defaultProtocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_VALUE_3, PROPERTY_VALUE_3)
+                .container(CONTAINER_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .dependency(DEPENDENCY_1)
+                .protocol(PROTOCOL_TYPE_1)
+                .property(PROPERTY_NAME_2, PROPERTY_VALUE_2)
+                .group(GROUP_NAME_1)
+                .container(CONTAINER_NAME_2)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .dependency(DEPENDENCY_2)
+                .protocol(PROTOCOL_TYPE_2)
+                .property(PROPERTY_NAME_3, PROPERTY_VALUE_3)
+                .group(GROUP_NAME_2)
+                .container(CONTAINER_NAME_3)
+                .protocol(PROTOCOL_TYPE_3)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_1)
+                .container(CONTAINER_NAME_4)
+                .extension(EXTENSION_NAME_1)
+                .property(PROPERTY_NAME_1, PROPERTY_VALUE_2)
+                .exportAsString();
     }
 
     //-------------------------------------------------------------------------------------||
@@ -512,8 +514,8 @@ public class ArquillianDescriptorTestCase {
         dbf.setValidating(true);
         dbf.setNamespaceAware(true);
         dbf.setAttribute(
-            "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
-            "http://www.w3.org/2001/XMLSchema");
+                "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
+                "http://www.w3.org/2001/XMLSchema");
         DocumentBuilder db = dbf.newDocumentBuilder();
         db.setErrorHandler(new ErrorHandler() {
             @Override

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.config.impl.extension;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
@@ -71,274 +72,292 @@ public class ConfigurationRegistrarTestCase extends AbstractManagerTestBase {
     @Test
     public void shouldBeAbleToLoadConfiguredXMLFileResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "src/test/resources/registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                    ArquillianDescriptor desc = descInst.get();
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "src/test/resources/registrar_tests/named_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                        ArquillianDescriptor desc = descInst.get();
 
-                    Assert.assertEquals(1, desc.getContainers().size());
-                    Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                    // verify mode = class, override test will set it to suite
-                    Assert.assertEquals("class", desc.getContainers().get(0).getMode());
-                }
-            });
+                        Assert.assertEquals(1, desc.getContainers().size());
+                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                        // verify mode = class, override test will set it to suite
+                        Assert.assertEquals("class", desc.getContainers().get(0).getMode());
+                    }
+                });
     }
 
     @Test
     public void shouldBeAbleToLoadConfiguredXMLClasspathResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                    ArquillianDescriptor desc = descInst.get();
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/named_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                        ArquillianDescriptor desc = descInst.get();
 
-                    Assert.assertEquals(1, desc.getContainers().size());
-                    Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                    // verify mode = class, override test will set it to suite
-                    Assert.assertEquals("class", desc.getContainers().get(0).getMode());
-                }
-            });
+                        Assert.assertEquals(1, desc.getContainers().size());
+                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                        // verify mode = class, override test will set it to suite
+                        Assert.assertEquals("class", desc.getContainers().get(0).getMode());
+                    }
+                });
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionOnMissingConfiguredXMLResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian_SHOULD_NOT_BE_FOUND_.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                }
-            });
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/named_arquillian_SHOULD_NOT_BE_FOUND_.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                    }
+                });
     }
 
     @Test
     public void shouldBeAbleToLoadConfiguredPropertiesFileResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-            "src/test/resources/registrar_tests/named_arquillian.properties",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                    ArquillianDescriptor desc = descInst.get();
+                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                "src/test/resources/registrar_tests/named_arquillian.properties",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                        ArquillianDescriptor desc = descInst.get();
 
-                    Assert.assertEquals(1, desc.getContainers().size());
-                    Assert.assertEquals("B", desc.getContainers().get(0).getContainerName());
-                }
-            });
+                        Assert.assertEquals(1, desc.getContainers().size());
+                        Assert.assertEquals("B", desc.getContainers().get(0).getContainerName());
+                    }
+                });
     }
 
     @Test
     public void shouldBeAbleToLoadConfiguredPropertiesClasspathResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-            "registrar_tests/named_arquillian.properties",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                    ArquillianDescriptor desc = descInst.get();
+                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                "registrar_tests/named_arquillian.properties",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                        ArquillianDescriptor desc = descInst.get();
 
-                    Assert.assertEquals(1, desc.getContainers().size());
-                    Assert.assertEquals("B", desc.getContainers().get(0).getContainerName());
-                    Assert.assertEquals("manual", desc.getContainers().get(0).getMode());
-                }
-            });
+                        Assert.assertEquals(1, desc.getContainers().size());
+                        Assert.assertEquals("B", desc.getContainers().get(0).getContainerName());
+                        Assert.assertEquals("manual", desc.getContainers().get(0).getMode());
+                    }
+                });
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionOnMissingConfiguredPropertiesResource() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-            "registrar_tests/named_arquillian_SHOULD_NOT_BE_FOUND_.properties",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                }
-            });
+                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                "registrar_tests/named_arquillian_SHOULD_NOT_BE_FOUND_.properties",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                    }
+                });
     }
 
     @Test
     public void shouldBeAbleToAddSystemProperties() throws Exception {
         validate(
-            "arq.container.C.mode",
-            "manual",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    registrar.loadConfiguration(new ManagerStarted());
-                    ArquillianDescriptor desc = descInst.get();
+                "arq.container.C.mode",
+                "manual",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        registrar.loadConfiguration(new ManagerStarted());
+                        ArquillianDescriptor desc = descInst.get();
 
-                    Assert.assertEquals(1, desc.getContainers().size());
-                    Assert.assertEquals("C", desc.getContainers().get(0).getContainerName());
-                    Assert.assertEquals("manual", desc.getContainers().get(0).getMode());
-                }
-            });
+                        Assert.assertEquals(1, desc.getContainers().size());
+                        Assert.assertEquals("C", desc.getContainers().get(0).getContainerName());
+                        Assert.assertEquals("manual", desc.getContainers().get(0).getMode());
+                    }
+                });
     }
 
     @Test
     public void shouldBeAbleToOverrideWithSystemProperties() throws Exception {
         validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    ConfigurationRegistrarTestCase.validate(
-                        "arq.container.A.mode",
-                        "suite",
-                        new AssertCallback() {
-                            @Override
-                            public void validate() {
-                                registrar.loadConfiguration(new ManagerStarted());
-                                ArquillianDescriptor desc = descInst.get();
-
-                                Assert.assertEquals(1, desc.getContainers().size());
-                                Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                                Assert.assertEquals("suite", desc.getContainers().get(0).getMode());
-                            }
-                        });
-                }
-            });
-    }
-
-    @Test
-    public void shouldBeAbleToAddToXMLWithProperties() throws Exception {
-        validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    ConfigurationRegistrarTestCase.validate(
-                        ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-                        "registrar_tests/named_arquillian.properties",
-                        new AssertCallback() {
-                            @Override
-                            public void validate() {
-                                registrar.loadConfiguration(new ManagerStarted());
-                                ArquillianDescriptor desc = descInst.get();
-
-                                Assert.assertEquals(2, desc.getContainers().size());
-                                Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                                Assert.assertEquals("B", desc.getContainers().get(1).getContainerName());
-                            }
-                        });
-                }
-            });
-    }
-
-    @Test
-    public void shouldBeAbleToOverrideToXMLWithProperties() throws Exception {
-        validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    ConfigurationRegistrarTestCase.validate(
-                        ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-                        "registrar_tests/override_named_arquillian.properties",
-                        new AssertCallback() {
-                            @Override
-                            public void validate() {
-                                registrar.loadConfiguration(new ManagerStarted());
-                                ArquillianDescriptor desc = descInst.get();
-
-                                Assert.assertEquals(1, desc.getContainers().size());
-                                Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                                Assert.assertEquals("suite", desc.getContainers().get(0).getMode());
-                            }
-                        });
-                }
-            });
-    }
-
-    @Test
-    public void shouldToOverrideToPropertiesWithSystemEnvironment() throws Exception {
-        validate(
-            ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-            "registrar_tests/named_arquillian.xml",
-            new AssertCallback() {
-                @Override
-                public void validate() {
-                    ConfigurationRegistrarTestCase.validate(
-                        ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-                        "registrar_tests/override_named_arquillian.properties",
-                        new AssertCallback() {
-                            @Override
-                            public void validate() {
-                                Map<String, String> envVars = new HashMap<String, String>();
-                                envVars.put("arq.container.A.mode", "none");
-                                registrar.setEnvironmentVariables(envVars);
-                                registrar.loadConfiguration(new ManagerStarted());
-
-                                ArquillianDescriptor desc = descInst.get();
-
-                                Assert.assertEquals(1, desc.getContainers().size());
-                                Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
-                                Assert.assertEquals("none", desc.getContainers().get(0).getMode());
-                            }
-                        });
-                }
-            });
-    }
-
-    @Test
-    public void shouldBeAbleToOverrideToXMLWithPlaceholderReplace() throws Exception {
-        validate(
                 ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
-                "registrar_tests/property_arquillian.xml",
+                "registrar_tests/named_arquillian.xml",
                 new AssertCallback() {
                     @Override
                     public void validate() {
                         ConfigurationRegistrarTestCase.validate(
-                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
-                                "registrar_tests/property_arquillian.properties",
+                                "arq.container.A.mode",
+                                "suite",
                                 new AssertCallback() {
                                     @Override
                                     public void validate() {
                                         registrar.loadConfiguration(new ManagerStarted());
                                         ArquillianDescriptor desc = descInst.get();
 
-                                        Assert.assertNotNull(desc.getDefaultProtocol());
-                                        Assert.assertEquals("X BBB X", desc.getDefaultProtocol().getProperty("bbb"));
-                                        Assert.assertEquals("X  X", desc.getDefaultProtocol().getProperty("bbb2"));
-
                                         Assert.assertEquals(1, desc.getContainers().size());
-                                        Assert.assertNotNull(desc.getContainers().get(0));
-                                        Assert.assertNotNull("Y AAA Y", desc.getContainers().get(0).getProperty("aaa"));
-                                        Assert.assertNotNull("Y  Y", desc.getContainers().get(0).getProperty("aaa2"));
-
-                                        Assert.assertEquals(1, desc.getExtensions().size());
-                                        Assert.assertNotNull(desc.getExtensions().get(0));
-                                        Assert.assertNotNull("Z DDD Z", desc.getExtensions().get(0).getProperty("ddd"));
-                                        Assert.assertNotNull("Z  Z", desc.getExtensions().get(0).getProperty("ddd2"));
-
-                                        Assert.assertEquals(2, desc.getGroups().size());
-                                        Assert.assertNotNull(desc.getGroups().get(0));
-                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().size());
-                                        Assert.assertEquals("T EEE T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee"));
-                                        Assert.assertEquals("T  T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee2"));
-                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().size());
-                                        Assert.assertEquals("R FFF R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff"));
-                                        Assert.assertEquals("R  R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff2"));
-                                        Assert.assertNotNull(desc.getGroups().get(1));
-                                        Assert.assertEquals(1, desc.getGroups().get(1).getGroupContainers().size());
-                                        Assert.assertEquals("WITHOUT ", desc.getGroups().get(1).getGroupContainers().get(0).getProtocols().get(0).getProperty("foo"));
+                                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                                        Assert.assertEquals("suite", desc.getContainers().get(0).getMode());
                                     }
                                 });
                     }
                 });
+    }
+
+    @Test
+    public void shouldBeAbleToAddToXMLWithProperties() throws Exception {
+        validate(
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/named_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        ConfigurationRegistrarTestCase.validate(
+                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                                "registrar_tests/named_arquillian.properties",
+                                new AssertCallback() {
+                                    @Override
+                                    public void validate() {
+                                        registrar.loadConfiguration(new ManagerStarted());
+                                        ArquillianDescriptor desc = descInst.get();
+
+                                        Assert.assertEquals(2, desc.getContainers().size());
+                                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                                        Assert.assertEquals("B", desc.getContainers().get(1).getContainerName());
+                                    }
+                                });
+                    }
+                });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideToXMLWithProperties() throws Exception {
+        validate(
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/named_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        ConfigurationRegistrarTestCase.validate(
+                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                                "registrar_tests/override_named_arquillian.properties",
+                                new AssertCallback() {
+                                    @Override
+                                    public void validate() {
+                                        registrar.loadConfiguration(new ManagerStarted());
+                                        ArquillianDescriptor desc = descInst.get();
+
+                                        Assert.assertEquals(1, desc.getContainers().size());
+                                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                                        Assert.assertEquals("suite", desc.getContainers().get(0).getMode());
+                                    }
+                                });
+                    }
+                });
+    }
+
+    @Test
+    public void shouldToOverrideToPropertiesWithSystemEnvironment() throws Exception {
+        validate(
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/named_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        ConfigurationRegistrarTestCase.validate(
+                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                                "registrar_tests/override_named_arquillian.properties",
+                                new AssertCallback() {
+                                    @Override
+                                    public void validate() {
+                                        Map<String, String> envVars = new HashMap<String, String>();
+                                        envVars.put("arq.container.A.mode", "none");
+                                        registrar.setEnvironmentVariables(envVars);
+                                        registrar.loadConfiguration(new ManagerStarted());
+
+                                        ArquillianDescriptor desc = descInst.get();
+
+                                        Assert.assertEquals(1, desc.getContainers().size());
+                                        Assert.assertEquals("A", desc.getContainers().get(0).getContainerName());
+                                        Assert.assertEquals("none", desc.getContainers().get(0).getMode());
+                                    }
+                                });
+                    }
+                });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideToXMLWithPlaceholderReplace() throws Exception {
+        validate("env.ENV1", "env1", new AssertCallback() {
+            @Override
+            public void validate() {
+                ConfigurationRegistrarTestCase.validate("env.ENV3", "env3", new AssertCallback() {
+                    @Override
+                    public void validate() {
+
+                        ConfigurationRegistrarTestCase.validate(
+                                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                                "registrar_tests/property_arquillian.xml",
+                                new AssertCallback() {
+                                    @Override
+                                    public void validate() {
+                                        ConfigurationRegistrarTestCase.validate(
+                                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                                                "registrar_tests/property_arquillian.properties",
+                                                new AssertCallback() {
+                                                    @Override
+                                                    public void validate() {
+                                                        registrar.loadConfiguration(new ManagerStarted());
+                                                        ArquillianDescriptor desc = descInst.get();
+
+                                                        Assert.assertNotNull(desc.getDefaultProtocol());
+                                                        Assert.assertEquals("X BBB X", desc.getDefaultProtocol().getProperty("bbb"));
+                                                        Assert.assertEquals("X  X", desc.getDefaultProtocol().getProperty("bbb2"));
+
+                                                        Assert.assertEquals(1, desc.getContainers().size());
+                                                        Assert.assertNotNull(desc.getContainers().get(0));
+                                                        Assert.assertNotNull("Y AAA Y", desc.getContainers().get(0).getProperty("aaa"));
+                                                        Assert.assertNotNull("Y  Y", desc.getContainers().get(0).getProperty("aaa2"));
+
+                                                        Assert.assertEquals(1, desc.getExtensions().size());
+                                                        Assert.assertNotNull(desc.getExtensions().get(0));
+                                                        Assert.assertNotNull("Z DDD Z", desc.getExtensions().get(0).getProperty("ddd"));
+                                                        Assert.assertNotNull("Z  Z", desc.getExtensions().get(0).getProperty("ddd2"));
+
+                                                        Assert.assertEquals(2, desc.getGroups().size());
+                                                        Assert.assertNotNull(desc.getGroups().get(0));
+                                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().size());
+                                                        Assert.assertEquals("T EEE T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee"));
+                                                        Assert.assertEquals("T  T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee2"));
+                                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().size());
+                                                        Assert.assertEquals("R FFF R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff"));
+                                                        Assert.assertEquals("R  R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff2"));
+                                                        Assert.assertEquals("env1", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("ggg1"));
+                                                        Assert.assertEquals("${env.ENV2}", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("ggg2"));
+                                                        Assert.assertEquals("G env1 G", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("ggg3"));
+                                                        Assert.assertEquals("env3 HHH", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("hhh1"));
+                                                        Assert.assertEquals("${env.ENV4} HHH", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("hhh2"));
+                                                        Assert.assertEquals("H env1 HHH H", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("hhh3"));
+                                                        Assert.assertEquals("env1  ${env.ENV2}", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("hhh4"));
+                                                        Assert.assertNotNull(desc.getGroups().get(1));
+                                                        Assert.assertEquals(1, desc.getGroups().get(1).getGroupContainers().size());
+                                                        Assert.assertEquals("WITHOUT ", desc.getGroups().get(1).getGroupContainers().get(0).getProtocols().get(0).getProperty("foo"));
+                                                    }
+                                                });
+                                    }
+                                });
+                    }
+                });
+            }
+        });
     }
 
     public interface AssertCallback {

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
@@ -312,21 +312,29 @@ public class ConfigurationRegistrarTestCase extends AbstractManagerTestBase {
 
                                         Assert.assertNotNull(desc.getDefaultProtocol());
                                         Assert.assertEquals("X BBB X", desc.getDefaultProtocol().getProperty("bbb"));
+                                        Assert.assertEquals("X  X", desc.getDefaultProtocol().getProperty("bbb2"));
 
                                         Assert.assertEquals(1, desc.getContainers().size());
                                         Assert.assertNotNull(desc.getContainers().get(0));
                                         Assert.assertNotNull("Y AAA Y", desc.getContainers().get(0).getProperty("aaa"));
+                                        Assert.assertNotNull("Y  Y", desc.getContainers().get(0).getProperty("aaa2"));
 
                                         Assert.assertEquals(1, desc.getExtensions().size());
                                         Assert.assertNotNull(desc.getExtensions().get(0));
                                         Assert.assertNotNull("Z DDD Z", desc.getExtensions().get(0).getProperty("ddd"));
+                                        Assert.assertNotNull("Z  Z", desc.getExtensions().get(0).getProperty("ddd2"));
 
-                                        Assert.assertEquals(1, desc.getGroups().size());
+                                        Assert.assertEquals(2, desc.getGroups().size());
                                         Assert.assertNotNull(desc.getGroups().get(0));
                                         Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().size());
                                         Assert.assertEquals("T EEE T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee"));
+                                        Assert.assertEquals("T  T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee2"));
                                         Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().size());
                                         Assert.assertEquals("R FFF R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff"));
+                                        Assert.assertEquals("R  R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff2"));
+                                        Assert.assertNotNull(desc.getGroups().get(1));
+                                        Assert.assertEquals(1, desc.getGroups().get(1).getGroupContainers().size());
+                                        Assert.assertEquals("WITHOUT ", desc.getGroups().get(1).getGroupContainers().get(0).getProtocols().get(0).getProperty("foo"));
                                     }
                                 });
                     }

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
@@ -293,6 +293,46 @@ public class ConfigurationRegistrarTestCase extends AbstractManagerTestBase {
             });
     }
 
+    @Test
+    public void shouldBeAbleToOverrideToXMLWithPlaceholderReplace() throws Exception {
+        validate(
+                ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY,
+                "registrar_tests/property_arquillian.xml",
+                new AssertCallback() {
+                    @Override
+                    public void validate() {
+                        ConfigurationRegistrarTestCase.validate(
+                                ConfigurationRegistrar.ARQUILLIAN_PROP_PROPERTY,
+                                "registrar_tests/property_arquillian.properties",
+                                new AssertCallback() {
+                                    @Override
+                                    public void validate() {
+                                        registrar.loadConfiguration(new ManagerStarted());
+                                        ArquillianDescriptor desc = descInst.get();
+
+                                        Assert.assertNotNull(desc.getDefaultProtocol());
+                                        Assert.assertEquals("X BBB X", desc.getDefaultProtocol().getProperty("bbb"));
+
+                                        Assert.assertEquals(1, desc.getContainers().size());
+                                        Assert.assertNotNull(desc.getContainers().get(0));
+                                        Assert.assertNotNull("Y AAA Y", desc.getContainers().get(0).getProperty("aaa"));
+
+                                        Assert.assertEquals(1, desc.getExtensions().size());
+                                        Assert.assertNotNull(desc.getExtensions().get(0));
+                                        Assert.assertNotNull("Z DDD Z", desc.getExtensions().get(0).getProperty("ddd"));
+
+                                        Assert.assertEquals(1, desc.getGroups().size());
+                                        Assert.assertNotNull(desc.getGroups().get(0));
+                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().size());
+                                        Assert.assertEquals("T EEE T", desc.getGroups().get(0).getGroupContainers().get(0).getProperty("eee"));
+                                        Assert.assertEquals(1, desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().size());
+                                        Assert.assertEquals("R FFF R", desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProperty("fff"));
+                                    }
+                                });
+                    }
+                });
+    }
+
     public interface AssertCallback {
         void validate();
     }

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
@@ -39,12 +39,12 @@ public class PropertiesParserTestCase {
     private static final String CONFIGURATION_PROP_1 = "jbossHome";
 
     private static final String CONTAINER_PROP_CONFIGURATION_1 =
-        "arq.container.jboss.configuration." + CONFIGURATION_PROP_1;
+            "arq.container.jboss.configuration." + CONFIGURATION_PROP_1;
     private static final String CONTAINER_VAL_CONFIGURATION_2 = "ccc";
     private static final String CONTAINER_VAL_CONFIGURATION_REPLACE = "c [ORIGINAL] c";
     private static final String CONTAINER_VAL_CONFIGURATION_1 = "target/jboss-as";
     private static final String CONTAINER_PROP_PROTOCOL_1 =
-        "arq.container.jboss.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
+            "arq.container.jboss.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
     private static final String CONTAINER_VAL_PROTOCOL_1 = "192.0.0.1";
     private static final String CONTAINER_VAL_PROTOCOL_2 = "www";
     private static final String CONTAINER_VAL_PROTOCOL_REPLACE = "w [ORIGINAL] w";
@@ -53,12 +53,12 @@ public class PropertiesParserTestCase {
     private static final String CONTAINER_VAL_1 = "suite";
 
     private static final String GROUP_PROP_CONTAINER_CONFIGURATION_1 =
-        "arq.group.cluster.container.jboss.configuration." + CONFIGURATION_PROP_1;
+            "arq.group.cluster.container.jboss.configuration." + CONFIGURATION_PROP_1;
     private static final String GROUP_VAL_CONTAINER_CONFIGURATION_1 = CONTAINER_VAL_1;
     private static final String GROUP_VAL_CONTAINER_CONFIGURATION_2 = "yyy";
     private static final String GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE = "y [ORIGINAL] y";
     private static final String GROUP_PROP_CONTAINER_PROTOCOL_1 =
-        "arq.group.Cluster 1.container.JBoss AS 7.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
+            "arq.group.Cluster 1.container.JBoss AS 7.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
     private static final String GROUP_VAL_CONTAINER_PROTOCOL_1 = CONTAINER_VAL_1;
     private static final String GROUP_VAL_CONTAINER_PROTOCOL_2 = "xxx";
     private static final String GROUP_VAL_CONTAINER_PROTOCOL_REPLACE = "x [ORIGINAL] x";
@@ -128,50 +128,42 @@ public class PropertiesParserTestCase {
     }
 
     @Test
-    public void shouldBeAbleToOverrideContainerConfiguration()
-    {
+    public void shouldBeAbleToOverrideContainerConfiguration() {
         validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideContainerConfigurationWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToOverrideContainerConfigurationWithPlaceholderReplace() {
         validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_REPLACE, "c ccc c", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddContainerConfigurationWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddContainerConfigurationWithoutOriginalValue() {
         validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_REPLACE, "c  c", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -183,60 +175,52 @@ public class PropertiesParserTestCase {
             @Override
             public String get() {
                 return desc.getContainers()
-                    .get(0)
-                    .getProtocols()
-                    .get(0)
-                    .getProtocolProperties()
-                    .get(CONFIGURATION_PROP_1);
+                        .get(0)
+                        .getProtocols()
+                        .get(0)
+                        .getProtocolProperties()
+                        .get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideContainerProtocol()
-    {
+    public void shouldBeAbleToOverrideContainerProtocol() {
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideContainerProtocolWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToOverrideContainerProtocolWithPlaceholderReplace() {
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_REPLACE, "w www w", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddContainerProtocolWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddContainerProtocolWithoutOriginalValue() {
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_REPLACE, "w  w", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -268,60 +252,52 @@ public class PropertiesParserTestCase {
             @Override
             public String get() {
                 return desc.getGroups()
-                    .get(0)
-                    .getGroupContainers()
-                    .get(0)
-                    .getContainerProperties()
-                    .get(CONFIGURATION_PROP_1);
+                        .get(0)
+                        .getGroupContainers()
+                        .get(0)
+                        .getContainerProperties()
+                        .get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideGroupContainerConfiguration()
-    {
+    public void shouldBeAbleToOverrideGroupContainerConfiguration() {
         validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideGroupContainerConfigurationWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToOverrideGroupContainerConfigurationWithPlaceholderReplace() {
         validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE, "y yyy y", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddGroupContainerConfigurationWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddGroupContainerConfigurationWithoutOriginalValue() {
         validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE, "y  y", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -333,62 +309,54 @@ public class PropertiesParserTestCase {
             @Override
             public String get() {
                 return desc.getGroups()
-                    .get(0)
-                    .getGroupContainers()
-                    .get(0)
-                    .getProtocols()
-                    .get(0)
-                    .getProtocolProperties()
-                    .get(CONFIGURATION_PROP_1);
+                        .get(0)
+                        .getGroupContainers()
+                        .get(0)
+                        .getProtocols()
+                        .get(0)
+                        .getProtocolProperties()
+                        .get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideGroupContainerProtocol()
-    {
+    public void shouldBeAbleToOverrideGroupContainerProtocol() {
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddGroupContainerProtocolWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToAddGroupContainerProtocolWithPlaceholderReplace() {
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_REPLACE, "x xxx x", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddGroupContainerProtocolWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddGroupContainerProtocolWithoutOriginalValue() {
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_REPLACE, "x  x", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -405,52 +373,44 @@ public class PropertiesParserTestCase {
     }
 
     @Test
-    public void shouldBeAbleToOverrideDefaultProtocol()
-    {
+    public void shouldBeAbleToOverrideDefaultProtocol() {
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
 
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddDefaultProtocolWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToAddDefaultProtocolWithPlaceholderReplace() {
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
 
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_REPLACE, "bar foo", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddDefaultProtocolWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddDefaultProtocolWithoutOriginalValue() {
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_REPLACE, "bar ", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -467,50 +427,42 @@ public class PropertiesParserTestCase {
     }
 
     @Test
-    public void shouldBeAbleToOverrideExtension()
-    {
+    public void shouldBeAbleToOverrideExtension() {
         validate(EXTENSION_PROP_1, EXTENSION_VAL_1, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(EXTENSION_PROP_1, EXTENSION_VAL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToOverrideExtensionWithPlaceholderReplace()
-    {
+    public void shouldBeAbleToOverrideExtensionWithPlaceholderReplace() {
         validate(EXTENSION_PROP_1, EXTENSION_VAL_2, new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
             }
         });
         validate(EXTENSION_PROP_1, EXTENSION_VAL_REPLACE, "a aaa a", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
 
     @Test
-    public void shouldBeAbleToAddExtensionWithoutOriginalValue()
-    {
+    public void shouldBeAbleToAddExtensionWithoutOriginalValue() {
         validate(EXTENSION_PROP_1, EXTENSION_VAL_REPLACE, "a  a", new ValueCallback() {
             @Override
-            public String get()
-            {
+            public String get() {
                 return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
             }
         });

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
@@ -40,10 +40,14 @@ public class PropertiesParserTestCase {
 
     private static final String CONTAINER_PROP_CONFIGURATION_1 =
         "arq.container.jboss.configuration." + CONFIGURATION_PROP_1;
+    private static final String CONTAINER_VAL_CONFIGURATION_2 = "ccc";
+    private static final String CONTAINER_VAL_CONFIGURATION_REPLACE = "c [ORIGINAL] c";
     private static final String CONTAINER_VAL_CONFIGURATION_1 = "target/jboss-as";
     private static final String CONTAINER_PROP_PROTOCOL_1 =
         "arq.container.jboss.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
     private static final String CONTAINER_VAL_PROTOCOL_1 = "192.0.0.1";
+    private static final String CONTAINER_VAL_PROTOCOL_2 = "www";
+    private static final String CONTAINER_VAL_PROTOCOL_REPLACE = "w [ORIGINAL] w";
 
     private static final String CONTAINER_PROP_1 = "arq.container.jboss.mode";
     private static final String CONTAINER_VAL_1 = "suite";
@@ -51,9 +55,13 @@ public class PropertiesParserTestCase {
     private static final String GROUP_PROP_CONTAINER_CONFIGURATION_1 =
         "arq.group.cluster.container.jboss.configuration." + CONFIGURATION_PROP_1;
     private static final String GROUP_VAL_CONTAINER_CONFIGURATION_1 = CONTAINER_VAL_1;
+    private static final String GROUP_VAL_CONTAINER_CONFIGURATION_2 = "yyy";
+    private static final String GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE = "y [ORIGINAL] y";
     private static final String GROUP_PROP_CONTAINER_PROTOCOL_1 =
         "arq.group.Cluster 1.container.JBoss AS 7.protocol.Servlet 3.0." + CONFIGURATION_PROP_1;
     private static final String GROUP_VAL_CONTAINER_PROTOCOL_1 = CONTAINER_VAL_1;
+    private static final String GROUP_VAL_CONTAINER_PROTOCOL_2 = "xxx";
+    private static final String GROUP_VAL_CONTAINER_PROTOCOL_REPLACE = "x [ORIGINAL] x";
 
     private static final String GROUP_PROP_CONTAINER_1 = "arq.group.cluster.container.jboss.mode";
     private static final String GROUP_VAL_CONTAINER_1 = "suite";
@@ -63,9 +71,13 @@ public class PropertiesParserTestCase {
 
     private static final String DEFAULT_PROTOCOL_PROP_1 = "arq.defaultprotocol.Servlet 3.0." + CONFIGURATION_PROP_1;
     private static final String DEFAULT_PROTOCOL_VAL_1 = "true";
+    private static final String DEFAULT_PROTOCOL_VAL_2 = "foo";
+    private static final String DEFAULT_PROTOCOL_VAL_REPLACE = "bar [ORIGINAL]";
 
     private static final String EXTENSION_PROP_1 = "arq.extension.extension-1." + CONFIGURATION_PROP_1;
     private static final String EXTENSION_VAL_1 = "suite";
+    private static final String EXTENSION_VAL_2 = "aaa";
+    private static final String EXTENSION_VAL_REPLACE = "a [ORIGINAL] a";
 
     private ArquillianDescriptor desc;
 
@@ -116,6 +128,44 @@ public class PropertiesParserTestCase {
     }
 
     @Test
+    public void shouldBeAbleToOverrideContainerConfiguration()
+    {
+        validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideContainerConfigurationWithPlaceholderReplace()
+    {
+        validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_REPLACE, "c ccc c", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
     public void shouldBeAbleToAddContainerProtocol() {
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_1, new ValueCallback() {
             @Override
@@ -126,6 +176,44 @@ public class PropertiesParserTestCase {
                     .get(0)
                     .getProtocolProperties()
                     .get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideContainerProtocol()
+    {
+        validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideContainerProtocolWithPlaceholderReplace()
+    {
+        validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_REPLACE, "w www w", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
             }
         });
     }
@@ -166,7 +254,45 @@ public class PropertiesParserTestCase {
     }
 
     @Test
-    public void shouldBeAbleToAddGroupContianerProtocol() {
+    public void shouldBeAbleToOverrideGroupContainerConfiguration()
+    {
+        validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideGroupContainerConfigurationWithPlaceholderReplace()
+    {
+        validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE, "y yyy y", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddGroupContainerProtocol() {
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_1, new ValueCallback() {
             @Override
             public String get() {
@@ -183,10 +309,88 @@ public class PropertiesParserTestCase {
     }
 
     @Test
+    public void shouldBeAbleToOverrideGroupContainerProtocol()
+    {
+        validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddGroupContainerProtocolWithPlaceholderReplace()
+    {
+        validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_REPLACE, "x xxx x", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
     public void shouldBeAbleToAddDefaultProtocol() {
         validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_1, new ValueCallback() {
             @Override
             public String get() {
+                return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideDefaultProtocol()
+    {
+        validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+
+        validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddDefaultProtocolWithPlaceholderReplace()
+    {
+        validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+
+        validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_REPLACE, "bar foo", new ValueCallback() {
+            @Override
+            public String get()
+            {
                 return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
             }
         });
@@ -202,13 +406,55 @@ public class PropertiesParserTestCase {
         });
     }
 
+    @Test
+    public void shouldBeAbleToOverrideExtension()
+    {
+        validate(EXTENSION_PROP_1, EXTENSION_VAL_1, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(EXTENSION_PROP_1, EXTENSION_VAL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToOverrideExtensionWithPlaceholderReplace()
+    {
+        validate(EXTENSION_PROP_1, EXTENSION_VAL_2, new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+        validate(EXTENSION_PROP_1, EXTENSION_VAL_REPLACE, "a aaa a", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
     private void validate(String property, String value, ValueCallback callback) {
+        validate(property, value, value, callback);
+    }
+
+    private void validate(String property, String value, String expectedValue, ValueCallback callback) {
         try {
             System.setProperty(property, value);
 
             new PropertiesParser().addProperties(desc, System.getProperties());
 
-            Assert.assertEquals(value, callback.get());
+            Assert.assertEquals(expectedValue, callback.get());
         } finally {
             System.clearProperty(property);
         }

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
@@ -166,6 +166,18 @@ public class PropertiesParserTestCase {
     }
 
     @Test
+    public void shouldBeAbleToAddContainerConfigurationWithoutOriginalValue()
+    {
+        validate(CONTAINER_PROP_CONFIGURATION_1, CONTAINER_VAL_CONFIGURATION_REPLACE, "c  c", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
     public void shouldBeAbleToAddContainerProtocol() {
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_1, new ValueCallback() {
             @Override
@@ -210,6 +222,18 @@ public class PropertiesParserTestCase {
             }
         });
         validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_REPLACE, "w www w", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddContainerProtocolWithoutOriginalValue()
+    {
+        validate(CONTAINER_PROP_PROTOCOL_1, CONTAINER_VAL_PROTOCOL_REPLACE, "w  w", new ValueCallback() {
             @Override
             public String get()
             {
@@ -292,6 +316,18 @@ public class PropertiesParserTestCase {
     }
 
     @Test
+    public void shouldBeAbleToAddGroupContainerConfigurationWithoutOriginalValue()
+    {
+        validate(GROUP_PROP_CONTAINER_CONFIGURATION_1, GROUP_VAL_CONTAINER_CONFIGURATION_REPLACE, "y  y", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getContainerProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
     public void shouldBeAbleToAddGroupContainerProtocol() {
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_1, new ValueCallback() {
             @Override
@@ -338,6 +374,18 @@ public class PropertiesParserTestCase {
             }
         });
         validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_REPLACE, "x xxx x", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getGroups().get(0).getGroupContainers().get(0).getProtocols().get(0).getProtocolProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddGroupContainerProtocolWithoutOriginalValue()
+    {
+        validate(GROUP_PROP_CONTAINER_PROTOCOL_1, GROUP_VAL_CONTAINER_PROTOCOL_REPLACE, "x  x", new ValueCallback() {
             @Override
             public String get()
             {
@@ -397,6 +445,18 @@ public class PropertiesParserTestCase {
     }
 
     @Test
+    public void shouldBeAbleToAddDefaultProtocolWithoutOriginalValue()
+    {
+        validate(DEFAULT_PROTOCOL_PROP_1, DEFAULT_PROTOCOL_VAL_REPLACE, "bar ", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getDefaultProtocol().getProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
     public void shouldBeAbleToAddExtension() {
         validate(EXTENSION_PROP_1, EXTENSION_VAL_1, new ValueCallback() {
             @Override
@@ -436,6 +496,18 @@ public class PropertiesParserTestCase {
             }
         });
         validate(EXTENSION_PROP_1, EXTENSION_VAL_REPLACE, "a aaa a", new ValueCallback() {
+            @Override
+            public String get()
+            {
+                return desc.getExtensions().get(0).getExtensionProperties().get(CONFIGURATION_PROP_1);
+            }
+        });
+    }
+
+    @Test
+    public void shouldBeAbleToAddExtensionWithoutOriginalValue()
+    {
+        validate(EXTENSION_PROP_1, EXTENSION_VAL_REPLACE, "a  a", new ValueCallback() {
             @Override
             public String get()
             {

--- a/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
+++ b/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
@@ -1,0 +1,5 @@
+arq.defaultprotocol.Foo.bbb=X [ORIGINAL] X
+arq.container.A.configuration.aaa=Y [ORIGINAL] Y
+arq.extension.EXT1.ddd=Z [ORIGINAL] Z
+arq.group.Q2.container.Q3.configuration.eee=T [ORIGINAL] T
+arq.group.Q2.container.Q3.protocol.P1.fff=R [ORIGINAL] R

--- a/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
+++ b/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
@@ -1,5 +1,11 @@
 arq.defaultprotocol.Foo.bbb=X [ORIGINAL] X
+arq.defaultprotocol.Foo.bbb2=X [ORIGINAL] X
 arq.container.A.configuration.aaa=Y [ORIGINAL] Y
+arq.container.A.configuration.aaa2=Y [ORIGINAL] Y
 arq.extension.EXT1.ddd=Z [ORIGINAL] Z
+arq.extension.EXT1.ddd2=Z [ORIGINAL] Z
 arq.group.Q2.container.Q3.configuration.eee=T [ORIGINAL] T
+arq.group.Q2.container.Q3.configuration.eee2=T [ORIGINAL] T
 arq.group.Q2.container.Q3.protocol.P1.fff=R [ORIGINAL] R
+arq.group.Q2.container.Q3.protocol.P1.fff2=R [ORIGINAL] R
+arq.group.XXX.container.XXX.protocol.XXX.foo=WITHOUT [ORIGINAL]

--- a/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
+++ b/config/impl-base/src/test/resources/registrar_tests/property_arquillian.properties
@@ -9,3 +9,6 @@ arq.group.Q2.container.Q3.configuration.eee2=T [ORIGINAL] T
 arq.group.Q2.container.Q3.protocol.P1.fff=R [ORIGINAL] R
 arq.group.Q2.container.Q3.protocol.P1.fff2=R [ORIGINAL] R
 arq.group.XXX.container.XXX.protocol.XXX.foo=WITHOUT [ORIGINAL]
+arq.group.Q2.container.Q3.protocol.P1.ggg3=G [ORIGINAL] G
+arq.group.Q2.container.Q3.protocol.P1.hhh3=H [ORIGINAL] H
+arq.group.Q2.container.Q3.protocol.P1.hhh4=${env.ENV1} [ORIGINAL] ${env.ENV2}

--- a/config/impl-base/src/test/resources/registrar_tests/property_arquillian.xml
+++ b/config/impl-base/src/test/resources/registrar_tests/property_arquillian.xml
@@ -20,6 +20,12 @@
             </configuration>
             <protocol type="P1">
                 <property name="fff">FFF</property>
+                <property name="ggg1">${env.ENV1}</property>
+                <property name="ggg2">${env.ENV2}</property>
+                <property name="ggg3">${env.ENV1}</property>
+                <property name="hhh1">${env.ENV3} HHH</property>
+                <property name="hhh2">${env.ENV4} HHH</property>
+                <property name="hhh3">${env.ENV1} HHH</property>
             </protocol>
         </container>
     </group>

--- a/config/impl-base/src/test/resources/registrar_tests/property_arquillian.xml
+++ b/config/impl-base/src/test/resources/registrar_tests/property_arquillian.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <defaultProtocol type="Foo">
+        <property name="bbb">BBB</property>
+    </defaultProtocol>
+    <container qualifier="A" mode="class">
+        <configuration>
+            <property name="aaa">AAA</property>
+        </configuration>
+    </container>
+    <extension qualifier="EXT1">
+        <property name="ddd">DDD</property>
+    </extension>
+    <group qualifier="Q2">
+        <container qualifier="Q3">
+            <configuration>
+                <property name="eee">EEE</property>
+            </configuration>
+            <protocol type="P1">
+                <property name="fff">FFF</property>
+            </protocol>
+        </container>
+    </group>
+</arquillian>


### PR DESCRIPTION
…new property value.

Hi,I have situation that arquillian.xml values in property elements are replaced with values from arquillian.properties file and when I use custom utility that generates arquillian.properties file my original value is replaced.
So I am sending you PR to allow add original value from arquillian.xml file property elements into new overriden value from arquillian.properties file.

Hope you will like it...
Ivos

arquillian.xml
```xml
<?xml version="1.0"?>
<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
    ...
    <container qualifier="wildfly10" default="true">
        <configuration>
            <property name="javaVmArguments">-DsomeKey=someValue</property>
        </configuration>
    </container>
</arquillian>
```

and arquillian.properties
```properties
arq.container.wildfly10.configuration.javaVmArguments=[ORIGINAL] -Djboss.socket.binding.port-offset=100
```

result value will be:
```
-DsomeKey=someValue -Djboss.socket.binding.port-offset=100
```

I am aware of having this kind of properties specified at various places, but what I want is to have "someKey" be part of testing module arquillian configuration (not to be part of pom.xml configuration somewhere).