### PR TITLE
fix: improves method name handling executors

### DIFF
--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/ContainerEventControllerTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/ContainerEventControllerTestCase.java
@@ -175,6 +175,11 @@ public class ContainerEventControllerTestCase extends AbstractContainerTestTestB
             }
 
             @Override
+            public String getMethodName() {
+                return getMethod().getName();
+            }
+
+            @Override
             public Method getMethod() {
                 return testMethod();
             }
@@ -199,6 +204,11 @@ public class ContainerEventControllerTestCase extends AbstractContainerTestTestB
             }
 
             @Override
+            public String getMethodName() {
+                return getMethod().getName();
+            }
+
+            @Override
             public Method getMethod() {
                 return testMethod();
             }
@@ -218,6 +228,11 @@ public class ContainerEventControllerTestCase extends AbstractContainerTestTestB
         fire(new org.jboss.arquillian.test.spi.event.suite.Test(new TestMethodExecutor() {
             @Override
             public void invoke(Object... parameters) throws Throwable {
+            }
+
+            @Override
+            public String getMethodName() {
+                return getMethod().getName();
             }
 
             @Override

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
@@ -18,6 +18,11 @@ abstract class MethodInvoker {
                 invokeMethod(parameters);
             }
 
+            @Override
+            public String getMethodName() {
+                return getMethod().getName();
+            }
+
             public Method getMethod() {
                 return method.getMethod();
             }

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
@@ -20,7 +20,7 @@ abstract class MethodInvoker {
 
             @Override
             public String getMethodName() {
-                return getMethod().getName();
+                return method.getName();
             }
 
             public Method getMethod() {

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXMethodExecutor.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXMethodExecutor.java
@@ -64,7 +64,7 @@ public class JMXMethodExecutor implements ContainerMethodExecutor {
         }
 
         String testClass = testMethodExecutor.getInstance().getClass().getName();
-        String testMethod = testMethodExecutor.getMethod().getName();
+        String testMethod = testMethodExecutor.getMethodName();
         String testCanonicalName = testClass + "." + testMethod;
 
         NotificationListener commandListener = null;

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/JMXTestRunnerTestCase.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/JMXTestRunnerTestCase.java
@@ -152,6 +152,11 @@ public class JMXTestRunnerTestCase {
                 }
 
                 @Override
+                public String getMethodName() {
+                    return getMethod().getName();
+                }
+
+                @Override
                 public Method getMethod() {
                     return testMethod();
                 }

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletMethodExecutor.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletMethodExecutor.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -75,16 +76,18 @@ public class ServletMethodExecutor implements ContainerMethodExecutor {
         URI targetBaseURI = uriHandler.locateTestServlet(testMethodExecutor.getMethod());
 
         Class<?> testClass = testMethodExecutor.getInstance().getClass();
-        final String url = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
-            + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
-            + testMethodExecutor.getMethod().getName();
-
-        final String eventUrl = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
-            + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
-            + testMethodExecutor.getMethod().getName() + "&cmd=event";
 
         Timer eventTimer = null;
         try {
+            String urlEncodedMethodName = URLEncoder.encode(testMethodExecutor.getMethodName(), "UTF-8");
+            final String url = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName;
+
+            final String eventUrl = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName + "&cmd=event";
+
             eventTimer = createCommandServicePullTimer(eventUrl);
             return executeWithRetry(url, TestResult.class);
         } catch (Exception e) {

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
@@ -136,6 +136,10 @@ public class AbstractServerBase {
         public void invoke(Object... parameters) throws Throwable {
         }
 
+        public String getMethodName() {
+            return getMethod().getName();
+        }
+
         public Method getMethod() {
             try {
                 return this.getClass().getMethod("getMethod");

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
@@ -51,6 +51,27 @@ public class ProtocolTestCase extends AbstractServerBase {
     }
 
     @Test
+    public void shouldUseLogicalMethodNameAndHandleUrlEscaping() throws Exception {
+        final String testMethodNameWithReservedUrlCharacters = "non standard!test&name";
+
+        MockTestRunner.add(TestResult.passed());
+
+        ServletMethodExecutor executor = createExecutor();
+        executor.invoke(new MockTestExecutor() {
+            @Override
+            public String getMethodName() {
+                return testMethodNameWithReservedUrlCharacters;
+            }
+        });
+
+        Assert.assertEquals(
+            "Should use the logical method name",
+            testMethodNameWithReservedUrlCharacters,
+            MockTestRunner.testRequests.get(0).getMethodName()
+        );
+    }
+
+    @Test
     public void shouldReturnThrownException() throws Exception {
         MockTestRunner.add(TestResult.failed(new Exception().fillInStackTrace()));
 

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
@@ -51,7 +51,7 @@ public class ProtocolTestCase extends AbstractServerBase {
     }
 
     @Test
-    public void shouldUseLogicalMethodNameAndHandleUrlEscaping() throws Exception {
+    public void shouldUseLogicalMethodNameAndSupportUrlReservedCharactersInIt() throws Exception {
         final String testMethodNameWithReservedUrlCharacters = "non standard!test&name";
 
         MockTestRunner.add(TestResult.passed());

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/MockTestRunner.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/MockTestRunner.java
@@ -37,6 +37,8 @@ public class MockTestRunner implements TestRunner {
     public static List<Command<?>> commands = new ArrayList<Command<?>>();
     public static List<Object> commandResults = new ArrayList<Object>();
 
+    public static List<TestRequest> testRequests = new ArrayList<TestRequest>();
+
     public static void add(Command<?> command) {
         commands.add(command);
     }
@@ -49,13 +51,33 @@ public class MockTestRunner implements TestRunner {
         wantedResults = null;
         commands.clear();
         commandResults.clear();
+        testRequests.clear();
     }
 
     public TestResult execute(Class<?> testClass, String methodName) {
+        testRequests.add(new TestRequest(testClass, methodName));
         for (Command<?> command : commands) {
             commandResults.add(new ServletCommandService().execute(command));
         }
 
         return wantedResults;
+    }
+
+    public static class TestRequest {
+        private final Class<?> testClass;
+        private final String methodName;
+
+        public TestRequest(Class<?> testClass, String methodName) {
+            this.testClass = testClass;
+            this.methodName = methodName;
+        }
+
+        public Class<?> getTestClass() {
+            return testClass;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
     }
 }

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestMethodExecutor.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestMethodExecutor.java
@@ -25,6 +25,12 @@ import java.lang.reflect.Method;
  * @version $Revision: $
  */
 public interface TestMethodExecutor {
+
+    /**
+     * The method name to invoke
+     */
+    String getMethodName();
+
     /**
      * The method to invoke.
      */

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -173,7 +173,7 @@ public abstract class Arquillian implements IHookable {
                 }
 
                 public String getMethodName() {
-                    return getMethod().getName();
+                    return testResult.getMethod().getMethodName();
                 }
 
                 public Method getMethod() {

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -172,6 +172,10 @@ public abstract class Arquillian implements IHookable {
                     }
                 }
 
+                public String getMethodName() {
+                    return getMethod().getName();
+                }
+
                 public Method getMethod() {
                     return testResult.getMethod().getMethod();
                 }


### PR DESCRIPTION
#### Short description of what this resolves:

This resolves #214 by adding support for JUnit compatible testing frameworks for which `FrameworkMethod.getName()` != `FrameworkMethod.getMethod().getName()` and which allow test method names with reserved url characters.

#### Changes proposed in this pull request:

- Use the logical and not the actual test method name in `ServletMethodExecutor`
- Escape reserved characters in test method names when composing urls in `ServletMethodExecutor`

#### Additional notes

I understand that this fixes two separate issues but I decided to submit fixes for them as a single PR because I believe that are interrelated. Please let me know if you'd like to have this split into two commits and two PRs.

I believe that changes made are backwards compatible with the only problematic one in my opinion being introduction of `TestMethodExecutor.getMethodName()`. Ideally it would be added as a default method but Arquillian is still Java 6 compatible so it's not possible. I'm not sure if users are expected to have custom `TestMethodExecutor` implementation but if they are then I'm looking forward on suggestions on how this could be implemented without the potentially breaking change.

I have added a test for my changes, tried to keep the changes to minimum and follow the conventions set out in the project. Please do let me know if I missed something and I will gladly apply any necessary changes to this PR.