### PR TITLE
feat: introducing a new set of modules to support testng v7

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -27,6 +27,7 @@
     <version.junit>4.12</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
     <version.testng>6.14.3</version.testng>
+    <version.testng7>7.1.0</version.testng7>
     <version.assertj>2.9.1</version.assertj>
   </properties>
 
@@ -67,12 +68,6 @@
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
         <version>1.78</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testng</groupId>
-        <artifactId>testng</artifactId>
-        <version>${version.testng}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,11 @@
 
     <module>junit</module>
     <module>testng</module>
+    <module>testng7</module>
 
     <module>testenrichers</module>
     <module>protocols</module>
-  
+
     <module>bom</module>
   </modules>
 

--- a/testng/container/pom.xml
+++ b/testng/container/pom.xml
@@ -79,6 +79,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <version>${version.testng}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/testng7/container/pom.xml
+++ b/testng7/container/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- vi:ts=2:sw=2:expandtab: -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Parent -->
@@ -14,63 +15,72 @@
 
   <!-- Artifact Configuration -->
   <groupId>org.jboss.arquillian.testng</groupId>
-  <artifactId>arquillian-testng-core</artifactId>
-  <name>Arquillian TestRunner TestNG Core</name>
-  <description>TestNG Implementations for the Arquillian Project</description>
-
-
-  <!-- Properties -->
-  <properties>
-
-  </properties>
+  <artifactId>arquillian-testng7-container</artifactId>
+  <name>Arquillian TestRunner TestNG 7 Container</name>
+  <description>TestNG 7 Container Implementation for the Arquillian Project</description>
 
   <!-- Dependencies -->
   <dependencies>
 
     <!-- org.jboss.arquillian -->
     <dependency>
+      <groupId>org.jboss.arquillian.testng</groupId>
+      <artifactId>arquillian-testng7-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- External Projects -->
-    <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
     <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <scope>provided</scope>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-api</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${version.testng}</version>
-      <scope>provided</scope>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+      <version>${project.version}</version>
     </dependency>
-
-    <!-- Test -->
     <dependency>
       <groupId>org.jboss.arquillian.core</groupId>
       <artifactId>arquillian-core-impl-base</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-impl-base</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-impl-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-impl-base</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${version.testng7}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- External Projects -->
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
     </dependency>
 
   </dependencies>

--- a/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/RemoveDependsOnTransformer.java
+++ b/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/RemoveDependsOnTransformer.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+/**
+ * RemoveDependsOnMethodTransformer
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RemoveDependsOnTransformer implements IAnnotationTransformer {
+
+    /* (non-Javadoc)
+     * @see org.testng.IAnnotationTransformer#transform(org.testng.annotations.ITestAnnotation, java.lang.Class, java.lang.reflect.Constructor, java.lang.reflect.Method)
+     */
+    @Override
+    public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
+        annotation.setDependsOnGroups(new String[0]);
+        annotation.setDependsOnMethods(new String[0]);
+    }
+}

--- a/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestListener.java
+++ b/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestListener.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.jboss.arquillian.test.spi.TestResult;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+/**
+ * TestListener
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestListener implements ITestListener {
+
+    private ITestContext context;
+
+    public void onFinish(ITestContext paramITestContext) {
+        context = paramITestContext;
+    }
+
+    public void onStart(ITestContext paramITestContext) {
+    }
+
+    public void onTestFailedButWithinSuccessPercentage(ITestResult paramITestResult) {
+    }
+
+    public void onTestFailure(ITestResult paramITestResult) {
+    }
+
+    public void onTestSkipped(ITestResult paramITestResult) {
+    }
+
+    public void onTestStart(ITestResult paramITestResult) {
+    }
+
+    public void onTestSuccess(ITestResult paramITestResult) {
+    }
+
+    public TestResult getTestResult() {
+        if (context.getFailedConfigurations().size() > 0) {
+            return TestResult.failed(
+                context.getFailedConfigurations().getAllResults().iterator().next().getThrowable());
+        } else if (context.getFailedTests().size() > 0) {
+            return TestResult.failed(
+                context.getFailedTests().getAllResults().iterator().next().getThrowable());
+        } else if (context.getSkippedTests().size() > 0) {
+            return TestResult.skipped().setThrowable(context.getSkippedTests().getAllResults().iterator().next().getThrowable());
+        }
+        if (context.getPassedTests().size() > 0) {
+            return TestResult.passed().setThrowable(
+                context.getPassedTests().getAllResults().iterator().next().getThrowable());
+        }
+        return TestResult.failed(
+            new RuntimeException("Unknown test result: " + context).fillInStackTrace());
+    }
+}

--- a/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGContainerExtension.java
+++ b/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGContainerExtension.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * TestNGContainerExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGContainerExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(AuxiliaryArchiveAppender.class, TestNGDeploymentAppender.class);
+    }
+}

--- a/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGDeploymentAppender.java
+++ b/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGDeploymentAppender.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filter;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * TestNGDeploymentAppender
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGDeploymentAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "arquillian-testng.jar")
+            .addPackages(
+                true,
+                // exclude com.sun.javadoc.Doclet loading, not in OpenJDK
+                Filters.exclude("/org/testng/junit/.*|/org/testng/eclipse/.*"),
+                "org.testng",
+                "bsh",
+                "org.jboss.arquillian.testng7")
+            .addAsServiceProvider(
+                TestRunner.class,
+                TestNGTestRunner.class);
+
+      /* Attempt to add Guice if on classpath. TestNG 5.12 > use Guice */
+        // exclude AOP Alliance reference, not provided as part of TestNG jar
+        optionalPackages(
+            archive,
+            Filters.exclude(".*/InterceptorStackCallback\\$InterceptedMethodInvocation.*"),
+            "com.google.inject");
+
+      /* Attempt to add com.beust, internal TestNG package 5.14 > */
+        optionalPackages(
+            archive,
+            Filters.includeAll(),
+            "com.beust");
+
+        return archive;
+    }
+
+    private void optionalPackages(JavaArchive jar, Filter<ArchivePath> filter, String... packages) {
+        try {
+            jar.addPackages(
+                true,
+                filter,
+                packages);
+        } catch (Exception e) { /* optional packages NO-OP */ }
+    }
+}

