### PR TITLE
ARQ-2143 - Allow testable to be overridden when throwing exception.

### DIFF
--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ShouldThrowException.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ShouldThrowException.java
@@ -37,8 +37,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * }
  * </code></pre>
  * <p>
- * Adding the @ShouldThrowException annotation will force the @{@link Deployment} to be testable = false which again
- * will force a @{@link RunAsClient} test run mode.
+ * Adding the @ShouldThrowException annotation will force the @{@link Deployment} to be <code>testable = false</code> which again
+ * will force a @{@link RunAsClient} test run mode, unless you explicitly mark <code>testable = true</code>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
@@ -48,4 +48,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(ElementType.METHOD)
 public @interface ShouldThrowException {
     Class<? extends Exception> value() default Exception.class;
+
+    /**
+     * @return whether or not this deployment is intended to be testable, default is false
+     */
+    boolean testable() default false;
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
@@ -120,8 +120,9 @@ public class AnnotationDeploymentScenarioGenerator implements DeploymentScenario
         }
 
         if (deploymentMethod.isAnnotationPresent(ShouldThrowException.class)) {
-            deployment.setExpectedException(deploymentMethod.getAnnotation(ShouldThrowException.class).value());
-            deployment.shouldBeTestable(false); // can't test against failing deployments
+            ShouldThrowException shouldThrowException = deploymentMethod.getAnnotation(ShouldThrowException.class);
+            deployment.setExpectedException(shouldThrowException.value());
+            deployment.shouldBeTestable(shouldThrowException.testable());
         }
 
         return deployment;

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGeneratorTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGeneratorTestCase.java
@@ -187,6 +187,22 @@ public class AnnotationDeploymentScenarioGeneratorTestCase {
     }
 
     @Test
+    public void shouldReadExpectedAndOverrideDeploymentWhenTestable() {
+        List<DeploymentDescription> scenario = generate(ExpectedDeploymentExceptionSetTestable.class);
+
+        Assert.assertNotNull(scenario);
+        Assert.assertEquals(
+            "Verify all deployments were found",
+            1, scenario.size());
+
+        DeploymentDescription deploymentOne = scenario.get(0);
+
+        Assert.assertEquals(true, deploymentOne.testable());
+        Assert.assertTrue(Validate.isArchiveOfType(JavaArchive.class, deploymentOne.getArchive()));
+        Assert.assertEquals(Exception.class, deploymentOne.getExpectedException());
+    }
+
+    @Test
     public void shouldAllowNoDeploymentPresent() throws Exception {
         List<DeploymentDescription> descriptors = generate(DeploymentNotPresent.class);
 
@@ -312,8 +328,17 @@ public class AnnotationDeploymentScenarioGeneratorTestCase {
 
     @SuppressWarnings("unused")
     private static class ExpectedDeploymentExceptionSet {
-        @Deployment(name = "second", testable = true) // testable should be overwritten by @Expected
+        @Deployment(name = "second", testable = true) // testable should be overwritten by @ShouldThrowException
         @ShouldThrowException
+        public static Archive<?> deploymentOne() {
+            return ShrinkWrap.create(JavaArchive.class);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ExpectedDeploymentExceptionSetTestable {
+        @Deployment(name = "second", testable = false)
+        @ShouldThrowException(testable = true)
         public static Archive<?> deploymentOne() {
             return ShrinkWrap.create(JavaArchive.class);
         }


### PR DESCRIPTION
#### Short description of what this resolves:

Makes it so that deployments that throw exceptions can be testable.

#### Changes proposed in this pull request:

- Adding new attribute on ShouldThrowException to indicate that it is testable
- Added new test for the case


Fixes # ARQ-2143

PS - Please give this some love.
