### PR TITLE
chore(ARQ-2172): merged the same runner and rule code to avoid code duplication

### DIFF
--- a/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManager.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManager.java
@@ -1,0 +1,64 @@
+package org.jboss.arquillian.junit;
+
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder;
+
+abstract class AdaptorManager {
+
+    void initializeAdaptor() throws Exception {
+        // first time we're being initialized
+        if (!State.hasTestAdaptor()) {
+            // no, initialization has been attempted before and failed, refuse
+            // to do anything else
+            if (State.hasInitializationException()) {
+                // failed on suite level, ignore children
+                // notifier.fireTestIgnored(getFailureDescription());
+                handleSuiteLevelFailure(State.getInitializationException());
+            } else {
+                try {
+                    // ARQ-1742 If exceptions happen during boot
+                    TestRunnerAdaptor adaptor = TestRunnerAdaptorBuilder
+                        .build();
+                    // don't set it if beforeSuite fails
+                    adaptor.beforeSuite();
+                    State.testAdaptor(adaptor);
+                } catch (Exception e) {
+                    // caught exception during BeforeSuite, mark this as failed
+                    State.caughtInitializationException(e);
+                    handleBeforeSuiteFailure(e);
+                }
+            }
+        }
+
+        if (State.hasTestAdaptor()) {
+            setAdaptor(State.getTestAdaptor());
+        }
+    }
+
+    protected void shutdown(TestRunnerAdaptor adaptor) {
+        State.runnerFinished();
+        try {
+            if (State.isLastRunner()) {
+                try {
+                    if (adaptor != null) {
+                        adaptor.afterSuite();
+                        adaptor.shutdown();
+                    }
+                } finally {
+                    State.clean();
+                }
+            }
+            setAdaptor(null);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not run @AfterSuite", e);
+        }
+    }
+
+    protected abstract void handleSuiteLevelFailure(Throwable initializationException);
+
+    protected abstract void handleBeforeSuiteFailure(Exception e) throws Exception;
+
+    protected abstract void setAdaptor(TestRunnerAdaptor testRunnerAdaptor);
+
+    protected abstract TestRunnerAdaptor getAdaptor();
+}

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManager.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManager.java
@@ -35,7 +35,7 @@ abstract class AdaptorManager {
         }
     }
 
