### PR TITLE
Fix for ignored runtime exception in runner.run() method

### DIFF
--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
@@ -46,7 +46,12 @@ public class TestNGTestRunner implements TestRunner {
         runner.setXmlSuites(
             Collections.singletonList(createSuite(testClass, methodName)));
 
-        runner.run();
+        //we catch problems in executing run method, e.g. ClassDefNotFoundError and wrap it in TestResult
+        try {
+            runner.run();
+        } catch (Throwable ex) {
+            return TestResult.failed(ex);
+        }
 
         return resultListener.getTestResult();
     }


### PR DESCRIPTION
#### Short description of what this resolves:
I would like to propose a fix for a problem that when there is a runtime exception or error while running runner.run() method in TestNGRunner, the problem is ignored.

If someone omits required runtime class in a deployment archive there will be ClassDefNotFoundError when executing run() method in TestNGRunner. Arquillian servlet will return HTTP code 500 which is ignored in servlet protocol runner and consequently returned as a test which passed. But in reality the test did not even run and should be marked as failed.

#### Changes proposed in this pull request:
I propose a fix which catches runtime exceptions and errors while executing runner.run() method and envelope it in TestResult.failed() so it is reported as failed test.
