### PR TITLE
octopatch onboarding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,9 @@ after_failure:
   - 'if [ $FORCE_DOC_GEN == 0 ] || [ $GENERATE_DOC == 0 ]; then
       docker logs adoc-to-html;
     fi'
+env:
+  global:
+    - secure: "A7TFpc2lJjeAEMDPKKYY2sAfIHTOueLnRsz9z+DSoOfI9tKMi9XEvgCBDmoEK8VJI5qc/lY16x6FEVBmE6n7Em5MQlYWGg11Dghq+31kQ9icJ54WwNwYZnR9MOkE7tmwZ4wpiqW6enA859wF7bwAE+awYDbkl6qdiEuUmO8WH7M="
+
+after_script:
+  - ./fixup.sh

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [ "$TRAVIS_PULL_REQUEST" = false ] ; then
+    echo 'Skipped build. This is not a pull request'
+    exit 0
+fi
+
+if [ -z "$TRAVIS_REPO_SLUG" ]
+then
+  echo "There is not TRAVIS_REPO_SLUG defined"
+  exit 1
+fi
+
+if [ -z "$TRAVIS_PULL_REQUEST_SHA" ]
+then
+  echo "There is not TRAVIS_PULL_REQUEST_SHA defined"
+  exit 1
+fi
+
+if [ -z "$OCTOPATCH_API_TOKEN" ] ; then
+    echo "There is not OCTOPATCH_API_TOKEN defined"
+    exit 1
+fi
+
+REQUEST="curl -X POST -H \"Content-Type: multipart/form-data\""
+FILES=$(find . -type f -name "*.patch")
+if [ -z "$FILES" ]
+then
+    echo "Perfect! There are not patch files"
+    exit 0
+fi
+
+for FILE in $FILES
+do
+  REQUEST+=" -F \"data=@$FILE\""
+done
+
+REQUEST+=" -H \"Authorization: $OCTOPATCH_API_TOKEN\" api.octopatch.io/api/pulls/$TRAVIS_REPO_SLUG/$TRAVIS_PULL_REQUEST/$TRAVIS_PULL_REQUEST_SHA"
+eval $REQUEST


### PR DESCRIPTION
 This commit enables octopatch in your `.travis.yml`.

After merging this PR, you will be able to automate fixups! in the pull requests, if during the build, you have a repairing tool (e.g walkmod) that generates a patch with the appropriate fixes.