### PR TITLE
Now getting warning only with arquillian.debug=true for observer with null object

### DIFF
--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
@@ -137,7 +137,7 @@ public class ObserverImpl implements ObserverMethod, Comparable<ObserverMethod> 
         for (int i = 1; i < numberOfArguments; i++) {
             Class<?> argumentType = argumentTypes[i];
             arguments[i] = manager.resolve(argumentType);
-            if (arguments[i] == null) {
+            if (RuntimeLogger.DEBUG && arguments[i] == null) {
                 log.warning(String.format("Argument %d for %s.%s is null. It won't be invoked.", i,
                     getMethod().getDeclaringClass().getSimpleName(), getMethod().getName()));
             }


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, when some observer won't be invoked because some of its parameters is null, then there is printed a warning in the log. It is nothing interesting for the testers - it is useful only for developers of an arq extension, so using warn level is excessive.

#### Changes proposed in this pull request:

- Print the warning information only when arquillian.debug=true is used
