### PR TITLE
Use Jakarta EE 9 servlet API, adapt tests.

### DIFF
--- a/protocols/servlet/pom.xml
+++ b/protocols/servlet/pom.xml
@@ -22,7 +22,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.jetty_jetty>8.1.2.v20120308</version.jetty_jetty>
+    <version.jetty_jetty>11.0.0-alpha0</version.jetty_jetty>
 
   </properties>
 
@@ -59,9 +59,9 @@
 
     <!-- servlet api -->
     <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-      <version>1.0.2.Final</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0-M1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletContextRegistrar.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletContextRegistrar.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.arquillian.protocol.servlet.runner;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletContextResourceProvider.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletContextResourceProvider.java
@@ -17,7 +17,8 @@
 package org.jboss.arquillian.protocol.servlet.runner;
 
 import java.lang.annotation.Annotation;
-import javax.servlet.ServletContext;
+
+import jakarta.servlet.ServletContext;
 import org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -35,7 +36,7 @@ public class ServletContextResourceProvider extends OperatesOnDeploymentAwarePro
 
     @Override
     public boolean canProvide(Class<?> type) {
-        return javax.servlet.ServletContext.class.isAssignableFrom(type);
+        return jakarta.servlet.ServletContext.class.isAssignableFrom(type);
     }
 
     @Override

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
@@ -22,11 +22,12 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.jboss.arquillian.container.test.spi.TestRunner;
 import org.jboss.arquillian.container.test.spi.command.Command;
 import org.jboss.arquillian.container.test.spi.util.TestRunners;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
@@ -26,6 +26,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
@@ -88,7 +90,7 @@ public class AbstractServerBase {
     }
 
     protected URI createBaseURL() {
-        return URI.create("http://localhost:" + server.getConnectors()[0].getPort() + "/arquillian-protocol");
+        return URI.create("http://localhost:" + ((NetworkConnector)server.getConnectors()[0]).getPort() + "/arquillian-protocol");
     }
 
     protected URL createURL(String outputMode, String testClass, String methodName) {


### PR DESCRIPTION
Fixes #248 

I quickly cobbled this together to see what changes are needed.
With these changes I was able to build Arq. code and I am able to run Weld servlet tests on Tomcat which previously failed.

I am fine going any other way; this just sums up what's needed.