--- a/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGTestRunner.java
+++ b/testng7/container/src/main/java/org/jboss/arquillian/testng7/container/TestNGTestRunner.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.testng.TestNG;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+/**
+ * TestNGTestRunner
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGTestRunner implements TestRunner {
+
+    public TestResult execute(Class<?> testClass, String methodName) {
+        TestListener resultListener = new TestListener();
+
+        TestNG runner = new TestNG(false);
+        runner.setVerbose(0);
+
+        runner.addListener(resultListener);
+        runner.addListener(new RemoveDependsOnTransformer());
+        runner.setXmlSuites(
+            Collections.singletonList(createSuite(testClass, methodName)));
+
+        //we catch problems in executing run method, e.g. ClassDefNotFoundError and wrap it in TestResult
+        try {
+            runner.run();
+        } catch (Throwable ex) {
+            return TestResult.failed(ex);
+        }
+
+        return resultListener.getTestResult();
+    }
+
+    private XmlSuite createSuite(Class<?> className, String methodName) {
+        XmlSuite suite = new XmlSuite();
+        suite.setName("Arquillian");
+
+        XmlTest test = new XmlTest(suite);
+        test.setName("Arquillian - " + className);
+        List<XmlClass> testClasses = new ArrayList<XmlClass>();
+        XmlClass testClass = new XmlClass(className);
+        testClass.getIncludedMethods().add(new XmlInclude(methodName));
+        testClasses.add(testClass);
+        test.setXmlClasses(testClasses);
+        return suite;
+    }
+}

--- a/testng7/container/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testng7/container/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testng7.container.TestNGContainerExtension

--- a/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/ShouldProvideConfigurationFailureToTestRunner.java
+++ b/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/ShouldProvideConfigurationFailureToTestRunner.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ShouldProvideConfigurationFailureToTestRunner {
+    @BeforeClass
+    public void failingConfiguration() throws ClassNotFoundException {
+        throw new ClassNotFoundException();
+    }
+
+    @Test
+    public void successfulTest() {
+        Assert.assertTrue(true);
+    }
+}

--- a/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/ShouldProvideVariousTestResultsToTestRunner.java
+++ b/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/ShouldProvideVariousTestResultsToTestRunner.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import java.lang.reflect.Method;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+
+public class ShouldProvideVariousTestResultsToTestRunner {
+    @DataProvider(name = "xx")
+    public static Object[][] getCurrentMethod(Method m) {
+        return new Object[][] {new Object[] {m}};
+    }
+
+    @org.testng.annotations.Test(expectedExceptions = IllegalArgumentException.class)
+    public void shouldProvideExpectedExceptionToRunner() throws Exception {
+        throw new IllegalArgumentException();
+    }
+
+    @org.testng.annotations.Test
+    public void shouldProvidePassingTestToRunner() throws Exception {
+        Assert.assertTrue(true);
+    }
+
+    @org.testng.annotations.Test
+    public void shouldProvideFailingTestToRunner() throws Exception {
+        Assert.fail("Failing by design");
+    }
+
+    @org.testng.annotations.Test
+    public void shouldProvideSkippingTestToRunner() throws Exception {
+        throw new SkipException("Skipping test", new Throwable("Skip exception"));
+    }
+
+    @org.testng.annotations.Test(dataProvider = "xx")
+    public void shouldBeAbleToUseOtherDataProviders(Method m) throws Exception {
+        Assert.assertNotNull(m);
+    }
+}

--- a/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/TestNGDeploymentAppenderTestCase.java
+++ b/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/TestNGDeploymentAppenderTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * TestNGDeploymentAppenderTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGDeploymentAppenderTestCase {
+
+    @Test
+    public void shouldGenerateDependencies() {
+        Archive<?> archive = new TestNGDeploymentAppender().createAuxiliaryArchive();
+
+        Assert.assertTrue(
+            archive.contains(
+                ArchivePaths.create("/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner")),
+            "Should have added TestRunner SPI");
+
+        Assert.assertTrue(
+            archive.contains(ArchivePaths.create("/org/jboss/arquillian/testng7/container/TestNGTestRunner.class")),
+            "Should have added TestRunner Impl");
+
+        System.out.println(archive.toString(true));
+    }
+}

--- a/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/TestNGTestRunnerTestCase.java
+++ b/testng7/container/src/test/java/org/jboss/arquillian/testng7/container/TestNGTestRunnerTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.container;
+
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.testng7.Arquillian;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+public class TestNGTestRunnerTestCase extends Arquillian {
+    @Test
+    public void shouldReturnPassedTest() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result =
+            runner.execute(ShouldProvideVariousTestResultsToTestRunner.class, "shouldProvidePassingTestToRunner");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.PASSED, result.getStatus());
+        Assert.assertNull(result.getThrowable());
+    }
+
+    @Test
+    public void shouldReturnFailedTest() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result =
+            runner.execute(ShouldProvideVariousTestResultsToTestRunner.class, "shouldProvideFailingTestToRunner");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.FAILED, result.getStatus());
+        Assert.assertEquals(AssertionError.class, result.getThrowable().getClass());
+    }
+
+    @Test
+    public void shouldReturnSkippedTest() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result =
+            runner.execute(ShouldProvideVariousTestResultsToTestRunner.class, "shouldProvideSkippingTestToRunner");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.SKIPPED, result.getStatus());
+        Assert.assertEquals(SkipException.class, result.getThrowable().getClass());
+    }
+
+    @Test
+    public void shouldReturnFailedTestAfterConfigurationError() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result = runner.execute(ShouldProvideConfigurationFailureToTestRunner.class, "successfulTest");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.FAILED, result.getStatus());
+        Assert.assertEquals(ClassNotFoundException.class, result.getThrowable().getClass());
+    }
+
+    @Test
+    public void shouldReturnExceptionOnPassedTest() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result =
+            runner.execute(ShouldProvideVariousTestResultsToTestRunner.class, "shouldProvideExpectedExceptionToRunner");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.PASSED, result.getStatus());
+        Assert.assertNotNull(result.getThrowable());
+        Assert.assertEquals(IllegalArgumentException.class, result.getThrowable().getClass());
+    }
+
+    @Test
+    // TODO: this should me moved to new TestNG test suite
+    public void shouldBeAbleToUseOtherDataProviders() {
+        TestNGTestRunner runner = new TestNGTestRunner();
+        TestResult result =
+            runner.execute(ShouldProvideVariousTestResultsToTestRunner.class, "shouldBeAbleToUseOtherDataProviders");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(TestResult.Status.PASSED, result.getStatus());
+        Assert.assertNull(result.getThrowable());
+    }
+}

--- a/testng7/core/pom.xml
+++ b/testng7/core/pom.xml
@@ -14,15 +14,9 @@
 
   <!-- Artifact Configuration -->
   <groupId>org.jboss.arquillian.testng</groupId>
-  <artifactId>arquillian-testng-core</artifactId>
-  <name>Arquillian TestRunner TestNG Core</name>
-  <description>TestNG Implementations for the Arquillian Project</description>
-
-
-  <!-- Properties -->
-  <properties>
-
-  </properties>
+  <artifactId>arquillian-testng7-core</artifactId>
+  <name>Arquillian TestRunner TestNG 7 Core</name>
+  <description>TestNG 7 Implementations for the Arquillian Project</description>
 
   <!-- Dependencies -->
   <dependencies>
@@ -35,16 +29,10 @@
     </dependency>
 
     <!-- External Projects -->
-    <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>${version.testng}</version>
+      <version>${version.testng7}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -55,15 +43,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-impl-base</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/Arquillian.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/Arquillian.java
@@ -1,0 +1,246 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import java.lang.reflect.Method;
+import java.util.Stack;
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder;
+import org.jboss.arquillian.test.spi.execution.SkippedTestExecutionException;
+import org.testng.IHookCallBack;
+import org.testng.IHookable;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+
+/**
+ * Arquillian
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@Listeners(Arquillian.UpdateResultListener.class)
+public abstract class Arquillian implements IHookable {
+    public static final String ARQUILLIAN_DATA_PROVIDER = "ARQUILLIAN_DATA_PROVIDER";
+    private static InheritableThreadLocal<TestRunnerAdaptor> deployableTest = new InheritableThreadLocal<TestRunnerAdaptor>();
+    private static InheritableThreadLocal<Stack<Cycle>> cycleStack = new InheritableThreadLocal<Stack<Cycle>>() {
+        protected java.util.Stack<Cycle> initialValue() {
+            return new Stack<Cycle>();
+        }
+
+        ;
+    };
+
+    @BeforeSuite(groups = "arquillian", inheritGroups = true)
+    public void arquillianBeforeSuite() throws Exception {
+        if (deployableTest.get() == null) {
+            TestRunnerAdaptor adaptor = TestRunnerAdaptorBuilder.build();
+            adaptor.beforeSuite();
+            deployableTest.set(adaptor); // don't set TestRunnerAdaptor if beforeSuite fails
+            cycleStack.get().push(Cycle.BEFORE_SUITE);
+        }
+    }
+
+    @AfterSuite(groups = "arquillian", inheritGroups = true, alwaysRun = true)
+    public void arquillianAfterSuite() throws Exception {
+        if (deployableTest.get() == null) {
+            return; // beforeSuite failed
+        }
+        if (cycleStack.get().empty()) {
+            return;
+        }
+        if (cycleStack.get().peek() != Cycle.BEFORE_SUITE) {
+            return; // Arquillian lifecycle called out of order, expected " + Cycle.BEFORE_SUITE
+        } else {
+            cycleStack.get().pop();
+        }
+        deployableTest.get().afterSuite();
+        deployableTest.get().shutdown();
+        deployableTest.set(null);
+        deployableTest.remove();
+        cycleStack.set(null);
+        cycleStack.remove();
+    }
+
+    @BeforeClass(groups = "arquillian", inheritGroups = true)
+    public void arquillianBeforeClass() throws Exception {
+        verifyTestRunnerAdaptorHasBeenSet();
+        cycleStack.get().push(Cycle.BEFORE_CLASS);
+        deployableTest.get().beforeClass(getClass(), LifecycleMethodExecutor.NO_OP);
+    }
+
+    @AfterClass(groups = "arquillian", inheritGroups = true, alwaysRun = true)
+    public void arquillianAfterClass() throws Exception {
+        if (cycleStack.get().empty()) {
+            return;
+        }
+        if (cycleStack.get().peek() != Cycle.BEFORE_CLASS) {
+            return; // Arquillian lifecycle called out of order, expected " + Cycle.BEFORE_CLASS
+        } else {
+            cycleStack.get().pop();
+        }
+        verifyTestRunnerAdaptorHasBeenSet();
+        deployableTest.get().afterClass(getClass(), LifecycleMethodExecutor.NO_OP);
+    }
+
+    @BeforeMethod(groups = "arquillian", inheritGroups = true)
+    public void arquillianBeforeTest(Method testMethod) throws Exception {
+        verifyTestRunnerAdaptorHasBeenSet();
+        cycleStack.get().push(Cycle.BEFORE);
+        deployableTest.get().before(this, testMethod, LifecycleMethodExecutor.NO_OP);
+    }
+
+    @AfterMethod(groups = "arquillian", inheritGroups = true, alwaysRun = true)
+    public void arquillianAfterTest(Method testMethod) throws Exception {
+        if (cycleStack.get().empty()) {
+            return;
+        }
+        if (cycleStack.get().peek() != Cycle.BEFORE) {
+            return; // Arquillian lifecycle called out of order, expected " + Cycle.BEFORE_CLASS
+        } else {
+            cycleStack.get().pop();
+        }
+        verifyTestRunnerAdaptorHasBeenSet();
+        deployableTest.get().after(this, testMethod, LifecycleMethodExecutor.NO_OP);
+    }
+
+    public void run(final IHookCallBack callback, final ITestResult testResult) {
+        verifyTestRunnerAdaptorHasBeenSet();
+        TestResult result;
+        try {
+            result = deployableTest.get().test(new TestMethodExecutor() {
+                public void invoke(Object... parameters) throws Throwable {
+               /*
+                *  The parameters are stored in the InvocationHandler, so we can't set them on the test result directly.
+                *  Copy the Arquillian found parameters to the InvocationHandlers parameters
+                */
+                    copyParameters(parameters, callback.getParameters());
+                    callback.runTestMethod(testResult);
+
+                    // Parameters can be contextual, so extract information
+                    swapWithClassNames(callback.getParameters());
+                    testResult.setParameters(callback.getParameters());
+                    if (testResult.getThrowable() != null) {
+                        throw testResult.getThrowable();
+                    }
+                }
+
+                private void copyParameters(Object[] source, Object[] target) {
+                    for (int i = 0; i < source.length; i++) {
+                        if (source[i] != null) {
+                            target[i] = source[i];
+                        }
+                    }
+                }
+
+                private void swapWithClassNames(Object[] source) {
+                    // clear parameters. they can be contextual and might fail TestNG during the report writing.
+                    for (int i = 0; source != null && i < source.length; i++) {
+                        Object parameter = source[i];
+                        if (parameter != null) {
+                            source[i] = parameter.toString();
+                        } else {
+                            source[i] = "null";
+                        }
+                    }
+                }
+
+                public String getMethodName() {
+                    return testResult.getMethod().getMethodName();
+                }
+
+                public Method getMethod() {
+                    return testResult.getMethod().getConstructorOrMethod().getMethod();
+                }
+
+                public Object getInstance() {
+                    return Arquillian.this;
+                }
+            });
+            Throwable throwable = result.getThrowable();
+            if (throwable != null) {
+                if (result.getStatus() == Status.SKIPPED) {
+                    if (throwable instanceof SkippedTestExecutionException) {
+                        result.setThrowable(new SkipException(throwable.getMessage()));
+                    }
+                }
+                testResult.setThrowable(result.getThrowable());
+
+                // setting status as failed.
+                testResult.setStatus(2);
+            }
+
+            // calculate test end time. this is overwritten in the testng invoker..
+            testResult.setEndMillis((result.getStart() - result.getEnd()) + testResult.getStartMillis());
+        } catch (Exception e) {
+            testResult.setThrowable(e);
+        }
+    }
+
+    @DataProvider(name = Arquillian.ARQUILLIAN_DATA_PROVIDER)
+    public Object[][] arquillianArgumentProvider(Method method) {
+        Object[][] values = new Object[1][method.getParameterTypes().length];
+
+        if (deployableTest.get() == null) {
+            return values;
+        }
+
+        Object[] parameterValues = new Object[method.getParameterTypes().length];
+        values[0] = parameterValues;
+
+        return values;
+    }
+
+    private void verifyTestRunnerAdaptorHasBeenSet() {
+        if (deployableTest.get() == null) {
+            throw new IllegalStateException("No TestRunnerAdaptor found, @BeforeSuite has not been called");
+        }
+    }
+
+    private static enum Cycle
+
+    {
+        BEFORE_SUITE, BEFORE_CLASS, BEFORE, TEST, AFTER, AFTER_CLASS, AFTER_SUITE
+    }
+
+    public static final class UpdateResultListener implements IInvokedMethodListener {
+
+        @Override
+        public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+            if (method.isTestMethod() && testResult.getStatus() != ITestResult.SUCCESS) {
+                State.caughtExceptionAfter(testResult.getThrowable());
+            }
+        }
+
+        @Override
+        public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        }
+    }
+}

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/State.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/State.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+/**
+ * State
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class State {
+    private static ThreadLocal<Throwable> caughtExceptionAfter = new ThreadLocal<Throwable>();
+
+    public static Throwable caughtExceptionAfter() {
+        return caughtExceptionAfter.get();
+    }
+
+    public static void caughtExceptionAfter(Throwable afterException) {
+        if (afterException == null) {
+            caughtExceptionAfter.remove();
+        } else {
+            caughtExceptionAfter.set(afterException);
+        }
+    }
+
+    static void clean() {
+        caughtExceptionAfter.remove();
+    }
+}

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/TestDataProviderTransformer.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/TestDataProviderTransformer.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ITestAnnotation;
+import org.testng.internal.annotations.TestAnnotation;
+
+/**
+ * A IAnnotationTransformer that will add the {@link TestEnricherDataProvider} as {@link DataProvider}
+ * to the given test method to enable method argument injection support.
+ *
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestDataProviderTransformer implements IAnnotationTransformer {
+
+    /* (non-Javadoc)
+     * @see org.testng.IAnnotationTransformer#transform(org.testng.annotations.ITestAnnotation, java.lang.Class, java.lang.reflect.Constructor, java.lang.reflect.Method)
+     */
+    public void transform(ITestAnnotation testAnnotation, Class clazz, Constructor constructor, Method method) {
+        if (testAnnotation.getDataProviderClass() == null) {
+            if (testAnnotation instanceof TestAnnotation) {
+                TestAnnotation annotation = (TestAnnotation) testAnnotation;
+                annotation.setDataProviderClass(TestEnricherDataProvider.class);
+                annotation.setDataProvider(TestEnricherDataProvider.PROVIDER_NAME);
+            }
+        }
+    }
+}

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/TestEnricherDataProvider.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/TestEnricherDataProvider.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import java.lang.reflect.Method;
+import org.testng.annotations.DataProvider;
+
+/**
+ * TestEnricherDataProvider
+ *
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestEnricherDataProvider {
+
+    public static final String PROVIDER_NAME = "enrich";
+
+    @DataProvider(name = PROVIDER_NAME)
+    public static Object[][] enrich(Method method) {
+        // actual enrichment happens inside a Observer
+        Object[] parameterValues = new Object[method.getParameterTypes().length];
+        Object[][] values = new Object[1][method.getParameterTypes().length];
+        values[0] = parameterValues;
+
+        return values;
+    }
+}

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/extension/TestNGCoreExtension.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/extension/TestNGCoreExtension.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.extension;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+class TestNGCoreExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(UpdateTestResultBeforeAfter.class);
+    }
+}

--- a/testng7/core/src/main/java/org/jboss/arquillian/testng7/extension/UpdateTestResultBeforeAfter.java
+++ b/testng7/core/src/main/java/org/jboss/arquillian/testng7/extension/UpdateTestResultBeforeAfter.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.extension;
+
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.EventContext;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.jboss.arquillian.test.spi.event.suite.After;
+import org.jboss.arquillian.testng7.State;
+
+/**
+ * Update the TestResult based on result After going through the TestNG chain.
+ * <p>
+ * This will give the correct TestResult in After, even with validation outside
+ * of Arquillians control, e.g. ExpectedExceptions.
+ */
+class UpdateTestResultBeforeAfter {
+    public void update(@Observes(precedence = 99) EventContext<After> context, TestResult result) {
+        if (State.caughtExceptionAfter() != null) {
+            result.setStatus(TestResult.Status.FAILED);
+            result.setThrowable(State.caughtExceptionAfter());
+        } else {
+            result.setStatus(Status.PASSED);
+            result.setThrowable(null);
+        }
+        State.caughtExceptionAfter(null);
+        context.proceed();
+    }
+}
+

