### PR TITLE
fix: fixes testng7 support

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -27,7 +27,6 @@
     <version.junit>4.13</version.junit>
     <version.mockito_all>1.10.19</version.mockito_all>
     <version.testng>7.3.0</version.testng>
-    <version.testng7>7.1.0</version.testng7>
     <version.assertj>2.9.1</version.assertj>
   </properties>
 


### PR DESCRIPTION
I've just realized I made a stupid and embarrassing error in my previous commit related to testng7 support.
When running tests using testng7, a runtime exception is generated that makes all tests pass (that's why I thought my previous PR was working) without even being executed!! :-(
This new PR fixes this (very annoying) problem.
I'm really sorry for that.