### PR TITLE
Added integration tests for JUnit 5 lifecycle methods

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ *
+ * @author lprimak
+ */
+public class FileWriterExtension implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
+    private static Path TMP_FILE_PATH;
+    static final String TMP_FILE_ASSET_NAME = "temporaryFileAsset";
+
+    enum RunsWhere {
+        CLIENT,
+        SERVER,
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        if (!isRunningOnServer()) {
+            Path tempDir = Files.createTempDirectory("arquillianLifecycleTest");
+            initTmpFileName(tempDir);
+            assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
+            createTmpFile();
+        }
+        extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(this.getClass().getName(), this);
+    }
+
+    @Override
+    public void close() throws Throwable {
+        if (isRunningOnServer()) {
+            return;
+        }
+        String contents;
+        try (FileReader fileReader = new FileReader(getTmpFilePath().toFile())) {
+            char[] buf = new char[1000];
+            int length = fileReader.read(buf);
+            contents = new String(buf, 0, length - 1);
+        }
+        Path tempDir = getTmpFilePath().getParent();
+        Files.walk(tempDir).map(Path::toFile).forEach(File::delete);
+        assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
+        assertEquals("before_all,before_each,test_one,after_each,before_each,test_two,after_each,after_all", contents);
+    }
+
+    static void initTmpFileName(Path tmpDirBase) {
+        TMP_FILE_PATH = tmpDirBase.getParent().resolve(
+                tmpDirBase.getFileName() + "-arquillianLifecycleTest")
+            .resolve("lifecycleOutput");
+    }
+
+    void createTmpFile() throws IOException {
+        TMP_FILE_PATH.getParent().toFile().mkdir();
+        File tmpFile = TMP_FILE_PATH.toFile();
+        tmpFile.delete();
+        assertTrue(tmpFile.createNewFile(), "cannot create results file");
+    }
+
+    static Path getTmpFilePath() {
+        if (isRunningOnServer()) {
+            try (InputStream istrm = Thread.currentThread().getContextClassLoader()
+                    .getResourceAsStream(TMP_FILE_ASSET_NAME)) {
+                return Paths.get(new BufferedReader(new InputStreamReader(istrm)).readLine());
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        } else {
+            return TMP_FILE_PATH;
+        }
+    }
+
+    static void appendToFile(String str) {
+        try (FileWriter fw = new FileWriter(getTmpFilePath().toFile(), true)) {
+            fw.append(str + ",");
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    static void checkRunsWhere(RunsWhere expected) {
+        assertEquals(expected, isRunningOnServer() ? RunsWhere.SERVER : RunsWhere.CLIENT);
+    }
+
+    static boolean isRunningOnServer() {
+        try {
+            new InitialContext().lookup("java:comp/env");
+            return true;
+        } catch (NamingException ex) {
+            return false;
+        }
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/Greeter.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/Greeter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import jakarta.enterprise.context.Dependent;
+import java.io.PrintStream;
+
+/**
+ *
+ * @author lprimak
+ */
+@Dependent
+public class Greeter {
+    public void greet(PrintStream to, String name) {
+        to.println(createGreeting(name));
+    }
+
+    public String createGreeting(String name) {
+        return "Hello, " + name + "!";
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/LifecycleMethodsTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/LifecycleMethodsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.CLIENT;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.TMP_FILE_ASSET_NAME;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.appendToFile;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.checkRunsWhere;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.getTmpFilePath;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author lprimak
+ */
+@ExtendWith(FileWriterExtension.class)
+@ExtendWith(ArquillianExtension.class)
+public class LifecycleMethodsTest {
+    @Inject
+    Greeter greeter;
+
+    @Test
+    @Order(1)
+    void one() {
+        assertEquals("one", "one");
+        appendToFile("test_one");
+        checkRunsWhere(SERVER);
+    }
+
+    @Test
+    @Order(2)
+    void should_create_greeting() {
+        assertEquals("Hello, Earthling!", greeter.createGreeting("Earthling"));
+        greeter.greet(System.out, "Earthling");
+        appendToFile("test_two");
+        checkRunsWhere(SERVER);
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        appendToFile("before_all");
+        checkRunsWhere(CLIENT);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        appendToFile("before_each");
+        checkRunsWhere(SERVER);
+    }
+
+    @AfterEach
+    void afterEeach() {
+        appendToFile("after_each");
+        checkRunsWhere(SERVER);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        appendToFile("after_all");
+        checkRunsWhere(CLIENT);
+    }
+
+
+    @Deployment
+    static JavaArchive createDeployment() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+                .addClass(FileWriterExtension.class)
+                .addClass(Greeter.class)
+                .addAsResource(new StringAsset(getTmpFilePath().toString()), TMP_FILE_ASSET_NAME);
+        return jar;
+    }
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -109,6 +109,19 @@
               </configuration>
             </execution>
             <execution>
+              <id>lifecycle-tests</id>
+              <goals>
+                <goal>test</goal>
+              </goals>
+              <phase>test</phase>
+              <configuration>
+                <skip>${skipTests}</skip>
+                <includes>
+                  <include>org.jboss.arquillian.integration.test.lifecycle.*Test</include>
+                </includes>
+              </configuration>
+            </execution>
+            <execution>
               <id>manual-mode-tests</id>
               <goals>
                 <goal>test</goal>


### PR DESCRIPTION
#### Short description of what this resolves:
Integration tests for lifecycle methods with JUnit 5
Relates to #310 #309 and #301

using `@TempDir` as a base for temporary directory
Could not use it 'as is' because it gets deleted for each test class,
but the files need to be kept throughout the test suite

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"
