### PR TITLE
fix: unit test shouldn't rely on localized strings

### DIFF
--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
@@ -229,8 +229,8 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
 
         final String capturedLog = getTestCapturedLog();
 
-        Assert.assertTrue(capturedLog.contains("WARNING: Provider for type class java.lang.Object returned a null value: resourceProvider"));
-        Assert.assertTrue(capturedLog.contains("WARNING: Provider for type class java.lang.Object returned a null value: resourceProvider1"));
+        Assert.assertTrue(capturedLog.contains(": Provider for type class java.lang.Object returned a null value: resourceProvider"));
+        Assert.assertTrue(capturedLog.contains(": Provider for type class java.lang.Object returned a null value: resourceProvider1"));
     }
 
     @Test


### PR DESCRIPTION
#### Short description of what this resolves:
Unit test ArquillianResourceTestEnricherTestCase.shouldBeAbleToThrowExceptionWithMultipleResourceProvidersWhichProvidesNullLookUp() does not pass on non-english systems.
It checks that the log contains strings like "WARNING: xxx", but this "WARNING" is translated on non-english systems. For exemple, on my computer the log messages are:
> AVERTISSEMENT: Provider for type class java.lang.Object returned a null value: resourceProvider

#### Changes proposed in this pull request:
This PR removes the "WARNING" words from the checks.
