### PR TITLE
Logs extension registration when debug enabled

### DIFF
--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventContextImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventContextImpl.java
@@ -38,6 +38,7 @@ public class EventContextImpl<T> implements EventContext<T>
    private List<ObserverMethod> interceptors;
    private List<ObserverMethod> observers;
    private NonManagedObserver<T> nonManagedObserver;
+   private RuntimeLogger runtimeLogger;
    
    private T event;
    
@@ -51,19 +52,22 @@ public class EventContextImpl<T> implements EventContext<T>
     * @param observers List of Observers, @Observes T
     * @param nonManagedObserver a NonManagedObserver of type T
     * @param event The event
+    * @param runtimeLogger to use to log events.
     * @throws IllegalArgumentException if Manager is null
     * @throws IllegalArgumentException if Event is null 
     */
-   public EventContextImpl(ManagerImpl manager, List<ObserverMethod> interceptors, List<ObserverMethod> observers, NonManagedObserver<T> nonManagedObserver, T event)
+   public EventContextImpl(ManagerImpl manager, List<ObserverMethod> interceptors, List<ObserverMethod> observers, NonManagedObserver<T> nonManagedObserver, T event, RuntimeLogger runtimeLogger)
    {
       Validate.notNull(manager, "Manager must be specified");
       Validate.notNull(event, "Event must be specified");
+      Validate.notNull(runtimeLogger, "Runtime logger must be specified");
       
       this.manager = manager;
       this.interceptors = interceptors == null ? new ArrayList<ObserverMethod>():interceptors;
       this.observers = observers == null ? new ArrayList<ObserverMethod>():observers;
       this.nonManagedObserver = nonManagedObserver;
       this.event = event;
+      this.runtimeLogger = runtimeLogger;
    }
 
    @Override
@@ -84,7 +88,7 @@ public class EventContextImpl<T> implements EventContext<T>
       else
       {
          ObserverMethod interceptor = interceptors.get(currentInterceptor++);
-         manager.debug(interceptor, true);
+         runtimeLogger.debug(interceptor, true);
          interceptor.invoke(manager, this);
       }
    }
@@ -95,7 +99,7 @@ public class EventContextImpl<T> implements EventContext<T>
       {
          try
          {
-            manager.debug(observer, false);
+            runtimeLogger.debug(observer, false);
             observer.invoke(manager, event);
          } 
          catch (InvocationException e) 

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.concurrent.Callable;
 
 import org.jboss.arquillian.core.api.Injector;
@@ -321,7 +320,7 @@ public class ManagerImpl implements Manager
          contexts.clear();
          extensions.clear();
 
-         runtimeLogger.cleanStack();
+         runtimeLogger.clear();
          
          handledThrowables.remove();
       }

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
@@ -603,19 +603,6 @@ public class ManagerImpl implements Manager
    {
       if (DEBUG)
       {
-
-         if(eventStack == null)
-         {
-            eventStack = new ThreadLocal<Stack<Object>>()
-            {
-               @Override
-               protected Stack<Object> initialValue()
-               {
-                  return new Stack<Object>();
-               }
-            };
-         }
-
          System.out.println(calcDebugPrefix() + "(X) " + extension.getName());
       }
    }
@@ -624,17 +611,6 @@ public class ManagerImpl implements Manager
    {
       if(DEBUG)
       {
-         if(eventStack == null)
-         {
-            eventStack = new ThreadLocal<Stack<Object>>() 
-            {
-               @Override
-               protected Stack<Object> initialValue()
-               {
-                  return new Stack<Object>();
-               } 
-            };
-         }
          if(push)
          {
             System.out.println(calcDebugPrefix() + "(E) " + getEventName(event));
@@ -664,8 +640,19 @@ public class ManagerImpl implements Manager
    private String calcDebugPrefix()
    {
 
-      final Stack<Object> objects = eventStack.get();
-      int size = objects.size();
+      if(eventStack == null)
+      {
+         eventStack = new ThreadLocal<Stack<Object>>()
+         {
+            @Override
+            protected Stack<Object> initialValue()
+            {
+               return new Stack<Object>();
+            }
+         };
+      }
+
+      final int size = eventStack.get().size();
       StringBuilder sb = new StringBuilder();
       for(int i = 0; i < size; i++)
       {

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
@@ -374,6 +374,7 @@ public class ManagerImpl implements Manager
       
       this.extensions.addAll(createExtensions(extensions));
       this.contexts.addAll(createContexts(contexts));
+
    }
    
    boolean isExceptionHandled(Throwable e)
@@ -440,6 +441,7 @@ public class ManagerImpl implements Manager
          Extension extension = ExtensionImpl.of(Reflections.createInstance(extensionClass));
          inject(extension);
          created.add(extension);
+         debugExtension(extensionClass);
       }
       return created;
    }
@@ -597,6 +599,27 @@ public class ManagerImpl implements Manager
       }
    }
 
