### PR TITLE
feat: provides default implementations for DeployableContainer

### DIFF
--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
@@ -22,7 +22,13 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 
 /**
- * DeployableContainer
+ * This interface defines a DeployableContainer in Arquillian.
+ *
+ * <p>
+ * Methods to get the configuration class, the default protocol and to deploy
+ * and undeploy an archive are required to be implemented. Other
+ * methods such as setup, start and stop default to NOOP, as not every
+ * type of container needs setup or an explicit start and stop.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @version $Revision: $

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
@@ -31,11 +31,14 @@ public interface DeployableContainer<T extends ContainerConfiguration> {
     // ControllableContainer
     Class<T> getConfigurationClass();
 
-    void setup(T configuration);
+    default void setup(T configuration) {
+    }
 
-    void start() throws LifecycleException;
+    default void start() throws LifecycleException {
+    }
 
-    void stop() throws LifecycleException;
+    default void stop() throws LifecycleException {
+    }
 
     // DeployableContainer
     ProtocolDescription getDefaultProtocol();
@@ -45,7 +48,9 @@ public interface DeployableContainer<T extends ContainerConfiguration> {
     void undeploy(Archive<?> archive) throws DeploymentException;
 
     // Admin ?
-    void deploy(Descriptor descriptor) throws DeploymentException;
+    default void deploy(Descriptor descriptor) throws DeploymentException {
+    }
 
-    void undeploy(Descriptor descriptor) throws DeploymentException;
+    default void undeploy(Descriptor descriptor) throws DeploymentException {
+    }
 }


### PR DESCRIPTION
Signed-off-by: arjantijms <arjan.tijms@gmail.com>


#### Short description of what this resolves:

Default methods for the DeployableContainer interface

#### Changes proposed in this pull request:

The DeployableContainer contains two methods that are never used: 
 - void deploy(Descriptor descriptor)
 - void undeploy(Descriptor descriptor)

Providing noop default methods for these reduces some of the noise in especially small implementations.

The interface also contains methods that are not always uses:
- void setup(T configuration)
- void start()
- void stop()

For instance, some embedded implementations don't have an explicit start/stop step. They start/stop implicitly with deploy/undeploy.


