### PR TITLE
fix: adds TestNG7 to bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -171,6 +171,23 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- TestNG 7 -->
+      <dependency>
+        <groupId>org.jboss.arquillian.testng</groupId>
+        <artifactId>arquillian-testng7-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.testng</groupId>
+        <artifactId>arquillian-testng7-container</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.testng</groupId>
+        <artifactId>arquillian-testng7-standalone</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- Protocols -->
       <dependency>
         <groupId>org.jboss.arquillian.protocol</groupId>


### PR DESCRIPTION
#### Short description of what this resolves:
TestNG 7 support has been added in #232. This PR adds the new artifacts to the bom.

#### Changes proposed in this pull request:
Add the new TestNG 7 artifacts to the bom.
