### PR TITLE
doc(ARQ-2207): updates the links in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@
 image:https://travis-ci.org/arquillian/arquillian-core.svg?branch=master["Build Status", link="https://travis-ci.org/arquillian/arquillian-core"]
 
 ifndef::generated-doc[]
-To read complete documentation visit http://arquillian.org/arquillian-core/
+To read complete documentation visit https://arquillian.org/arquillian-core/
 endif::generated-doc[]
 
 
@@ -55,4 +55,4 @@ endif::generated-doc[]
 * http://arquillian.org[Project Site]
 * http://arquillian.org/guides[Guides]
 * http://discuss.arquillian.org/[Forum]
-* https://jira.jboss.org/jira/browse/ARQ[Issue Tracker]
+* https://issues.redhat.com/browse/ARQ[Issue Tracker]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ARQ-2207

Description: The Issue Tracker link provided inside README.adoc of arquillian/arquillian-core need to replace with the new one.