### PR TITLE
fix(ARQ-2175): exception handling in case DeploymentException.getCause

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandler.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandler.java
@@ -103,7 +103,7 @@ public class DeploymentExceptionHandler {
 
     private Throwable transform(Throwable exception) {
         Throwable toBeTransformed = exception;
-        if (exception instanceof DeploymentException) {
+        if (exception instanceof DeploymentException && exception.getCause() != null) {
             toBeTransformed = exception.getCause();
         }
         Collection<DeploymentExceptionTransformer> transformers =

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandlerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandlerTestCase.java
@@ -98,6 +98,20 @@ public class DeploymentExceptionHandlerTestCase extends AbstractContainerTestBas
     }
 
     @Test
+    public void shouldCallDeploymentTransformersWithEmptyCauseException() throws Exception {
+        TestExceptionDeployThrower.shouldThrow =
+            new DeploymentException("Could not handle ba", null);
+        Mockito.when(serviceLoader.all(DeploymentExceptionTransformer.class))
+            .thenReturn(Collections.singletonList(transformer));
+
+        fire(new DeployDeployment(
+            container,
+            new Deployment(new DeploymentDescription("test", ShrinkWrap.create(JavaArchive.class))
+                .setExpectedException(DeploymentException.class))));
+        Mockito.verify(transformer, Mockito.times(1)).transform(TestExceptionDeployThrower.shouldThrow);
+    }
+
+    @Test
     public void shouldTransformException() throws Exception {
         TestExceptionDeployThrower.shouldThrow = new IllegalStateException();
         Mockito.when(serviceLoader.all(DeploymentExceptionTransformer.class))


### PR DESCRIPTION
…returns null."

Issue link - https://issues.jboss.org/browse/ARQ-2175

#### Short description of what this resolves:

Fixes possible `null` value handed over to exception transformers.

#### Changes proposed in this pull request:

`DeploymentExceptionHandler` should never pass `null` value to transformers.
This is a possible scenario when the exception in question is `DeploymentException` and when it has either no cause set or the cause is itself (is which case `getCause()` returns null).

Test attached.

@MatousJobanek I find this to be the least painful solution to the issue we discussed earlier. Please review.