-    protected void shutdown(TestRunnerAdaptor adaptor) {
+    void shutdown(TestRunnerAdaptor adaptor) {
         State.runnerFinished();
         try {
             if (State.isLastRunner()) {

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManagerWithNotifier.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/AdaptorManagerWithNotifier.java
@@ -1,0 +1,47 @@
+package org.jboss.arquillian.junit;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+
+abstract class AdaptorManagerWithNotifier extends AdaptorManager {
+
+    private final RunNotifier notifier;
+
+    AdaptorManagerWithNotifier(RunNotifier notifier){
+        this.notifier = notifier;
+    }
+
+    void initializeAdaptor() {
+        try {
+            super.initializeAdaptor();
+        } catch (Exception e) {
+            // this never happens
+        }
+    }
+
+    void prepareDestroyAdaptorProcess(){
+        notifier.addListener(new RunListener() {
+            @Override
+            public void testRunFinished(Result result) throws Exception {
+                shutdown(getAdaptor());
+            }
+        });
+    }
+
+    protected void handleSuiteLevelFailure(Throwable initializationException) {
+        notifier.fireTestFailure(
+            new Failure(getFailureDescription(),
+                new RuntimeException(
+                    "Arquillian initialization has already been attempted, but failed. See previous exceptions for cause",
+                    initializationException)));
+    }
+
+    protected void handleBeforeSuiteFailure(Exception e) throws Exception {
+        notifier.fireTestFailure(new Failure(getFailureDescription(), e));
+    }
+
+    protected abstract Description getFailureDescription();
+}

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/ArquillianTestClass.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/ArquillianTestClass.java
@@ -1,8 +1,6 @@
 package org.jboss.arquillian.junit;
 
-import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
-import org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -28,57 +26,21 @@ public class ArquillianTestClass implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                State.runnerStarted();
-                // first time we're being initialized
-                if (!State.hasTestAdaptor()) {
-                    // no, initialization has been attempted before and failed, refuse
-                    // to do anything else
-                    if (State.hasInitializationException()) {
-                        // failed on suite level, ignore children
-                        // notifier.fireTestIgnored(getDescription());
-                        throw new RuntimeException(
-                            "Arquillian initialization has already been attempted, but failed. See previous exceptions for cause",
-                                State.getInitializationException());
-                    } else {
-                        try {
-                            // ARQ-1742 If exceptions happen during boot
-                            TestRunnerAdaptor adaptor = TestRunnerAdaptorBuilder
-                                    .build();
-                            // don't set it if beforeSuite fails
-                            adaptor.beforeSuite();
-                            State.testAdaptor(adaptor);
-                        } catch (Exception e) {
-                            // caught exception during BeforeSuite, mark this as failed
-                            State.caughtInitializationException(e);
-                            State.runnerFinished();
-                            if (State.isLastRunner()) {
-                                State.clean();
-                            }
-                            throw e;
+                ArquillianTestClassLifecycleManager arquillian =
+                    new ArquillianTestClassLifecycleManager() {
+                        protected void setAdaptor(TestRunnerAdaptor testRunnerAdaptor) {
+                            adaptor = testRunnerAdaptor;
                         }
-                    }
-                }
 
-                // initialization ok, run children
-                if (State.hasTestAdaptor()) {
-                    adaptor = State.getTestAdaptor();
-                }
-
-                adaptor.beforeClass(description.getTestClass(), LifecycleMethodExecutor.NO_OP);
+                        protected TestRunnerAdaptor getAdaptor() {
+                            return adaptor;
+                        }
+                    };
+                arquillian.beforeTestClassPhase(description.getTestClass());
                 try {
                     base.evaluate();
                 } finally {
-                    adaptor.afterClass(description.getTestClass(), LifecycleMethodExecutor.NO_OP);
-                    State.runnerFinished();
-                    if (State.isLastRunner()) {
-                        try {
-                            adaptor.afterSuite();
-                            adaptor.shutdown();
-                        } finally {
-                            State.clean();
-                        }
-                    }
-                    adaptor = null;
+                    arquillian.afterTestClassPhase(description.getTestClass());
                 }
             }
         };

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/ArquillianTestClassLifecycleManager.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/ArquillianTestClassLifecycleManager.java
@@ -1,0 +1,38 @@
+package org.jboss.arquillian.junit;
+
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+
+abstract class ArquillianTestClassLifecycleManager extends AdaptorManager {
+
+    protected void handleSuiteLevelFailure(Throwable initializationException) {
+        throw new RuntimeException(
+            "Arquillian initialization has already been attempted, but failed. See previous exceptions for cause",
+            initializationException);
+    }
+
+    protected void handleBeforeSuiteFailure(Exception e) throws Exception {
+        State.runnerFinished();
+        if (State.isLastRunner()) {
+            State.clean();
+        }
+        throw e;
+    }
+
+
+    void beforeTestClassPhase(Class<?> testClass) throws Exception {
+        State.runnerStarted();
+        initializeAdaptor();
+
+        // initialization ok, run children
+        if (State.hasTestAdaptor()) {
+            setAdaptor(State.getTestAdaptor());
+        }
+
+        getAdaptor().beforeClass(testClass, LifecycleMethodExecutor.NO_OP);
+    }
+
+    void afterTestClassPhase(Class<?> testClass) throws Exception {
+        getAdaptor().afterClass(testClass, LifecycleMethodExecutor.NO_OP);
+        shutdown(getAdaptor());
+    }
+}

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
@@ -1,0 +1,41 @@
+package org.jboss.arquillian.junit;
+
+import java.lang.reflect.Method;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.execution.SkippedTestExecutionException;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.runners.model.FrameworkMethod;
+
+abstract class MethodInvoker {
+
+    void invoke(final TestRunnerAdaptor adaptor, final FrameworkMethod method,
+        final Object test) throws Throwable {
+        TestResult result = adaptor.test(new TestMethodExecutor() {
+            @Override
+            public void invoke(Object... parameters) throws Throwable {
+                invokeMethod(parameters);
+            }
+
+            public Method getMethod() {
+                return method.getMethod();
+            }
+
+            public Object getInstance() {
+                return test;
+            }
+        });
+        Throwable throwable = result.getThrowable();
+        if (throwable != null) {
+            if (result.getStatus() == TestResult.Status.SKIPPED) {
+                if (throwable instanceof SkippedTestExecutionException) {
+                    result.setThrowable(new AssumptionViolatedException(throwable.getMessage()));
+                }
+            }
+            throw result.getThrowable();
+        }
+    }
+
+    abstract void invokeMethod(Object... parameters) throws Throwable;
+}


### PR DESCRIPTION
#### Short description of what this resolves:

The code of the `TestRunnerAdaptor` management is same in both JUnit runner and JUnit class rule. The same can be also applied to the logic that invokes the test method. 
I've moved the code to separated classes that are used by both implementations. As a benefit:
* we don't duplicate the code
* it is guaranteed that when the code is changed, it will affect both implementations.

When I was doing the refactoring, I've noticed that in the rule implementations there was missing enrichment of the other rules used in the test class:
```java
adaptor.fireCustomLifecycle(new RulesEnrichment(target, testClass, testMethod, LifecycleMethodExecutor.NO_OP));
```
So I added it there.

