### PR TITLE
fix: removes duplicate "version.shrinkwrap_resolver"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -46,7 +46,6 @@
     <version.shrinkwrap_core>1.2.6</version.shrinkwrap_core>
     <version.shrinkwrap_descriptors>2.0.0</version.shrinkwrap_descriptors>
     <version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
-    <version.shrinkwrap_resolver>3.1.4</version.shrinkwrap_resolver>
 
     <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/
     </jboss.releases.repo.url>


### PR DESCRIPTION
There appears to be a duplicate entry for `version.shrinkwrap_resolver` in bom/pom.xml.