### PR TITLE
fix: skips deployment validation if not present

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AbstractDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AbstractDeploymentScenarioGenerator.java
@@ -118,7 +118,7 @@ public abstract class AbstractDeploymentScenarioGenerator implements DeploymentS
     }
 
     private void logWarningIfArchiveHasUnexpectedFileExtension(final DeploymentDescription deployment) {
-        if (!Validate.archiveHasExpectedFileExtension(deployment.getArchive())) {
+        if ((deployment.getArchive() != null) && (!Validate.archiveHasExpectedFileExtension(deployment.getArchive()))) {
             log.warning("Deployment archive of type " + deployment.getArchive().getClass().getSimpleName()
                 + " has been given an unexpected file extension. Archive name: " + deployment.getArchive().getName()
                 + ", deployment name: " + deployment.getName() + ". It might not be wrong, but the container will"


### PR DESCRIPTION
It seems to me that there is possibility to create valid deployment without the archive (f.e. with only descriptor). In such case this check will always fail with NullPointerException.
