### PR TITLE
Update to CDI 2.0, the test no longer needs to depend on Weld interna…

### DIFF
--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -23,7 +23,7 @@
   <properties>
 
     <!-- Versioning -->
-    <version.weld-core>1.1.34.Final</version.weld-core>
+    <version.weld-core>3.1.4.Final</version.weld-core>
     <version.javax-el>2.2</version.javax-el>
     <version.slf4j>1.7.28</version.slf4j>
 
@@ -46,9 +46,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <version>1.0</version>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>2.0.2</version>
       <scope>provided</scope>
     </dependency>
 
@@ -94,17 +94,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.weld</groupId>
-      <artifactId>weld-core</artifactId>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-shaded</artifactId>
       <version>${version.weld-core}</version>
       <scope>test</scope>
-      <!-- ARQ-990 Removed, not needed runtime and not part of Fedora Maven Packages -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.weld</groupId>
-          <artifactId>weld-build-config</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
@@ -158,6 +158,10 @@ public class MethodParameterInjectionPoint<T> implements InjectionPoint {
             return new HashSet<Annotation>(Arrays.asList(method.getParameterAnnotations()[position]));
         }
 
+        public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
+            return AnnotatedParameter.super.getAnnotations(annotationType);
+        }
+
         /* (non-Javadoc)
          * @see javax.enterprise.inject.spi.Annotated#getBaseType()
          */

--- a/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricherTestCase.java
+++ b/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricherTestCase.java
@@ -16,21 +16,13 @@
  */
 package org.jboss.arquillian.testenricher.cdi;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLStreamHandler;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.test.spi.annotation.TestScoped;
@@ -40,24 +32,14 @@ import org.jboss.arquillian.testenricher.cdi.beans.CatService;
 import org.jboss.arquillian.testenricher.cdi.beans.Dog;
 import org.jboss.arquillian.testenricher.cdi.beans.DogService;
 import org.jboss.arquillian.testenricher.cdi.beans.Service;
-import org.jboss.weld.bootstrap.WeldBootstrap;
-import org.jboss.weld.bootstrap.api.Environments;
-import org.jboss.weld.bootstrap.api.ServiceRegistry;
-import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
-import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
-import org.jboss.weld.bootstrap.spi.BeansXml;
-import org.jboss.weld.bootstrap.spi.Deployment;
-import org.jboss.weld.bootstrap.spi.Metadata;
-import org.jboss.weld.ejb.spi.EjbDescriptor;
-import org.jboss.weld.manager.api.WeldManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 public class CDIInjectionEnricherTestCase extends AbstractTestTestBase {
-    private WeldBootstrap bootstrap;
-    private WeldManager manager;
+    private SeContainer container;
+    private BeanManager manager;
     private CDIInjectionEnricher enricher;
 
     @org.jboss.arquillian.core.api.annotation.Inject
@@ -70,15 +52,9 @@ public class CDIInjectionEnricherTestCase extends AbstractTestTestBase {
 
     @Before
     public void setup() throws Exception {
-        Deployment deployment = createDeployment(Service.class, Cat.class, CatService.class, Dog.class, DogService.class);
-        bootstrap = new WeldBootstrap();
-        bootstrap.startContainer(Environments.SE, deployment)
-            .startInitialization()
-            .deployBeans()
-            .validateBeans()
-            .endInitialization();
-
-        manager = bootstrap.getManager(deployment.getBeanDeploymentArchives().iterator().next());
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(Service.class, Cat.class, CatService.class, Dog.class, DogService.class).initialize();
+        manager = container.getBeanManager();
 
         bind(TestScoped.class, BeanManager.class, manager);
 
@@ -88,7 +64,7 @@ public class CDIInjectionEnricherTestCase extends AbstractTestTestBase {
 
     @After
     public void teardown() throws Exception {
-        bootstrap.shutdown();
+        container.close();
     }
 
     @Test
@@ -135,77 +111,6 @@ public class CDIInjectionEnricherTestCase extends AbstractTestTestBase {
 
         TestClass testClass = new TestClass();
         testMethod.invoke(testClass, resolvedBeans);
-    }
-
-    private Deployment createDeployment(final Class<?>... classes) {
-        final BeanDeploymentArchive beanArchive = new BeanDeploymentArchive() {
-            private ServiceRegistry registry = new SimpleServiceRegistry();
-
-            public ServiceRegistry getServices() {
-                return registry;
-            }
-
-            public String getId() {
-                return "test.jar";
-            }
-
-            public Collection<EjbDescriptor<?>> getEjbs() {
-                return Collections.emptyList();
-            }
-
-            public BeansXml getBeansXml() {
-                try {
-                    Collection<URL> beansXmlPaths =
-                        Collections.singletonList(new URL(null, "archive://beans.xml", new URLStreamHandler() {
-                            @Override
-                            protected URLConnection openConnection(URL u) throws IOException {
-                                return new URLConnection(u) {
-                                    public void connect() throws IOException {
-                                    }
-
-                                    public InputStream getInputStream() throws IOException {
-                                        return new ByteArrayInputStream("<beans/>".getBytes());
-                                    }
-                                };
-                            }
-                        }));
-                    return bootstrap.parse(beansXmlPaths);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            public Collection<BeanDeploymentArchive> getBeanDeploymentArchives() {
-                return Collections.emptyList();
-            }
-
-            public Collection<String> getBeanClasses() {
-                Collection<String> beanClasses = new ArrayList<String>();
-                for (Class<?> c : classes) {
-                    beanClasses.add(c.getName());
-                }
-                return beanClasses;
-            }
-        };
-        final Deployment deployment = new Deployment() {
-            public Collection<BeanDeploymentArchive> getBeanDeploymentArchives() {
-                return Collections.singletonList(beanArchive);
-            }
-
-            public ServiceRegistry getServices() {
-                return beanArchive.getServices();
-            }
-
-            public BeanDeploymentArchive loadBeanDeploymentArchive(
-                Class<?> beanClass) {
-                return beanArchive;
-            }
-
-            public Iterable<Metadata<Extension>> getExtensions() {
-                return Collections.emptyList();
-            }
-        };
-        return deployment;
     }
 
     private static class TestClass {


### PR DESCRIPTION
…ls and uses CDI SE API instead.

I am not sure how much Arq. needs/wants to stay compatible with older versions (as this just bumps CDI to 2.0 which means JEE 8), but we will also need to make one that's working with Jakarta EE 9 which means package changes.
This PR is a prequel to that which follows a conversation that I had with @starksm64 about CDI changes.