### PR TITLE
fix(#166): removes duplicate service from ContainerTestExtension to fix illegal argument exception.

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.test.impl.client.LocalCommandService;
 import org.jboss.arquillian.container.test.impl.client.container.ClientContainerControllerCreator;
 import org.jboss.arquillian.container.test.impl.client.container.ContainerRestarter;
 import org.jboss.arquillian.container.test.impl.client.container.command.ContainerCommandObserver;
-import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.container.test.impl.client.deployment.AutomaticDeploymentScenarioGenerator;
 import org.jboss.arquillian.container.test.impl.client.deployment.ClientDeployerCreator;
 import org.jboss.arquillian.container.test.impl.client.deployment.DeploymentGenerator;
@@ -84,7 +83,6 @@ public class ContainerTestExtension implements LoadableExtension {
             .service(ResourceProvider.class, DeployerProvider.class)
             .service(ResourceProvider.class, InitialContextProvider.class)
             .service(ResourceProvider.class, ContainerControllerProvider.class)
-            .service(DeploymentScenarioGenerator.class, AnnotationDeploymentScenarioGenerator.class)
             .service(DeploymentScenarioGenerator.class, AutomaticDeploymentScenarioGenerator.class);
 
         builder.observer(ContainerEventController.class)


### PR DESCRIPTION
#### Short description of what this resolves:

Service registered twice in `ContainerTestExtension` leading to `Illegal Argument Exception` thrown due to multiple deployments using the same name: "_DEFAULT_".

#### Changes proposed in this pull request:

- removes duplicate service from ContainerTestExtension

Fixes #166 
