### PR TITLE
fix(junit5): ClassCastException when filtering test methods

### DIFF
--- a/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunner.java
+++ b/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunner.java
@@ -38,10 +38,12 @@ public class JUnitJupiterTestRunner implements TestRunner {
                     .selectors(DiscoverySelectors.selectClass(testClass.getCanonicalName()))
                     .configurationParameter(ArquillianExtension.RUNNING_INSIDE_ARQUILLIAN, "true")
                     .filters((PostDiscoveryFilter) object -> {
-                        Method m = ((MethodBasedTestDescriptor) object).getTestMethod();
-                        if (m.getName().equals(methodName)) {
-                            matchCounter.incrementAndGet();
-                            return FilterResult.included("Matched method name");
+                        if (object instanceof MethodBasedTestDescriptor) {
+                            Method m = ((MethodBasedTestDescriptor) object).getTestMethod();
+                            if (m.getName().equals(methodName)) {
+                                matchCounter.incrementAndGet();
+                                return FilterResult.included("Matched method name");
+                            }
                         }
                         return FilterResult.excluded("Not matched");
                     })


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
When testing my project with JUnit 5, I get `ClassCastException` instead of test result

Full stack trace is here: https://github.com/arquillian/arquillian-core/issues/137#issuecomment-725028937

Relates to #137 