### PR TITLE
refactor: migrates to mockito-core and enforces jdk8 bytecode

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -27,7 +27,7 @@
     <version.junit>4.13.2</version.junit>
     <version.junit5.platform>1.8.2</version.junit5.platform>
     <version.junit5>5.8.2</version.junit5>
-    <version.mockito_all>1.10.19</version.mockito_all>
+    <version.mockito>3.10.0</version.mockito>
     <version.testng>7.4.0</version.testng>
     <version.assertj>3.21.0</version.assertj>
   </properties>
@@ -99,8 +99,8 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${version.mockito_all}</version>
+        <artifactId>mockito-core</artifactId>
+        <version>3.10.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.10.0</version>
+        <version>${version.mockito}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/config/impl-base/pom.xml
+++ b/config/impl-base/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/container/impl-base/pom.xml
+++ b/container/impl-base/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
@@ -17,7 +17,6 @@
  */
 package org.jboss.arquillian.container.impl.client.container;
 
-import java.util.List;
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.container.impl.LocalContainerRegistry;
 import org.jboss.arquillian.container.impl.client.ContainerDeploymentContextHandler;
@@ -58,7 +57,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -112,9 +113,7 @@ public class ContainerDeployControllerTestCase extends AbstractContainerTestBase
     @Before
     public void setup() throws Exception {
         when(deployableContainer1.deploy(isA(Archive.class))).thenReturn(protocolMetaData);
-        when(deployableContainer1.getConfigurationClass()).thenReturn(DummyContainerConfiguration.class);
         when(deployableContainer2.deploy(isA(Archive.class))).thenReturn(protocolMetaData);
-        when(deployableContainer2.getConfigurationClass()).thenReturn(DummyContainerConfiguration.class);
         when(serviceLoader.onlyOne(eq(DeployableContainer.class))).thenReturn(deployableContainer1, deployableContainer2);
         when(container1.getContainerName()).thenReturn(CONTAINER_1_NAME);
         when(container2.getContainerName()).thenReturn(CONTAINER_2_NAME);

--- a/container/test-impl-base/pom.xml
+++ b/container/test-impl-base/pom.xml
@@ -89,7 +89,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerTestCase.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * ClientDeployerTestCase
@@ -64,15 +64,9 @@ public class ClientDeployerTestCase extends AbstractContainerTestTestBase {
         ContainerRegistry reg = Mockito.mock(ContainerRegistry.class);
         Container container = Mockito.mock(Container.class);
         Mockito.when(container.getState()).thenReturn(State.STARTED);
-        Mockito.when(container.getName()).thenReturn("_DEFAULT_");
         Container containerStopped = Mockito.mock(Container.class);
-        Mockito.when(containerStopped.getState()).thenReturn(State.STOPPED);
-        Mockito.when(containerStopped.getName()).thenReturn("_CONTAINER_STOPPED_");
 
-        Mockito.when(reg.getContainer("_DEFAULT_")).thenReturn(container);
-        Mockito.when(reg.getContainer("_CONTAINER_STOPPED_")).thenReturn(containerStopped);
         Mockito.when(reg.getContainer(new TargetDescription("_DEFAULT_"))).thenReturn(container);
-        Mockito.when(reg.getContainer(new TargetDescription("_CONTAINER_STOPPED_"))).thenReturn(containerStopped);
 
         bind(ApplicationScoped.class, DeploymentScenario.class, new DeploymentScenario());
         bind(ApplicationScoped.class, ContainerRegistry.class, reg);

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistryTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistryTestCase.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.arquillian.container.test.impl.domain;
 
-import java.util.HashMap;
 import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
 import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
 import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfiguration;
@@ -26,7 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
 
 /**
  * DomainModelTestCase
@@ -44,7 +45,6 @@ public class ProtocolRegistryTestCase {
     @Before
     public void setup() throws Exception {
         Mockito.when(protocol.getDescription()).thenReturn(new ProtocolDescription(name));
-        Mockito.when(protocol.getProtocolConfigurationClass()).thenReturn(DummyProtocolConfiguration.class);
     }
 
     @Test

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProviderTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProviderTestCase.java
@@ -25,7 +25,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * ArquillianTestEnricherTestCase

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
@@ -114,16 +114,12 @@ public abstract class OperatesOnDeploymentAwareProviderBase extends AbstractCont
         Mockito.when(registry.getContainer(
             new TargetDescription("X")))
             .thenReturn(new ContainerImpl("X", deployableContainer, new ContainerDefImpl("X")));
-        Mockito.when(registry.getContainer(
-            new TargetDescription("Z")))
-            .thenReturn(new ContainerImpl("Z", deployableContainer, new ContainerDefImpl("Z")));
 
         Deployment deploymentZ = new Deployment(new DeploymentDescription("Z", ShrinkWrap.create(JavaArchive.class))
             .setTarget(new TargetDescription("Z")));
         Deployment deploymentX = new Deployment(new DeploymentDescription("X", ShrinkWrap.create(JavaArchive.class))
             .setTarget(new TargetDescription("X")));
 
-        Mockito.when(scenario.deployment(new DeploymentTargetDescription("Z"))).thenReturn(deploymentZ);
         Mockito.when(scenario.deployment(new DeploymentTargetDescription("X"))).thenReturn(deploymentX);
 
         ContainerContext containerContext = getManager().getContext(ContainerContext.class);

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProviderTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProviderTestCase.java
@@ -28,7 +28,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * ArquillianTestEnricherTestCase

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuterTestCase.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * InContainerExecuterTestCase
@@ -54,7 +54,6 @@ public class LocalTestExecuterTestCase extends AbstractContainerTestTestBase {
     public void shouldReturnPassed() throws Throwable {
         bind(ApplicationScoped.class, ServiceLoader.class, serviceLoader);
 
-        Mockito.when(testExecutor.getInstance()).thenReturn(this);
         Mockito.when(testExecutor.getMethod()).thenReturn(
             getTestMethod("shouldReturnPassed"));
 
@@ -81,7 +80,6 @@ public class LocalTestExecuterTestCase extends AbstractContainerTestTestBase {
 
         Exception exception = new Exception();
 
-        Mockito.when(testExecutor.getInstance()).thenReturn(this);
         Mockito.when(testExecutor.getMethod()).thenReturn(
             getTestMethod("shouldReturnFailedOnException"));
         Mockito.doThrow(exception).when(testExecutor).invoke();

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuterTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
 import org.jboss.arquillian.container.test.impl.domain.ProtocolDefinition;
 import org.jboss.arquillian.container.test.impl.domain.ProtocolRegistry;
+import org.jboss.arquillian.container.test.impl.domain.ProtocolRegistryTestCase;
 import org.jboss.arquillian.container.test.impl.execution.event.RemoteExecutionEvent;
 import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
 import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
@@ -46,7 +47,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -103,6 +104,7 @@ public class RemoteTestExecuterTestCase extends AbstractContainerTestTestBase {
 
         Mockito.when(deploymentDescription.getProtocol()).thenReturn(new ProtocolDescription("TEST"));
         Mockito.when(protocolRegistry.getProtocol(Mockito.any(ProtocolDescription.class))).thenReturn(protocolDefinition);
+        Mockito.when(protocolDefinition.createProtocolConfiguration()).thenReturn(new ProtocolRegistryTestCase.DummyProtocolConfiguration());
         Mockito.when(protocolDefinition.getProtocol()).thenReturn(protocol);
         Mockito.when(protocol.getExecutor(
             Mockito.any(ProtocolConfiguration.class),
@@ -113,10 +115,6 @@ public class RemoteTestExecuterTestCase extends AbstractContainerTestTestBase {
                 return new TestContainerMethodExecutor((CommandCallback) invocation.getArguments()[2]);
             }
         });
-
-        Mockito.when(testExecutor.getInstance()).thenReturn(this);
-        Mockito.when(testExecutor.getMethod()).thenReturn(
-            getTestMethod("shouldReactivePreviousContextsOnRemoteEvents"));
     }
 
     @Test

--- a/junit/container/pom.xml
+++ b/junit/container/pom.xml
@@ -89,7 +89,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/junit/core/pom.xml
+++ b/junit/core/pom.xml
@@ -73,7 +73,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/junit/standalone/pom.xml
+++ b/junit/standalone/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/junit5/container/pom.xml
+++ b/junit5/container/pom.xml
@@ -93,7 +93,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     <!-- 3.8.1-jboss-1 is causing issues with test deps -->
     <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
 
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
 
     <!-- External Deps -->
     <version.shrinkwrap_shrinkwrap>1.2.6</version.shrinkwrap_shrinkwrap>

--- a/test/impl-base/pom.xml
+++ b/test/impl-base/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptorTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptorTestCase.java
@@ -97,7 +97,6 @@ public class EventTestRunnerAdaptorTestCase extends AbstractTestTestBase {
         Object testInstance = this;
 
         TestMethodExecutor testExecutor = Mockito.mock(TestMethodExecutor.class);
-        Mockito.when(testExecutor.getInstance()).thenReturn(testInstance);
         Mockito.when(testExecutor.getMethod()).thenReturn(testMethod);
 
         // ApplicationContext is auto started, deactivate to be future proof

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
@@ -35,7 +35,7 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.internal.matchers.VarargMatcher;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -121,8 +121,8 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
     @Test
     public void shouldBeAbleToInjectBaseContext() throws Exception {
         Mockito.when(resourceProvider.lookup(
-            (ArquillianResource) Mockito.any(),
-            Mockito.argThat(new ClassInjectionAnnotationMatcher())))
+                Mockito.any(ArquillianResource.class),
+                Mockito.any(ResourceProvider.ClassInjection.class)))
             .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -139,9 +139,9 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         Method resourceMethod = ObjectClass.class.getMethod("test", Object.class);
 
         Mockito.when(
-            resourceProvider.lookup(
-                (ArquillianResource) Mockito.any(),
-                Mockito.argThat(new MethodInjectionAnnotationMatcher())))
+                resourceProvider.lookup(
+                    Mockito.any(ArquillianResource.class),
+                    Mockito.any(ResourceProvider.MethodInjection.class)))
             .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -157,12 +157,11 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         Field resource2Field = ObjectClass2.class.getField("resource2");
 
         Mockito.when(
-            resourceProvider.lookup(
-                (ArquillianResource) Mockito.any(),
-                Mockito.argThat(
-                    new CustomAnnotationMatcher(
-                        resource2Field.getAnnotation(ArquillianTestQualifier.class),
-                        ResourceProvider.ClassInjection.class))))
+                resourceProvider.lookup(
+                    Mockito.any(ArquillianResource.class),
+                    Mockito.any(resource2Field.getAnnotation(ArquillianTestQualifier.class).getClass()),
+                    Mockito.any(ResourceProvider.ClassInjection.class)
+                ))
             .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -180,13 +179,13 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         Mockito.when(resourceProvider1.canProvide(Object.class)).thenReturn(true);
 
         Mockito.when(resourceProvider.lookup(
-            (ArquillianResource) Mockito.any(),
-            Mockito.argThat(new ClassInjectionAnnotationMatcher())))
+                Mockito.any(ArquillianResource.class),
+                Mockito.any(ResourceProvider.ClassInjection.class)))
             .thenReturn(null);
 
         Mockito.when(resourceProvider1.lookup(
-            (ArquillianResource) Mockito.any(),
-            Mockito.argThat(new ClassInjectionAnnotationMatcher())))
+                Mockito.any(ArquillianResource.class),
+                Mockito.any(ResourceProvider.ClassInjection.class)))
             .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -205,13 +204,13 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         Mockito.when(resourceProvider1.canProvide(Object.class)).thenReturn(true);
 
         Mockito.when(resourceProvider.lookup(
-            (ArquillianResource) Mockito.any(),
-            Mockito.argThat(new ClassInjectionAnnotationMatcher())))
+                Mockito.any(ArquillianResource.class),
+                Mockito.any(ResourceProvider.ClassInjection.class)))
             .thenReturn(null);
 
         Mockito.when(resourceProvider1.lookup(
-            (ArquillianResource) Mockito.any(),
-            Mockito.argThat(new ClassInjectionAnnotationMatcher())))
+                Mockito.any(ArquillianResource.class),
+                Mockito.any(ResourceProvider.ClassInjection.class)))
             .thenReturn(null);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -238,12 +237,11 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         Method resourceMethod = ObjectClass.class.getMethod("testWithQualifier", Object.class);
 
         Mockito.when(
-            resourceProvider.lookup(
-                (ArquillianResource) Mockito.any(),
-                Mockito.argThat(
-                    new CustomAnnotationMatcher(
-                        resourceMethod.getParameterAnnotations()[0][1],
-                        ResourceProvider.MethodInjection.class))))
+                resourceProvider.lookup(
+                    Mockito.any(ArquillianResource.class),
+                    Mockito.any(resourceMethod.getParameterAnnotations()[0][1].getClass()),
+                    Mockito.any(ResourceProvider.MethodInjection.class)
+                ))
             .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
@@ -257,15 +255,6 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
     @Test
     public void shouldThrowExceptionWhenUsedMethodScopeInjectionOnArquillianResource() throws Exception {
         Method resourceMethod = ObjectClass3.class.getMethod("testWithInjectionQualifier", Object.class);
-
-        Mockito.when(
-            resourceProvider.lookup(
-                (ArquillianResource) Mockito.any(),
-                Mockito.argThat(
-                    new CustomAnnotationMatcher(
-                        resourceMethod.getParameterAnnotations()[0][1],
-                        ResourceProvider.MethodInjection.class))))
-            .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
         injector.get().inject(enricher);
@@ -283,13 +272,6 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
 
     @Test
     public void shouldThrowExceptionWhenUsedClassScopeInjectionOnArquillianResource() {
-
-        Mockito.when(
-            resourceProvider.lookup(
-                (ArquillianResource) Mockito.any(),
-                Mockito.argThat(
-                    new ClassInjectionAnnotationMatcher())))
-            .thenReturn(resource);
 
         TestEnricher enricher = new ArquillianResourceTestEnricher();
         injector.get().inject(enricher);
@@ -335,50 +317,6 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
         public Object resource;
 
         public void testWithInjectionQualifier(@ArquillianResource @ResourceProvider.MethodInjection Object resource) {
-        }
-    }
-
-    private class ClassInjectionAnnotationMatcher extends ArgumentMatcher<Annotation[]> implements VarargMatcher {
-        private static final long serialVersionUID = 7468313136186740343L;
-
-        @Override
-        public boolean matches(Object varargArgument) {
-            Class<?> qualifier = ((Annotation) varargArgument).annotationType();
-
-            return qualifier.equals(ResourceProvider.ClassInjection.class);
-        }
-    }
-
-    private class MethodInjectionAnnotationMatcher extends ArgumentMatcher<Annotation[]> implements VarargMatcher {
-        private static final long serialVersionUID = 7468313136186740343L;
-
-        @Override
-        public boolean matches(Object varargArgument) {
-            Class<?> qualifier = ((Annotation) varargArgument).annotationType();
-
-            return qualifier.equals(ResourceProvider.MethodInjection.class);
-        }
-    }
-
-    private class CustomAnnotationMatcher extends ArgumentMatcher<Annotation[]> implements VarargMatcher {
-        private static final long serialVersionUID = 7468313136186740343L;
-
-        private Annotation additionalQualifier;
-
-        private Class<? extends Annotation> injectionScope;
-
-        public CustomAnnotationMatcher(Annotation additionalQualifier, Class<? extends Annotation> injectionScope) {
-            this.additionalQualifier = additionalQualifier;
-            this.injectionScope = injectionScope;
-        }
-
-        @Override
-        public boolean matches(Object varargArgument) {
-            Annotation[] annotations = (Annotation[]) varargArgument;
-
-            return annotations.length == 2
-                && annotations[0].annotationType().equals(additionalQualifier.annotationType())
-                && annotations[1].annotationType().equals(injectionScope);
         }
     }
 }

--- a/testng/core/pom.xml
+++ b/testng/core/pom.xml
@@ -69,7 +69,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
This PR solves https://github.com/arquillian/arquillian-core/issues/364

#### Changes proposed in this pull request:

- Bump java version from 1.6 to 1.8
- Remove mockito-all that is not maintained and use mockito-core
- Remove unused stubbing.


Fixes #364