+   private void debugExtension(Class<?> extension)
+   {
+      if (DEBUG)
+      {
+
+         if(eventStack == null)
+         {
+            eventStack = new ThreadLocal<Stack<Object>>()
+            {
+               @Override
+               protected Stack<Object> initialValue()
+               {
+                  return new Stack<Object>();
+               }
+            };
+         }
+
+         System.out.println(calcDebugPrefix() + "(X) " + extension.getName());
+      }
+   }
+
    private void debug(Object event, boolean push)
    {
       if(DEBUG)
@@ -640,7 +663,9 @@ public class ManagerImpl implements Manager
    
    private String calcDebugPrefix()
    {
-      int size = eventStack.get().size();
+
+      final Stack<Object> objects = eventStack.get();
+      int size = objects.size();
       StringBuilder sb = new StringBuilder();
       for(int i = 0; i < size; i++)
       {

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/RuntimeLogger.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/RuntimeLogger.java
@@ -6,14 +6,14 @@ import java.util.Stack;
 
 public class RuntimeLogger {
 
-    public static final String ARQUILLIAN_DEBUG_PROPERTY = "arquillian.debug";
-    public static Boolean DEBUG = Boolean.valueOf(SecurityActions.getProperty(ARQUILLIAN_DEBUG_PROPERTY));
+    private static final String ARQUILLIAN_DEBUG_PROPERTY = "arquillian.debug";
+    static Boolean DEBUG = Boolean.valueOf(SecurityActions.getProperty(ARQUILLIAN_DEBUG_PROPERTY));
 
     private ThreadLocal<Stack<Object>> eventStack;
 
-    void cleanStack()
+    void clear()
     {
-        if(eventStack != null)
+        if (eventStack != null)
         {
             eventStack.remove();
         }
@@ -21,9 +21,9 @@ public class RuntimeLogger {
 
     void debug(ObserverMethod method, boolean interceptor)
     {
-        if(DEBUG)
+        if (DEBUG)
         {
-            System.out.println(calcDebugPrefix() + "(" + (interceptor ? "I":"O") + ") " +method.getMethod().getDeclaringClass().getSimpleName() + "." + method.getMethod().getName());
+            System.out.println(indent() + "(" + (interceptor ? "I" : "O") + ") " +method.getMethod().getDeclaringClass().getSimpleName() + "." + method.getMethod().getName());
         }
     }
 
@@ -31,22 +31,22 @@ public class RuntimeLogger {
     {
         if (DEBUG)
         {
-            System.out.println(calcDebugPrefix() + "(X) " + extension.getName());
+            System.out.println(indent() + "(X) " + extension.getName());
         }
     }
 
     void debug(Object event, boolean push)
     {
-        if(DEBUG)
+        if (DEBUG)
         {
-            if(push)
+            if (push)
             {
-                System.out.println(calcDebugPrefix() + "(E) " + getEventName(event));
+                System.out.println(indent() + "(E) " + getEventName(event));
                 eventStack.get().push(event);
             }
             else
             {
-                if(!eventStack.get().isEmpty())
+                if (!eventStack.get().isEmpty())
                 {
                     eventStack.get().pop();
                 }
@@ -58,17 +58,17 @@ public class RuntimeLogger {
     {
         Class<?> eventClass = object.getClass();
         // Print the Interface name of Anonymous classes to show the defined interface, not creation point.
-        if(eventClass.isAnonymousClass() && eventClass.getInterfaces().length == 1 && !eventClass.getInterfaces()[0].getName().startsWith("java"))
+        if (eventClass.isAnonymousClass() && eventClass.getInterfaces().length == 1 && !eventClass.getInterfaces()[0].getName().startsWith("java"))
         {
             return eventClass.getInterfaces()[0].getSimpleName();
         }
         return eventClass.getSimpleName();
     }
 
-    private String calcDebugPrefix()
+    private String indent()
     {
 
-        if(eventStack == null)
+        if (eventStack == null)
         {
             eventStack = new ThreadLocal<Stack<Object>>()
             {
@@ -81,7 +81,7 @@ public class RuntimeLogger {
         }
 
         final int size = eventStack.get().size();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(size * 2);
         for(int i = 0; i < size; i++)
         {
             sb.append("\t");

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/RuntimeLogger.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/RuntimeLogger.java
@@ -1,0 +1,92 @@
+package org.jboss.arquillian.core.impl;
+
+import org.jboss.arquillian.core.spi.ObserverMethod;
+
+import java.util.Stack;
+
+public class RuntimeLogger {
+
+    public static final String ARQUILLIAN_DEBUG_PROPERTY = "arquillian.debug";
+    public static Boolean DEBUG = Boolean.valueOf(SecurityActions.getProperty(ARQUILLIAN_DEBUG_PROPERTY));
+
+    private ThreadLocal<Stack<Object>> eventStack;
+
+    void cleanStack()
+    {
+        if(eventStack != null)
+        {
+            eventStack.remove();
+        }
+    }
+
+    void debug(ObserverMethod method, boolean interceptor)
+    {
+        if(DEBUG)
+        {
+            System.out.println(calcDebugPrefix() + "(" + (interceptor ? "I":"O") + ") " +method.getMethod().getDeclaringClass().getSimpleName() + "." + method.getMethod().getName());
+        }
+    }
+
+    void debugExtension(Class<?> extension)
+    {
+        if (DEBUG)
+        {
+            System.out.println(calcDebugPrefix() + "(X) " + extension.getName());
+        }
+    }
+
+    void debug(Object event, boolean push)
+    {
+        if(DEBUG)
+        {
+            if(push)
+            {
+                System.out.println(calcDebugPrefix() + "(E) " + getEventName(event));
+                eventStack.get().push(event);
+            }
+            else
+            {
+                if(!eventStack.get().isEmpty())
+                {
+                    eventStack.get().pop();
+                }
+            }
+        }
+    }
+
+    private String getEventName(Object object)
+    {
+        Class<?> eventClass = object.getClass();
+        // Print the Interface name of Anonymous classes to show the defined interface, not creation point.
+        if(eventClass.isAnonymousClass() && eventClass.getInterfaces().length == 1 && !eventClass.getInterfaces()[0].getName().startsWith("java"))
+        {
+            return eventClass.getInterfaces()[0].getSimpleName();
+        }
+        return eventClass.getSimpleName();
+    }
+
+    private String calcDebugPrefix()
+    {
+
+        if(eventStack == null)
+        {
+            eventStack = new ThreadLocal<Stack<Object>>()
+            {
+                @Override
+                protected Stack<Object> initialValue()
+                {
+                    return new Stack<Object>();
+                }
+            };
+        }
+
+        final int size = eventStack.get().size();
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < size; i++)
+        {
+            sb.append("\t");
+        }
+        return sb.toString();
+    }
+
+}

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerProcessingTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerProcessingTestCase.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class ManagerProcessingTestCase
 {
    static {
-      ManagerImpl.DEBUG = true;
+      RuntimeLogger.DEBUG = true;
    }
    
    @Test


### PR DESCRIPTION
#### Short description of what this resolves:

Logs extension registration when debug enabled

When the test is run with a property arquillian.debug then there should be printed a list of all loaded extensions on the stdout.

**Fixes**: https://issues.jboss.org/browse/ARQ-2075

Example of output:

```
(X) org.jboss.arquillian.core.impl.loadable.LoadableExtensionLoader
(E) ManagerProcessing
	(O) LoadableExtensionLoader.load
	(E) ServiceRegistryLoader
(X) org.arquillian.algeron.pact.consumer.core.PactConsumerConfigurator
(X) org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar
(X) org.arquillian.algeron.pact.consumer.core.client.StandaloneConsumerPactTest
(X) org.arquillian.algeron.consumer.core.AlgeronConsumerConfigurator
(X) org.jboss.arquillian.junit.extension.UpdateTestResultBeforeAfter
(X) org.arquillian.algeron.pact.consumer.core.PactReportDirectoryConfigurator
(X) org.arquillian.algeron.consumer.core.ContractsPublisherObserver
(X) org.jboss.arquillian.junit.standalone.AllLifecycleEventExecutor
(X) org.jboss.arquillian.test.impl.TestInstanceEnricher
(X) org.jboss.arquillian.test.impl.TestContextHandler
(X) org.jboss.arquillian.junit.RulesEnricher
(X) org.arquillian.algeron.pact.consumer.core.client.MockProviderConfigCreator
(X) org.jboss.arquillian.junit.standalone.LocalTestMethodExecutor
(E) ManagerStarted
	(O) ConfigurationRegistrar.loadConfiguration
	(E) ArquillianDescriptorImpl
		(O) AlgeronConsumerConfigurator.configure
		(E) AlgeronConsumerConfiguration
			(O) PactConsumerConfigurator.configure
			(E) PactConsumerConfiguration
				(O) PactReportDirectoryConfigurator.configurePactReportDirectory
(E) BeforeSuite
	(I) TestContextHandler.createSuiteContext
(E) BeforeClass
	(I) TestContextHandler.createSuiteContext
	(I) TestContextHandler.createClassContext
	(E) TestClass
	(O) MockProviderConfigCreator.create
	(E) MockProviderConfig
	(O) AllLifecycleEventExecutor.on
(E) RulesEnrichment
	(I) TestContextHandler.createSuiteContext
	(I) TestContextHandler.createClassContext
	(E) TestClass
	(I) TestContextHandler.createTestContext
	(O) RulesEnricher.enrichRulesAndTestInstance
	(O) AllLifecycleEventExecutor.on
(E) BeforeRules
	(I) TestContextHandler.createSuiteContext
	(I) TestContextHandler.createClassContext
	(E) TestClass
	(I) TestContextHandler.createTestContext
	(O) RulesEnricher.enrichStatement
	(E) BeforeEnrichment
	(E) AfterEnrichment
	(O) AllLifecycleEventExecutor.on
	(E) Before
		(I) TestContextHandler.createSuiteContext
		(I) TestContextHandler.createClassContext
		(E) TestClass
		(I) TestContextHandler.createTestContext
		(O) TestInstanceEnricher.enrich
		(E) BeforeEnrichment
		(E) AfterEnrichment
		(O) AllLifecycleEventExecutor.on
	(E) Test
		(I) TestContextHandler.createSuiteContext
		(I) TestContextHandler.createClassContext
		(E) TestClass
		(I) TestContextHandler.createTestContext
		(I) StandaloneConsumerPactTest.testPact
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
		(O) LocalTestMethodExecutor.execute
		(E) TestResult
	(E) After
		(I) TestContextHandler.createSuiteContext
		(I) TestContextHandler.createClassContext
		(E) TestClass
		(I) TestContextHandler.createTestContext
		(I) UpdateTestResultBeforeAfter.update
		(O) AllLifecycleEventExecutor.on
(E) AfterRules
	(I) TestContextHandler.createSuiteContext
	(I) TestContextHandler.createClassContext
	(E) TestClass
	(I) TestContextHandler.createTestContext
	(I) UpdateTestResultBeforeAfter.update
	(O) AllLifecycleEventExecutor.on
(E) AfterClass
	(I) TestContextHandler.createSuiteContext
	(I) TestContextHandler.createClassContext
	(E) TestClass
	(O) AllLifecycleEventExecutor.on
	(O) ContractsPublisherObserver.publish
(E) AfterSuite
	(I) TestContextHandler.createSuiteContext
(E) ManagerStopping
	(O) PactReportDirectoryConfigurator.unsetSystemProperty

Process finished with exit code 0

```