### PR TITLE
chore: exposes Arquillian Descriptor to be used in extensions. 

### DIFF
--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
@@ -59,6 +59,20 @@ public class ConfigurationRegistrar {
     private Instance<ServiceLoader> serviceLoaderInstance;
 
     public void loadConfiguration(@Observes ManagerStarted event) {
+        //Placeholder resolver
+        ArquillianDescriptor resolvedDesc = loadConfiguration();
+
+        final List<ConfigurationPlaceholderResolver> configurationPlaceholderResolvers =
+            loadAndOrderPlaceholderResolvers();
+
+        for (ConfigurationPlaceholderResolver configurationPlaceholderResolver : configurationPlaceholderResolvers) {
+            resolvedDesc = configurationPlaceholderResolver.resolve(resolvedDesc);
+        }
+
+        descriptorInst.set(resolvedDesc);
+    }
+
+    public ArquillianDescriptor loadConfiguration() {
         final InputStream input = FileUtils.loadArquillianXml(ARQUILLIAN_XML_PROPERTY, ARQUILLIAN_XML_DEFAULT);
 
         //First arquillian.xml is resolved
@@ -75,17 +89,7 @@ public class ConfigurationRegistrar {
         envProperties.putAll(systemEnvironmentVars);
         propertiesParser.addProperties(descriptor, envProperties);
 
-        //Placeholder resolver
-        ArquillianDescriptor resolvedDesc = descriptor;
-
-        final List<ConfigurationPlaceholderResolver> configurationPlaceholderResolvers =
-            loadAndOrderPlaceholderResolvers();
-
-        for (ConfigurationPlaceholderResolver configurationPlaceholderResolver : configurationPlaceholderResolvers) {
-            resolvedDesc = configurationPlaceholderResolver.resolve(resolvedDesc);
-        }
-
-        descriptorInst.set(resolvedDesc);
+        return descriptor;
     }
 
     private List<ConfigurationPlaceholderResolver> loadAndOrderPlaceholderResolvers() {


### PR DESCRIPTION
#### Short description of what this resolves:
Exposes Arquillian Descriptor to extract extension configuration in Arquillian Cube. 

#### Changes proposed in this pull request:

- refactors `loadConfiguration()` to expose `Arquillian Descriptor`

Fixes https://github.com/arquillian/arquillian-cube/issues/984