--- a/testng7/core/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testng7/core/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testng7.extension.TestNGCoreExtension

--- a/testng7/core/src/test/java/org/jboss/arquillian/testng7/ArquillianClass1.java
+++ b/testng7/core/src/test/java/org/jboss/arquillian/testng7/ArquillianClass1.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import org.testng.annotations.Test;
+
+/*
+ * Predfined TestClass
+ */
+public class ArquillianClass1 extends Arquillian {
+    @Test
+    public void shouldBeInvoked() throws Throwable {
+    }
+}

--- a/testng7/core/src/test/java/org/jboss/arquillian/testng7/ArquillianClass2.java
+++ b/testng7/core/src/test/java/org/jboss/arquillian/testng7/ArquillianClass2.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import org.testng.annotations.Test;
+
+/*
+ * Predfined TestClass
+ */
+public class ArquillianClass2 extends Arquillian {
+    @Test(groups = "arq")
+    public void shouldBeInvoked2() throws Throwable {
+    }
+}

--- a/testng7/core/src/test/java/org/jboss/arquillian/testng7/NonArquillianClass1.java
+++ b/testng7/core/src/test/java/org/jboss/arquillian/testng7/NonArquillianClass1.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import org.testng.annotations.Test;
+
+/*
+ * Predfined TestClass
+ */
+public class NonArquillianClass1 {
+    @Test(groups = "non-arq")
+    public void shouldBeInvoked() throws Throwable {
+    }
+}

