### PR TITLE
feat: exposes deploymentError in Deployment

### DIFF
--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Deployment.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Deployment.java
@@ -49,6 +49,10 @@ public class Deployment {
         return deploymentError != null;
     }
 
+    public Throwable getDeploymentError() {
+        return deploymentError;
+    }
+
     public void deployedWithError(Throwable deploymentError) {
         this.deployed = true;
         this.deploymentError = deploymentError;


### PR DESCRIPTION
#### Short description of what this resolves:

We use an event observer to give detailed error messages to our developers when an Arquillian deployment fails, as some of the errors specific to our project may be somewhat misleading and lead them to conclude that the test setup is broken, when it is in fact their local settings. To do this, we need to analyze the exception stored in the Deployment object.

Currently, we are using reflection to get at this field, but a simple getter is much more desirable.

#### Changes proposed in this pull request:

- Exposes the field deploymentError in Deployment using a getter