### PR TITLE
CDIInjectionEnricher uses deprecated BeanManager method, switch to a …

### DIFF
--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
@@ -121,8 +121,9 @@ public class CDIInjectionEnricher implements TestEnricher {
     @SuppressWarnings("unchecked")
     protected void injectNonContextualInstance(BeanManager manager, Object instance) {
         CreationalContext<Object> creationalContext = getCreationalContext();
-        InjectionTarget<Object> injectionTarget = (InjectionTarget<Object>) manager.createInjectionTarget(manager
-            .createAnnotatedType(instance.getClass()));
+        InjectionTarget<Object> injectionTarget = (InjectionTarget<Object>) manager
+                .getInjectionTargetFactory(manager.createAnnotatedType(instance.getClass()))
+                .createInjectionTarget(null);
         injectionTarget.inject(instance, creationalContext);
     }
 }


### PR DESCRIPTION
…replacement.

Fixes #338