--- a/testng7/core/src/test/java/org/jboss/arquillian/testng7/TestNGIntegrationTestCase.java
+++ b/testng7/core/src/test/java/org/jboss/arquillian/testng7/TestNGIntegrationTestCase.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verify the that TestNG integration adaptor fires the expected events even when Handlers are failing.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGIntegrationTestCase extends TestNGTestBaseClass {
+    @Test(enabled = false) // ARQ-582
+    public void shouldNotCallAnyMethodsWithoutLifecycleHandlers() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        when(adaptor.test(isA(TestMethodExecutor.class))).thenReturn(TestResult.passed());
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class);
+
+        Assert.assertTrue(wasSuccessful(result));
+        assertCycle(0, Cycle.values());
+
+        assertCycle(1, Cycle.BEFORE_SUITE, Cycle.AFTER_SUITE);
+    }
+
+    @Test
+    public void shouldCallAllMethods() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class);
+
+        Assert.assertTrue(wasSuccessful(result));
+        assertCycle(1, Cycle.values());
+
+        assertCycle(1, Cycle.BEFORE_SUITE, Cycle.AFTER_SUITE);
+    }
+
+    @Test
+    public void shouldCallAfterClassWhenBeforeThrowsException() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        throwException(Cycle.BEFORE_CLASS, new Throwable());
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class);
+        Assert.assertFalse(wasSuccessful(result));
+
+        assertCycle(1, Cycle.BEFORE_CLASS, Cycle.AFTER_CLASS);
+        assertCycle(0, Cycle.BEFORE, Cycle.AFTER, Cycle.TEST);
+
+        verify(adaptor, times(1)).beforeSuite();
+        verify(adaptor, times(1)).afterSuite();
+    }
+
+    @Test
+    public void shouldCallAfterWhenBeforeThrowsException() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        throwException(Cycle.BEFORE, new Throwable());
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class);
+        Assert.assertFalse(wasSuccessful(result));
+
+        assertCycle(1, Cycle.BEFORE_CLASS, Cycle.AFTER_CLASS, Cycle.BEFORE, Cycle.AFTER);
+        assertCycle(0, Cycle.TEST);
+
+        assertCycle(1, Cycle.BEFORE_SUITE, Cycle.AFTER_SUITE);
+    }
+
+    @Test
+    public void shouldOnlyCallSecondTestWhenFirstBeforeClassThrowsException() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        // throwException removes exception marker when thrown
+        throwException(Cycle.BEFORE_CLASS, new Throwable());
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class, ArquillianClass2.class);
+        Assert.assertFalse(wasSuccessful(result));
+
+        assertCycle(2, Cycle.BEFORE_CLASS, Cycle.AFTER_CLASS);
+        assertCycle(1, Cycle.BEFORE, Cycle.TEST, Cycle.AFTER);
+
+        assertCycle(1, Cycle.BEFORE_SUITE, Cycle.AFTER_SUITE);
+    }
+
+    @Test
+    public void shouldOnlyCallBeforeAfterSuiteOnce() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class, ArquillianClass2.class);
+        Assert.assertTrue(wasSuccessful(result));
+
+        assertCycle(1, Cycle.BEFORE_SUITE, Cycle.AFTER_SUITE);
+    }
+
+    @Test
+    public void shouldCallAllWhenTestThrowsException() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        throwException(Cycle.TEST, new Throwable());
+
+        TestListenerAdapter result = run(adaptor, ArquillianClass1.class);
+        Assert.assertFalse(wasSuccessful(result));
+
+        assertCycle(1, Cycle.values());
+    }
+
+    @Test
+    public void shouldNotCallArquillianWhenNonArquillianClassIsRan() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result = run(adaptor, NonArquillianClass1.class);
+        Assert.assertTrue(wasSuccessful(result));
+
+        assertCycle(0, Cycle.values());
+    }
+
+    @Test
+    public void shouldNotCallArquillianWhenNonArquillianGroupIsRan() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result =
+            run(new String[] {"non-arq"}, adaptor, NonArquillianClass1.class, ArquillianClass1.class);
+        Assert.assertTrue(wasSuccessful(result));
+
+        assertCycle(0, Cycle.values());
+    }
+
+    @Test(enabled = false) // ARQ-646
+    public void shouldCallArquillianWhenGroupIsRan() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result =
+            run(new String[] {"arq"}, adaptor, NonArquillianClass1.class, ArquillianClass2.class);
+        Assert.assertTrue(wasSuccessful(result));
+
+        assertCycle(1, Cycle.values());
+    }
+
+    @Test // workaround for ARQ-646, enable the arquillian group
+    public void shouldCallArquillianWhenArquillianGroupIsActive() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        TestListenerAdapter result =
+            run(new String[] {"arq", "arquillian"}, adaptor, NonArquillianClass1.class, ArquillianClass2.class);
+        Assert.assertTrue(wasSuccessful(result));
+
+        assertCycle(1, Cycle.values());
+    }
+}

