### PR TITLE
feat(ARQ-2174): Added Observer annotation for specifying an Arquillian observer  for the given test class

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,6 +47,7 @@ include::{asciidoctor-source}/rules.adoc[]
 include::{asciidoctor-source}/additional-features.adoc[]
 include::{asciidoctor-source}/protocols.adoc[]
 include::{asciidoctor-source}/build-integration.adoc[]
+include::{asciidoctor-source}/advanced-topics.adoc[]
 endif::generated-doc[]
 
 == Useful URLs

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
@@ -41,6 +41,7 @@ import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observer;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.test.spi.TestClass;
@@ -169,6 +170,7 @@ public class DeploymentGenerator {
                 if (ClassContainer.class.isInstance(applicationArchive)) {
                     ClassContainer<?> classContainer = ClassContainer.class.cast(applicationArchive);
                     classContainer.addClass(testCase.getJavaClass());
+                    addAdditionalObserverClass(classContainer, testCase.getJavaClass());
                 }
             } catch (UnsupportedOperationException e) {
             /*
@@ -183,6 +185,15 @@ public class DeploymentGenerator {
                     new TestDeployment(deployment.getDescription(), applicationArchive, auxiliaryArchives),
                     serviceLoader.get().all(ProtocolArchiveProcessor.class)));
         }
+    }
+
+    private void addAdditionalObserverClass(ClassContainer<?> classContainer, Class<?> testClass){
+        if (testClass.isAnnotationPresent(Observer.class)) {
+            Observer annotation = testClass.getAnnotation(Observer.class);
+            Class<?> value = annotation.value();
+            classContainer.addClass(value);
+        }
+
     }
 
     private List<Archive<?>> loadAuxiliaryArchives(DeploymentDescription deployment) {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
@@ -170,7 +170,7 @@ public class DeploymentGenerator {
                 if (ClassContainer.class.isInstance(applicationArchive)) {
                     ClassContainer<?> classContainer = ClassContainer.class.cast(applicationArchive);
                     classContainer.addClass(testCase.getJavaClass());
-                    addAdditionalObserverClassIfPresent(classContainer, testCase.getJavaClass());
+                    addAdditionalObserverClassesIfPresent(classContainer, testCase.getJavaClass());
                 }
             } catch (UnsupportedOperationException e) {
             /*
@@ -187,11 +187,13 @@ public class DeploymentGenerator {
         }
     }
 
-    private void addAdditionalObserverClassIfPresent(ClassContainer<?> classContainer, Class<?> testClass){
+    private void addAdditionalObserverClassesIfPresent(ClassContainer<?> classContainer, Class<?> testClass){
         if (testClass.isAnnotationPresent(Observer.class)) {
             Observer annotation = testClass.getAnnotation(Observer.class);
-            Class<?> value = annotation.value();
-            classContainer.addClass(value);
+            Class<?>[] classes = annotation.value();
+            for (Class<?> observerClass : classes) {
+                classContainer.addClass(observerClass);
+            }
         }
 
     }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
@@ -170,7 +170,7 @@ public class DeploymentGenerator {
                 if (ClassContainer.class.isInstance(applicationArchive)) {
                     ClassContainer<?> classContainer = ClassContainer.class.cast(applicationArchive);
                     classContainer.addClass(testCase.getJavaClass());
-                    addAdditionalObserverClass(classContainer, testCase.getJavaClass());
+                    addAdditionalObserverClassIfPresent(classContainer, testCase.getJavaClass());
                 }
             } catch (UnsupportedOperationException e) {
             /*
@@ -187,7 +187,7 @@ public class DeploymentGenerator {
         }
     }
 
-    private void addAdditionalObserverClass(ClassContainer<?> classContainer, Class<?> testClass){
+    private void addAdditionalObserverClassIfPresent(ClassContainer<?> classContainer, Class<?> testClass){
         if (testClass.isAnnotationPresent(Observer.class)) {
             Observer annotation = testClass.getAnnotation(Observer.class);
             Class<?> value = annotation.value();

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGeneratorTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGeneratorTestCase.java
@@ -135,20 +135,23 @@ public class DeploymentGeneratorTestCase extends AbstractContainerTestTestBase {
     }
 
     @Test
-    public void shouldAddAdditionalObserverClass() {
+    public void shouldAddAdditionalObserverClasses() {
         addContainer("test-contianer").getContainerConfiguration().setMode("suite");
         addProtocol(PROTOCOL_NAME_1, true);
 
         fire(createEvent(DeploymentWithObserver.class));
 
         DeploymentScenario scenario = getManager().resolve(DeploymentScenario.class);
-        String testClassPath = DeploymentWithObserver.class.getName().replace(".", "/") + ".class";
-        String observerPath = ObserverClass.class.getName().replace(".", "/") + ".class";
         Archive<?> archive = scenario.deployments().get(0).getDescription().getArchive();
-        Assert.assertTrue(String.format("archive %s should contain the path %s", archive.toString(true), testClassPath),
-            archive.contains(testClassPath));
-        Assert.assertTrue(String.format("archive %s should contain the path %s", archive.toString(true), observerPath),
-            archive.contains(observerPath));
+        verifyThatIsContainedInArchive(archive, DeploymentWithObserver.class);
+        verifyThatIsContainedInArchive(archive, ObserverClass.class);
+        verifyThatIsContainedInArchive(archive, SecondObserverClass.class);
+    }
+
+    private void verifyThatIsContainedInArchive(Archive<?> archive, Class<?> clazz) {
+        String classPath = clazz.getName().replace(".", "/") + ".class";
+        Assert.assertTrue(String.format("archive %s should contain the path %s", archive.toString(true), classPath),
+            archive.contains(classPath));
     }
 
     @Test
@@ -360,7 +363,7 @@ public class DeploymentGeneratorTestCase extends AbstractContainerTestTestBase {
         }
     }
 
-    @Observer(ObserverClass.class)
+    @Observer({ObserverClass.class, SecondObserverClass.class})
     private static class DeploymentWithObserver {
         @SuppressWarnings("unused")
         @Deployment
@@ -370,6 +373,9 @@ public class DeploymentGeneratorTestCase extends AbstractContainerTestTestBase {
     }
 
     private static class ObserverClass {
+    }
+
+    private static class SecondObserverClass {
     }
 
     private static class DeploymentMultipleNoNamed {

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * An annotation to specify an arquillian observer (class that contains a method with annotation {@link Observes}) for
+ * An annotation to specify an Arquillian observer (class that contains a method with annotation {@link Observes}) for
  * test class - it will observe all events starting with {@code org.jboss.arquillian.test.spi.event.suite.BeforeClass}
  * and ending with {@code org.jboss.arquillian.test.spi.event.suite.AfterClass}.
  * It will behave as any other Arquillian observer - it will be supported by dependency injection for Arquillian extensions.

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
@@ -1,0 +1,23 @@
+package org.jboss.arquillian.core.api.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An annotation to specify an arquillian observer (class that contains a method with annotation {@link Observes}) for
+ * test class - it will observe all events starting with {@code org.jboss.arquillian.test.spi.event.suite.BeforeClass}
+ * and ending with {@code org.jboss.arquillian.test.spi.event.suite.AfterClass}.
+ * It will behave as any other Arquillian observer - it will be supported by dependency injection for Arquillian extensions.
+ * The observer specified in this annotation has to have a non-parametric constructor.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Observer {
+
+    Class<?> value();
+}

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observer.java
@@ -8,16 +8,16 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * An annotation to specify an Arquillian observer (class that contains a method with annotation {@link Observes}) for
- * test class - it will observe all events starting with {@code org.jboss.arquillian.test.spi.event.suite.BeforeClass}
+ * An annotation to specify one or more Arquillian observers (class that contains a method with annotation {@link Observes})
+ * for test class - it will observe all events starting with {@code org.jboss.arquillian.test.spi.event.suite.BeforeClass}
  * and ending with {@code org.jboss.arquillian.test.spi.event.suite.AfterClass}.
- * It will behave as any other Arquillian observer - it will be supported by dependency injection for Arquillian extensions.
- * The observer specified in this annotation has to have a non-parametric constructor.
+ * These observers will behave as any other Arquillian observer - it will be supported by dependency injection for Arquillian
+ * extensions. The observer specified in this annotation has to have a non-parametric constructor.
  */
 @Documented
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Observer {
 
-    Class<?> value();
+    Class<?>[] value();
 }

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
@@ -320,6 +320,23 @@ public class ManagerImpl implements Manager {
         this.contexts.addAll(createContexts(contexts));
     }
 
+    public void addExtension(Class<?> extensionClass) throws Exception {
+        runtimeLogger.debugExtension(extensionClass);
+        ExtensionImpl newExtension = ExtensionImpl.of(Reflections.createInstance(extensionClass));
+        inject(newExtension);
+        extensions.add(newExtension);
+    }
+
+    public void removeExtension(Class<?> extensionClass) {
+        for (Extension extension : extensions) {
+            Object target = ((ExtensionImpl) extension).getTarget();
+            if (extensionClass.isInstance(target)) {
+                extensions.remove(extension);
+                break;
+            }
+        }
+    }
+
     boolean isExceptionHandled(Throwable e) {
         return handledThrowables.get().contains(e.getClass());
     }

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
@@ -46,4 +46,10 @@ public interface Manager {
 
     // clean
     void shutdown();
+
+    // adds extension specified via annotation @Observer
+    void addExtension(Class<?> extension) throws Exception;
+
+    // removes extension specified via annotation @Observer
+    void removeExtension(Class<?> extension) throws Exception;
 }

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
@@ -47,9 +47,7 @@ public interface Manager {
     // clean
     void shutdown();
 
-    // adds extension specified via annotation @Observer
     void addExtension(Class<?> extension) throws Exception;
 
-    // removes extension specified via annotation @Observer
     void removeExtension(Class<?> extension) throws Exception;
 }

--- a/docs/advanced-topics.adoc
+++ b/docs/advanced-topics.adoc
@@ -22,7 +22,8 @@ The output has four types of information - you can distinguish them by their pre
 
 === Test Observer
 
-In case you need to observe one or more Arquillian events and you don't want to deal with the whole SPI machinery, you can use the annotation `@Observer` at your test class and observe any Arquillian event in the context of the related test class (starting with `BeforeClass` and ending with `AfterClass`):
+In case you need to add an additional logic to the whole test suite, you can use Arquillian SPI and create your own Arquillian extension. But this extension is applied to all test classes.
+In case you want to add an additional observer that will be applied only to one specific test class, then you can use an annotation `@Observer` at the test class level. This will use the specified class(es) as Arquillian observer(s) and observe any Arquillian event in the context of the related test class that you need (starting with `BeforeClass` and ending with `AfterClass`):
 
 [source,java]
 ----
@@ -31,7 +32,7 @@ In case you need to observe one or more Arquillian events and you don't want to 
 public class MyTestCase {
 ----
 
-The Arquillian observer class has to have a non-parametric constructor and the the observer method you can define by `@Observes` annotation:
+The Arquillian observer class has to have a non-parametric constructor and the observer method should be defined by `@Observes` annotation:
 
 [source,java]
 ----

--- a/docs/advanced-topics.adoc
+++ b/docs/advanced-topics.adoc
@@ -1,0 +1,41 @@
+ifdef::env-github,env-browser[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+:outfilesuffix: .adoc
+endif::[]
+
+== Advanced Topics
+
+=== Debugging
+
+If you are struggling with running your Arquillian test and you need more info about what is going on underneath, then you can specify `-Darquillian.debug=true`. Arquillian will print out its lifecycle so you will know exactly where it got stuck.
+The output has four types of information - you can distinguish them by their prefix:
+
+* (E) Arquillian event that was fired
+* (I) Arquillian interceptor that observed the related event context
+* (O) Arquillian observer that observed the related event
+* (X) Arquillian extension that was registered
+
+
+=== Test Observer
+
+In case you need to observe one or more Arquillian events and you don't want to deal with the whole SPI machinery, you can use the annotation `@Observer` at your test class and observe any Arquillian event in the context of the related test class (starting with `BeforeClass` and ending with `AfterClass`):
+
+[source,java]
+----
+@RunWith(Arquillian.class)
+@Observer(MyObserver.class)
+public class MyTestCase {
+----
+
+The Arquillian observer class has to have a non-parametric constructor and the the observer method you can define by `@Observes` annotation:
+
+[source,java]
+----
+public void observeBeforeClass(@Observes BeforeClass event) {
+    ...
+}
+----

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
@@ -80,9 +80,9 @@ public class EventTestRunnerAdaptor implements TestRunnerAdaptor {
 
         if (testClass.isAnnotationPresent(Observer.class)) {
             Observer annotation = testClass.getAnnotation(Observer.class);
-            Class<?> value = annotation.value();
-            if (value != null) {
-                manager.addExtension(value);
+            Class<?>[] classes = annotation.value();
+            for (Class<?> observerClass : classes) {
+                manager.addExtension(observerClass);
             }
         }
 
@@ -96,9 +96,9 @@ public class EventTestRunnerAdaptor implements TestRunnerAdaptor {
 
         if (testClass.isAnnotationPresent(Observer.class)) {
             Observer annotation = testClass.getAnnotation(Observer.class);
-            Class<?> value = annotation.value();
-            if (value != null) {
-                manager.removeExtension(value);
+            Class<?>[] classes = annotation.value();
+            for (Class<?> observerClass : classes) {
+                manager.removeExtension(observerClass);
             }
         }
     }

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observer;
 import org.jboss.arquillian.core.spi.Manager;
 import org.jboss.arquillian.core.spi.ManagerBuilder;
 import org.jboss.arquillian.core.spi.NonManagedObserver;
@@ -77,6 +78,14 @@ public class EventTestRunnerAdaptor implements TestRunnerAdaptor {
     public void beforeClass(Class<?> testClass, LifecycleMethodExecutor executor) throws Exception {
         Validate.notNull(testClass, "TestClass must be specified");
 
+        if (testClass.isAnnotationPresent(Observer.class)) {
+            Observer annotation = testClass.getAnnotation(Observer.class);
+            Class<?> value = annotation.value();
+            if (value != null) {
+                manager.addExtension(value);
+            }
+        }
+
         manager.fire(new BeforeClass(testClass, executor));
     }
 
@@ -84,6 +93,14 @@ public class EventTestRunnerAdaptor implements TestRunnerAdaptor {
         Validate.notNull(testClass, "TestClass must be specified");
 
         manager.fire(new AfterClass(testClass, executor));
+
+        if (testClass.isAnnotationPresent(Observer.class)) {
+            Observer annotation = testClass.getAnnotation(Observer.class);
+            Class<?> value = annotation.value();
+            if (value != null) {
+                manager.removeExtension(value);
+            }
+        }
     }
 
     public void before(Object testInstance, Method testMethod, LifecycleMethodExecutor executor) throws Exception {

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/AdditionalTestClassObserverTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/AdditionalTestClassObserverTestCase.java
@@ -1,0 +1,85 @@
+package org.jboss.arquillian.test.impl;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observer;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.annotation.ClassScoped;
+import org.jboss.arquillian.test.test.AbstractTestTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AdditionalTestClassObserverTestCase extends AbstractTestTestBase {
+
+    @Test
+    public void should_add_observer_to_list_of_extensions() throws Exception {
+        // given
+        EventTestRunnerAdaptor adaptor = new EventTestRunnerAdaptor(getManager());
+
+        // when
+        adaptor.beforeClass(TestClassWithObserver.class, LifecycleMethodExecutor.NO_OP);
+
+        // then
+        ObserverClass extension = getManager().getExtension(ObserverClass.class);
+        Assert.assertNotNull("the extension of type " + ObserverClass.class.getName() + " should be present", extension);
+    }
+
+    @Test
+    public void should_remove_observer_from_list_of_extensions_in_after_class_phase() throws Exception {
+        // given
+        EventTestRunnerAdaptor adaptor = new EventTestRunnerAdaptor(getManager());
+        adaptor.beforeClass(TestClassWithObserver.class, LifecycleMethodExecutor.NO_OP);
+
+        // when
+        adaptor.afterClass(TestClassWithObserver.class, LifecycleMethodExecutor.NO_OP);
+
+        // then
+        ObserverClass extension = getManager().getExtension(ObserverClass.class);
+        Assert.assertNull("The extension of type " + ObserverClass.class.getName() + " should NOT be present", extension);
+    }
+
+    @Test
+    public void should_invoke_additionally_added_observer_and_inject_value_to_variable() throws Exception {
+        // given
+        EventTestRunnerAdaptor adaptor = new EventTestRunnerAdaptor(getManager());
+        adaptor.beforeClass(TestClassWithObserver.class, LifecycleMethodExecutor.NO_OP);
+        InvokedInfo invokedInfo = new InvokedInfo();
+        getManager().bind(ClassScoped.class, InvokedInfo.class, invokedInfo);
+
+        // when
+        getManager().fire(new MyEvent());
+
+        // then
+        Assert.assertTrue("The observer should be invoked but wasn't", invokedInfo.isInvoked());
+    }
+
+    @Observer(ObserverClass.class)
+    private static class TestClassWithObserver {
+    }
+
+    private static class ObserverClass {
+        @Inject
+        private Instance<InvokedInfo> invokedInfoInstance;
+
+        void observe(@Observes MyEvent event) {
+            invokedInfoInstance.get().setInvoked(true);
+        }
+    }
+
+    private static class MyEvent {
+    }
+
+    private static class InvokedInfo {
+
+        private boolean invoked = false;
+
+        private boolean isInvoked() {
+            return invoked;
+        }
+
+        private void setInvoked(boolean invoked) {
+            this.invoked = invoked;
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

In case a user needs to observe one or more Arquillian events and he doesn't want to deal with the whole SPI machinery (to create a new Arquillian extension), then it is  possible to use a new annotation `@Observer` at the test class and observe any Arquillian event in the context of the related test class that he need (starting with `BeforeClass` and ending with `AfterClass`):

