### PR TITLE
Fix the argument number on observer warning

### DIFF
--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
@@ -137,8 +137,8 @@ public class ObserverImpl implements ObserverMethod, Comparable<ObserverMethod> 
             final Class<?> argumentType = argumentTypes[i];
             arguments[i] = manager.resolve(argumentType);
             if (RuntimeLogger.DEBUG && arguments[i] == null) {
-                log.warning(String.format("Argument %d for %s#%s is null. Observer method won't be invoked.", i,
-                    getMethod().getDeclaringClass().getName(), getMethod().getName()));
+                log.warning(String.format("Argument %d (of type %s) for %s#%s is null. Observer method won't be invoked.", i+1,
+                    argumentType.getSimpleName(), getMethod().getDeclaringClass().getName(), getMethod().getName()));
             }
         }
         return arguments;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
@@ -137,7 +137,7 @@ public class ObserverImpl implements ObserverMethod, Comparable<ObserverMethod> 
             final Class<?> argumentType = argumentTypes[i];
             arguments[i] = manager.resolve(argumentType);
             if (RuntimeLogger.DEBUG && arguments[i] == null) {
-                log.warning(String.format("Argument %d (of type %s) for %s#%s is null. Observer method won't be invoked.", i+1,
+                log.warning(String.format("Argument %d (of type %s) for %s#%s is null. Observer method won't be invoked.", i + 1,
                     argumentType.getSimpleName(), getMethod().getDeclaringClass().getName(), getMethod().getName()));
             }
         }


### PR DESCRIPTION
Humans read arguments starting on 1, not 0.

Also, while on it, print the type of the null argument,
to make it easier to identify it.