--- a/testng7/core/src/test/java/org/jboss/arquillian/testng7/TestNGTestBaseClass.java
+++ b/testng7/core/src/test/java/org/jboss/arquillian/testng7/TestNGTestBaseClass.java
@@ -1,0 +1,211 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptorBuilder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.AfterMethod;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+/**
+ * TestNGTestBaseClass
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGTestBaseClass {
+    /*
+     * Setup / Clear the static callback info.
+     */
+    private static Map<Cycle, Integer> callbackCount = new HashMap<Cycle, Integer>();
+    private static Map<Cycle, Throwable> callbackException = new HashMap<Cycle, Throwable>();
+
+    static {
+        for (Cycle tmp : Cycle.values()) {
+            callbackCount.put(tmp, 0);
+        }
+    }
+
+    public static void throwException(Cycle cycle, Throwable exception) {
+        callbackException.put(cycle, exception);
+    }
+
+    public static void wasCalled(Cycle cycle) throws Throwable {
+        System.out.println("called: " + cycle);
+        if (callbackCount.containsKey(cycle)) {
+            callbackCount.put(cycle, callbackCount.get(cycle) + 1);
+        } else {
+            throw new RuntimeException("Unknown callback: " + cycle);
+        }
+        if (callbackException.containsKey(cycle)) {
+            throw callbackException.remove(cycle);
+        }
+    }
+
+    @AfterMethod
+    public void clearCallbacks() {
+        callbackCount.clear();
+        for (Cycle tmp : Cycle.values()) {
+            callbackCount.put(tmp, 0);
+        }
+        callbackException.clear();
+    }
+
+    /*
+     * Internal Helpers
+     */
+    protected void executeAllLifeCycles(TestRunnerAdaptor adaptor) throws Exception {
+        doAnswer(new ExecuteLifecycle(Cycle.BEFORE_SUITE)).when(adaptor).beforeSuite();
+        doAnswer(new ExecuteLifecycle(Cycle.AFTER_SUITE)).when(adaptor).afterSuite();
+        doAnswer(new ExecuteLifecycle(Cycle.BEFORE_CLASS)).when(adaptor)
+            .beforeClass(any(Class.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new ExecuteLifecycle(Cycle.AFTER_CLASS)).when(adaptor)
+            .afterClass(any(Class.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new ExecuteLifecycle(Cycle.BEFORE)).when(adaptor)
+            .before(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new ExecuteLifecycle(Cycle.AFTER)).when(adaptor)
+            .after(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new TestExecuteLifecycle(TestResult.passed())).when(adaptor)
+            .test(any(TestMethodExecutor.class));
+    }
+
+    public void assertCycle(int count, Cycle... cycles) {
+        for (Cycle cycle : cycles) {
+            Assert.assertEquals(
+                count, (int) callbackCount.get(cycle),
+                "Verify " + cycle + " called N times");
+        }
+    }
+
+    protected TestListenerAdapter run(TestRunnerAdaptor adaptor, Class<?>... classes)
+        throws Exception {
+        return run(null, adaptor, classes);
+    }
+
+    protected TestListenerAdapter run(String[] groups, TestRunnerAdaptor adaptor, Class<?>... classes)
+        throws Exception {
+        try {
+            setAdaptor(adaptor);
+
+            TestListenerAdapter listener = new TestListenerAdapter();
+            TestNG runner = new TestNG(false);
+            runner.addListener(listener);
+            runner.setXmlSuites(Collections.singletonList(createSuite(groups, classes)));
+
+            runner.run();
+            return listener;
+        } finally {
+            setAdaptor(null);
+        }
+    }
+
+    protected boolean wasSuccessful(TestListenerAdapter adapter) {
+        return adapter.getFailedTests().size() == 0 && adapter.getSkippedTests().size() == 0;
+    }
+
+    private XmlSuite createSuite(String[] groups, Class<?>... classes) {
+        XmlSuite suite = new XmlSuite();
+        suite.setName("Arquillian - TEST");
+
+        suite.setConfigFailurePolicy(XmlSuite.FailurePolicy.CONTINUE);
+        XmlTest test = new XmlTest(suite);
+        if (groups != null) {
+            test.setIncludedGroups(Arrays.asList(groups));
+        }
+        test.setName("Arquillian - TEST");
+        List<XmlClass> testClasses = new ArrayList<XmlClass>();
+        for (Class<?> clazz : classes) {
+            XmlClass testClass = new XmlClass(clazz);
+            testClasses.add(testClass);
+        }
+        test.setXmlClasses(testClasses);
+        return suite;
+    }
+
+    // force set the TestRunnerAdaptor to use
+    private void setAdaptor(TestRunnerAdaptor adaptor) throws Exception {
+        Method method = TestRunnerAdaptorBuilder.class.getMethod("set", TestRunnerAdaptor.class);
+        method.setAccessible(true);
+        method.invoke(null, adaptor);
+    }
+
+    public enum Cycle
+
+    {
+        BEFORE_SUITE, BEFORE_CLASS, BEFORE, TEST, AFTER, AFTER_CLASS, AFTER_SUITE
+    }
+
+    /*
+     * Mockito Answers for invoking the LifeCycle callbacks.
+     */
+    public static class ExecuteLifecycle implements Answer<Object> {
+        private Cycle cycle;
+
+        public ExecuteLifecycle(Cycle cycle) {
+            this.cycle = cycle;
+        }
+
+        @Override
+        public Object answer(org.mockito.invocation.InvocationOnMock invocation) throws Throwable {
+            wasCalled(cycle);
+            for (Object argument : invocation.getArguments()) {
+                if (argument instanceof LifecycleMethodExecutor) {
+                    ((LifecycleMethodExecutor) argument).invoke();
+                } else if (argument instanceof TestMethodExecutor) {
+                    ((TestMethodExecutor) argument).invoke();
+                }
+            }
+            return null;
+        }
+    }
+
+    public static class TestExecuteLifecycle extends ExecuteLifecycle {
+        private TestResult result;
+
+        public TestExecuteLifecycle(TestResult result) {
+            super(Cycle.TEST);
+            this.result = result;
+        }
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            super.answer(invocation);
+            return result;
+        }
+    }
+}

