### PR TITLE
fix(ARQ-2169): removes exported directory if exists

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
@@ -74,12 +74,14 @@ public class ArchiveDeploymentExporter {
                 deployment = event.getDeployment().getArchive();
             }
 
+            final File fileToExport = new File(exportDir, createFileName(event.getDeployment(), deployment));
+            deleteIfExists(fileToExport);
+
             if (exportExploded) {
                 deployment.as(ExplodedExporter.class).exportExploded(
                     exportDir, createFileName(event.getDeployment(), deployment));
             } else {
-                deployment.as(ZipExporter.class).exportTo(
-                    new File(exportDir, createFileName(event.getDeployment(), deployment)),
+                deployment.as(ZipExporter.class).exportTo(fileToExport,
                     true);
             }
         }
@@ -88,5 +90,17 @@ public class ArchiveDeploymentExporter {
     private String createFileName(DeploymentDescription deployment, Archive<?> archive) {
         // TODO: where do we get TestClass name from ?
         return deployment.getTarget().getName() + "_" + deployment.getName() + "_" + archive.getName();
+    }
+
+    private void deleteIfExists(File file) {
+        if (!file.exists()) {
+            return;
+        }
+        if (file.isDirectory()) {
+            for (File sub : file.listFiles()) {
+                deleteIfExists(sub);
+            }
+        }
+        file.delete();
     }
 }

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.container.impl.client.deployment;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.logging.Logger;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.EngineDef;
@@ -92,7 +93,7 @@ public class ArchiveDeploymentExporter {
         return deployment.getTarget().getName() + "_" + deployment.getName() + "_" + archive.getName();
     }
 
-    private void deleteIfExists(File file) {
+    private void deleteIfExists(File file) throws IOException {
         if (!file.exists()) {
             return;
         }
@@ -101,6 +102,9 @@ public class ArchiveDeploymentExporter {
                 deleteIfExists(sub);
             }
         }
-        file.delete();
+
+        if (!file.delete()) {
+            throw new IOException("Failed to delete file: " + file);
+        }
     }
 }

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporterTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporterTestCase.java
@@ -141,6 +141,46 @@ public class ArchiveDeploymentExporterTestCase extends AbstractContainerTestBase
     }
 
     @Test
+    public void shouldBeDeleteAlreadyExportedDeploymentAndExportExplodedWhenDeploymentExportExplodedIsSet() throws Exception {
+        // given - To create exploded deployment
+        bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class).engine()
+            .deploymentExportPath(EXPORT_PATH)
+            .deploymentExportExploded(false));
+
+        fire(new BeforeDeploy(deployableContainer, deployment));
+
+        // when
+        bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class).engine()
+            .deploymentExportPath(EXPORT_PATH)
+            .deploymentExportExploded(true));
+
+        fire(new BeforeDeploy(deployableContainer, deployment));
+
+        // then
+        directoryShouldExist();
+    }
+
+    @Test
+    public void shouldBeDeleteAlreadyExplodedDeploymentAndExportDeploymentWhenDeploymentExportIsNotSet() throws Exception {
+        // given - To export deployment archive
+        bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class).engine()
+            .deploymentExportPath(EXPORT_PATH)
+            .deploymentExportExploded(true));
+
+        fire(new BeforeDeploy(deployableContainer, deployment));
+
+        // when
+        bind(ApplicationScoped.class, ArquillianDescriptor.class, Descriptors.create(ArquillianDescriptor.class).engine()
+            .deploymentExportPath(EXPORT_PATH)
+            .deploymentExportExploded(false));
+
+        fire(new BeforeDeploy(deployableContainer, deployment));
+
+        // then
+        fileShouldExist(true);
+    }
+
+    @Test
     public void shouldExportExplodedIfExportExplodedSystemPropertyIsSet() throws Exception {
         System.setProperty(ARQUILLIAN_DEPLOYMENT_EXPORT_PATH, EXPORT_PATH);
         System.setProperty(ARQUILLIAN_DEPLOYMENT_EXPORT_EXPLODED, "true");


### PR DESCRIPTION
#### Short description of what this resolves:
Removes exported/exploded directory if present before exporting directory.

#### Changes proposed in this pull request:

- Removes directory if present
- Add unit test.



**Fixes**: #151 (ARQ-2169)
