### PR TITLE
updates testng to 6.14.0

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -26,8 +26,9 @@
     <version.javax.inject>1</version.javax.inject>
     <version.junit>4.12</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
-    <version.jcommander>1.69</version.jcommander>
-    <version.testng>6.13.1</version.testng>
+
+    <!--<version.testng>6.8.1</version.testng>-->
+    <version.testng>6.14.0</version.testng>
     <version.assertj>2.5.0</version.assertj>
   </properties>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -27,7 +27,7 @@
     <version.junit>4.12</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
     <version.jcommander>1.69</version.jcommander>
-    <version.testng>6.13</version.testng>
+    <version.testng>6.13.1</version.testng>
     <version.assertj>2.5.0</version.assertj>
   </properties>
 
@@ -60,14 +60,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
-        <scope>test</scope>
-      </dependency>
-      <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
-      <!-- JCommander 1.66 is missing in Maven Central, thus taking newer one first -->
-      <dependency>
-        <groupId>com.beust</groupId>
-        <artifactId>jcommander</artifactId>
-        <version>1.69</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -27,8 +27,7 @@
     <version.junit>4.12</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
 
-    <!--<version.testng>6.8.1</version.testng>-->
-    <version.testng>6.14.0</version.testng>
+    <version.testng>6.14.2</version.testng>
     <version.assertj>2.5.0</version.assertj>
   </properties>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -26,7 +26,7 @@
     <version.javax.inject>1</version.javax.inject>
     <version.junit>4.12</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
-    <version.testng>6.14.2</version.testng>
+    <version.testng>6.14.3</version.testng>
     <version.jcommander>1.69</version.jcommander>
     <version.assertj>2.9.0</version.assertj>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,15 @@
     <tag>HEAD</tag>
   </scm>
 
+  <!--To remove -->
+  <repositories>
+    <repository>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>http://jcenter.bintray.com</url>
+    </repository>
+  </repositories>
+
   <modules>
     <module>build</module>
     <module>core</module>

--- a/testng/container/pom.xml
+++ b/testng/container/pom.xml
@@ -82,10 +82,17 @@
       <version>1.73</version>
       <scope>provided</scope>
     </dependency>
+    
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.beust</groupId>
+          <artifactId>jcommander</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- External Projects -->

--- a/testng/container/pom.xml
+++ b/testng/container/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>1.73</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>provided</scope>

--- a/testng/container/pom.xml
+++ b/testng/container/pom.xml
@@ -76,12 +76,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppenderTestCase.java
+++ b/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppenderTestCase.java
@@ -43,5 +43,11 @@ public class TestNGDeploymentAppenderTestCase {
             archive.contains(ArchivePaths.create("/org/jboss/arquillian/testng/container/TestNGTestRunner.class")));
 
         System.out.println(archive.toString(true));
+
+        Assert.assertTrue(archive.contains("/org/testng"));
+        Assert.assertTrue(archive.contains("/bsh"));
+        Assert.assertTrue(archive.contains("/org/jboss/arquillian/testng"));
+        Assert.assertTrue(archive.contains("/com/beust"));
+        Assert.assertTrue(archive.contains("/com/beust/jcommander"));
     }
 }

--- a/testng/core/pom.xml
+++ b/testng/core/pom.xml
@@ -33,11 +33,23 @@
       <artifactId>arquillian-test-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>1.73</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.beust</groupId>
+          <artifactId>jcommander</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test -->

--- a/testng/core/pom.xml
+++ b/testng/core/pom.xml
@@ -34,13 +34,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- External Projects -->
-    <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>


### PR DESCRIPTION
#### Short description of what this resolves:
Updates testng to `6.14.0` and removes  `jcommander`

Note: Build for this PR will fail as latest TestNG has issues [[1]](https://github.com/cbeust/testng/issues/1677) & [[2]](https://github.com/cbeust/jcommander/issues/430)