--- a/testng7/pom.xml
+++ b/testng7/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- vi:ts=2:sw=2:expandtab: -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian</groupId>
+    <artifactId>arquillian-parent</artifactId>
+    <version>1.6.1.Final-SNAPSHOT</version>
+  </parent>
+
+  <!-- Model Information -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Information -->
+  <groupId>org.jboss.arquillian.testng</groupId>
+  <artifactId>arquillian-testng7-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>Arquillian TestRunner TestNG 7 Aggregator</name>
+  <description>Arquillian TestNG 7 Aggregator</description>
+
+  <modules>
+    <module>core</module>
+    <module>standalone</module>
+    <module>container</module>
+  </modules>
+</project>

--- a/testng7/standalone/pom.xml
+++ b/testng7/standalone/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- vi:ts=2:sw=2:expandtab: -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Parent -->
@@ -14,65 +15,39 @@
 
   <!-- Artifact Configuration -->
   <groupId>org.jboss.arquillian.testng</groupId>
-  <artifactId>arquillian-testng-core</artifactId>
-  <name>Arquillian TestRunner TestNG Core</name>
-  <description>TestNG Implementations for the Arquillian Project</description>
-
-
-  <!-- Properties -->
-  <properties>
-
-  </properties>
+  <artifactId>arquillian-testng7-standalone</artifactId>
+  <name>Arquillian TestRunner TestNG 7 Standalone</name>
+  <description>TestNG 7 Standalone Implementation for the Arquillian Project</description>
 
   <!-- Dependencies -->
   <dependencies>
 
     <!-- org.jboss.arquillian -->
     <dependency>
+      <groupId>org.jboss.arquillian.testng</groupId>
+      <artifactId>arquillian-testng7-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- External Projects -->
-    <!-- Workaround https://github.com/cbeust/testng/issues/1506#issuecomment-347178740 -->
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${version.testng}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- Test -->
     <dependency>
       <groupId>org.jboss.arquillian.core</groupId>
       <artifactId>arquillian-core-impl-base</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.test</groupId>
       <artifactId>arquillian-test-impl-base</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.jboss.arquillian.config</groupId>
+      <artifactId>arquillian-config-impl-base</artifactId>
+      <version>${project.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/testng7/standalone/src/main/java/org/jboss/arquillian/testng7/standalone/LocalTestMethodExecutor.java
+++ b/testng7/standalone/src/main/java/org/jboss/arquillian/testng7/standalone/LocalTestMethodExecutor.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.standalone;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
+import org.jboss.arquillian.test.spi.event.suite.Test;
+
+/**
+ * LocalTestMethodExecutor
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class LocalTestMethodExecutor {
+    @Inject
+    private Instance<ServiceLoader> serviceLoader;
+
+    @Inject
+    @TestScoped
+    private InstanceProducer<TestResult> testResult;
+
+    public void execute(@Observes Test event) {
+        TestResult result= null;
+        try {
+            event.getTestMethodExecutor().invoke(
+                enrichArguments(
+                    event.getTestMethod(),
+                    serviceLoader.get().all(TestEnricher.class)));
+            result = TestResult.passed();
+        } catch (Throwable e) {
+            result = TestResult.failed(e);
+        } finally {
+            if (result != null) {
+                result.setEnd(System.currentTimeMillis());
+            }
+        }
+        testResult.set(result);
+    }
+
+    /**
+     * Enrich the method arguments of a method call.<br/>
+     * The Object[] index will match the method parameterType[] index.
+     *
+     * @return the argument values
+     */
+    private Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        if (method.getParameterTypes().length == 0) {
+            return values;
+        }
+        for (TestEnricher enricher : enrichers) {
+            mergeValues(values, enricher.resolve(method));
+        }
+        return values;
+    }
+
+    private void mergeValues(Object[] values, Object[] resolvedValues) {
+        if (resolvedValues == null || resolvedValues.length == 0) {
+            return;
+        }
+        if (values.length != resolvedValues.length) {
+            throw new IllegalStateException("TestEnricher resolved wrong argument count, expected " +
+                values.length + " returned " + resolvedValues.length);
+        }
+        for (int i = 0; i < resolvedValues.length; i++) {
+            Object resvoledValue = resolvedValues[i];
+            if (resvoledValue != null && values[i] == null) {
+                values[i] = resvoledValue;
+            }
+        }
+    }
+}

--- a/testng7/standalone/src/main/java/org/jboss/arquillian/testng7/standalone/TestNGStandaloneExtension.java
+++ b/testng7/standalone/src/main/java/org/jboss/arquillian/testng7/standalone/TestNGStandaloneExtension.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testng7.standalone;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * JTestNGStandaloneExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestNGStandaloneExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(LocalTestMethodExecutor.class);
+    }
+}

--- a/testng7/standalone/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testng7/standalone/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testng7.standalone.TestNGStandaloneExtension


### PR DESCRIPTION
This PR is a naive implementation of TestNG 7 support. As v7 brings changes to the API, it might be reasonable to have TestNG 6 and 7 support fully independent, even if that brings some code duplication.
In scope of this request all TestNG 6 modules have been copied and the code adjusted to be compatible with v7. Effectively the only change in the code so far is in `org.jboss.arquillian.test.spi.TestMethodExecutor#getMethod` to:
```
public Method getMethod() {
   return testResult.getMethod().getConstructorOrMethod().getMethod();
}
```