### PR TITLE
Add a REST protocol option to not depend on servlet to run tests

### DIFF
--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -23,5 +23,6 @@
     <module>servlet</module>
     <module>servlet-jakarta</module>
     <module>jmx</module>
+    <module>rest-jakarta</module>
   </modules>
 </project>

--- a/protocols/rest-jakarta/README.adoc
+++ b/protocols/rest-jakarta/README.adoc
@@ -1,0 +1,10 @@
+= Jakarta EE 9 REST 3 API Protocol
+
+This is a port of the servlet jakarta protocol handler for communicating using a REST application following the Jakarta RESTful Web Services 3.x spec.
+
+== Issues
+This relies on a release of org.eclipse.jetty:jetty-server that supports the Jakarta Servlet 5.x spec. The current
+11.0.0-alpha0 release in turn requires Java 11, so this module required Java 8 to compile the module artifact, but
+it requires Java 11 to build and run the modules tests.
+
+https://github.com/eclipse/jetty.project

--- a/protocols/rest-jakarta/pom.xml
+++ b/protocols/rest-jakarta/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian</groupId>
+    <artifactId>arquillian-build</artifactId>
+    <version>1.7.0.Final-SNAPSHOT</version>
+    <relativePath>../../build/pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.protocol</groupId>
+  <artifactId>arquillian-protocol-rest-jakarta</artifactId>
+  <name>Arquillian Protocol REST 3.x</name>
+  <description>Protocol handler for communicating using REST following the Jakarta RESTful Web Services 3.x spec and jakarta.ws.rs.* apis
+  </description>
+
+  <!-- Properties -->
+  <properties>
+    <!-- Versioning -->
+    <version.jetty_jetty>11.0.5</version.jetty_jetty>
+    <version.resteasy>6.0.3.Final</version.resteasy>
+    <version.restfulws-api>3.0.0</version.restfulws-api>
+    <!-- The protocol adaptor requires Java 8 -->
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-impl-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.protocol</groupId>
+      <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>shrinkwrap-descriptors-spi</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- restfulws api -->
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${version.restfulws-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!-- The test -->
+  <profiles>
+    <!-- Need to skip test compilation for Java8 and earlier since jetty-server is compiled under Java11 -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>[,9)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <!-- The tests need to be build and run the Java 11 due to the fact that jetty 11.x which
+        supports the Java EE 9 apis requires Java 11
+        -->
+        <maven.compiler.testSource>11</maven.compiler.testSource>
+        <maven.compiler.testTarget>11</maven.compiler.testTarget>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/REST3Extension.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/REST3Extension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class REST3Extension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(Protocol.class, RESTProtocol.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentAppender.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentAppender.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import org.jboss.arquillian.protocol.rest.runner.RESTRemoteExtension;
+
+public class RESTDeploymentAppender implements AuxiliaryArchiveAppender {
+
+    @Override
+    public JavaArchive createAuxiliaryArchive() {
+        // Load based on package to avoid ClassNotFoundException on Application when loading RESTTestRunner
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-jakarta-rest-protocol.jar")
+            .addPackage(RESTRemoteExtension.class.getPackage()) // rest.runner
+            .addAsServiceProvider(RemoteLoadableExtension.class, RESTRemoteExtension.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackager.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackager.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.Processor;
+import org.jboss.arquillian.protocol.servlet5.ServletUtil;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+import static org.jboss.arquillian.protocol.servlet5.ServletUtil.APPLICATION_XML_PATH;
+
+/**
+ * Same as the Servlet DeploymentPackager except uses the RESTDeploymentAppender instead.
+ */
+public class RESTDeploymentPackager implements DeploymentPackager {
+
+    @Override
+    public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
+        JavaArchive protocol = new RESTDeploymentAppender().createAuxiliaryArchive();
+
+        Archive<?> applicationArchive = testDeployment.getApplicationArchive();
+        Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
+
+        Processor processor = new Processor(testDeployment, processors);
+
+        if (Validate.isArchiveOfType(EnterpriseArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(EnterpriseArchive.class), auxiliaryArchives, protocol, processor,
+                testDeployment);
+        }
+
+        if (Validate.isArchiveOfType(WebArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(WebArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        if (Validate.isArchiveOfType(JavaArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(JavaArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        throw new IllegalArgumentException(RESTDeploymentPackager.class.getName() +
+            " can not handle archive of type " + applicationArchive.getClass().getName());
+    }
+
+    private Archive<?> handleArchive(WebArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        applicationArchive
+            .addAsLibraries(
+                auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        // Can be null when reusing logic in EAR packaging
+        if (protocol != null) {
+            applicationArchive.addAsLibrary(protocol);
+        }
+        processor.process(applicationArchive);
+        return applicationArchive;
+    }
+
+    private Archive<?> handleArchive(JavaArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        return handleArchive(
+            ShrinkWrap.create(WebArchive.class, "test-" + UUID.randomUUID().toString() + ".war")
+                .addAsLibrary(applicationArchive),
+            auxiliaryArchives,
+            protocol,
+            processor);
+    }
+
+    private Archive<?> handleArchive(EnterpriseArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor, TestDeployment testDeployment) {
+        Map<ArchivePath, Node> applicationArchiveWars = applicationArchive.getContent(Filters.include(".*\\.war"));
+        if (applicationArchiveWars.size() == 1) {
+            ArchivePath warPath = applicationArchiveWars.keySet().iterator().next();
+            try {
+                handleArchive(
+                    applicationArchive.getAsType(WebArchive.class, warPath),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Can not manipulate war's that are not of type " + WebArchive.class,
+                    e);
+            }
+        } else if (applicationArchiveWars.size() > 1) {
+            Archive<?> archiveToTest = testDeployment.getArchiveForEnrichment();
+            if (archiveToTest == null) {
+                throw new UnsupportedOperationException("Multiple WebArchives found in "
+                    + applicationArchive.getName()
+                    + ". Can not determine which to enrich");
+            } else if (!archiveToTest.getName().endsWith(".war")) {
+                //TODO: Removed throwing an exception when EJB modules are supported as well
+                throw new UnsupportedOperationException("Archive to test is not a WebArchive!");
+            } else {
+                handleArchive(
+                    archiveToTest.as(WebArchive.class),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            }
+        } else {
+            // reuse handle(JavaArchive, ..) logic
+            Archive<?> wrappedWar = handleArchive(protocol, new ArrayList<Archive<?>>(), null, processor);
+            applicationArchive
+                .addAsModule(wrappedWar);
+
+            if (applicationArchive.contains(APPLICATION_XML_PATH)) {
+                ApplicationDescriptor applicationXml = Descriptors.importAs(ApplicationDescriptor.class).fromStream(
+                    applicationArchive.get(APPLICATION_XML_PATH).getAsset().openStream());
+
+                applicationXml.webModule(wrappedWar.getName(), ServletUtil.calculateContextRoot(wrappedWar.getName()));
+
+                // SHRINKWRAP-187, to eager on not allowing overrides, delete it first
+                applicationArchive.delete(APPLICATION_XML_PATH);
+                applicationArchive.setApplicationXML(
+                    new StringAsset(applicationXml.exportAsString()));
+            }
+        }
+
+        applicationArchive.addAsLibraries(
+            auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        return applicationArchive;
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTMethodExecutor.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTMethodExecutor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.Timer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletMethodExecutor;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+
+public class RESTMethodExecutor extends ServletMethodExecutor {
+    public static final String ARQUILLIAN_REST_NAME = "ArquillianRESTRunnerEE9";
+    public static final String ARQUILLIAN_REST_MAPPING = "/" + ARQUILLIAN_REST_NAME;
+
+    public RESTMethodExecutor(ServletProtocolConfiguration config, Collection<HTTPContext> contexts,
+            CommandCallback callback) {
+        if (config == null) {
+            throw new IllegalArgumentException("ServletProtocolConfiguration must be specified");
+        }
+        if (contexts == null || contexts.size() == 0) {
+            throw new IllegalArgumentException("HTTPContext must be specified");
+        }
+        if (callback == null) {
+            throw new IllegalArgumentException("Callback must be specified");
+        }
+        this.config = config;
+        this.uriHandler = new RESTURIHandler(config, contexts);
+        this.callback = callback;
+    }
+
+    @Override
+    public TestResult invoke(final TestMethodExecutor testMethodExecutor) {
+        if (testMethodExecutor == null) {
+            throw new IllegalArgumentException("TestMethodExecutor must be specified");
+        }
+
+        URI targetBaseURI = uriHandler.locateTestServlet(testMethodExecutor.getMethod());
+
+        Class<?> testClass = testMethodExecutor.getInstance().getClass();
+
+        Timer eventTimer = null;
+        Lock timerLock = new ReentrantLock();
+        AtomicBoolean isCanceled = new AtomicBoolean();
+        try {
+            String urlEncodedMethodName = URLEncoder.encode(testMethodExecutor.getMethodName(), "UTF-8");
+            final String url = targetBaseURI.toASCIIString() + ARQUILLIAN_REST_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName;
+
+            final String eventUrl = targetBaseURI.toASCIIString() + ARQUILLIAN_REST_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName + "&cmd=event";
+
+            eventTimer = createCommandServicePullTimer(eventUrl, timerLock, isCanceled);
+            return executeWithRetry(url, TestResult.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error launching test " + testClass.getName() + " "
+                + testMethodExecutor.getMethod(), e);
+        } finally {
+            if (eventTimer != null) {
+                eventTimer.cancel();
+                timerLock.lock();
+                try {
+                    isCanceled.set(true);
+                } finally {
+                    timerLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTProtocol.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTProtocol.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.Collection;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+
+public class RESTProtocol implements Protocol<ServletProtocolConfiguration> {
+    public static final String PROTOCOL_NAME = "REST 3.0";
+
+    @Override
+    public ProtocolDescription getDescription() {
+        return new ProtocolDescription(PROTOCOL_NAME);
+    }
+
+    @Override
+    public RESTMethodExecutor getExecutor(ServletProtocolConfiguration protocolConfiguration, ProtocolMetaData metaData,
+            CommandCallback callback) {
+        Collection<HTTPContext> contexts = metaData.getContexts(HTTPContext.class);
+        if (contexts.size() == 0) {
+            throw new IllegalArgumentException(
+                "No " + HTTPContext.class.getName() + " found in " + ProtocolMetaData.class.getName() + ". " +
+                    "REST protocol can not be used");
+        }
+        return new RESTMethodExecutor(protocolConfiguration, contexts, callback);
+    }
+
+    @Override
+    public DeploymentPackager getPackager() {
+        return new RESTDeploymentPackager();
+    }
+
+    @Override
+    public Class<ServletProtocolConfiguration> getProtocolConfigurationClass() {
+        return ServletProtocolConfiguration.class;
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTURIHandler.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTURIHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Collection;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.servlet5.ServletURIHandler;
+import org.jboss.arquillian.protocol.servlet5.ServletUtil;
+
+public class RESTURIHandler extends ServletURIHandler {
+
+    private ServletProtocolConfiguration config;
+    public RESTURIHandler(ServletProtocolConfiguration config, Collection<HTTPContext> contexts) {
+        super(config, contexts);
+        this.config = config;
+    }
+
+    public URI locateTestServlet(Method method) {
+        HTTPContext context = locateHTTPContext(method);
+        return ServletUtil.determineBaseURI(
+            config,
+            context,
+            RESTMethodExecutor.ARQUILLIAN_REST_NAME);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTCommandService.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTCommandService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+
+public class RESTCommandService implements CommandService {
+    private static long TIMEOUT = 30000;
+
+    @SuppressWarnings("unchecked")
+    public <T> T execute(Command<T> command) {
+        String currentId = RESTTestRunner.currentCall.get();
+        RESTTestRunner.events.put(currentId, command);
+
+        long timeoutTime = System.currentTimeMillis() + TIMEOUT;
+        while (timeoutTime > System.currentTimeMillis()) {
+            Command<?> newCommand = RESTTestRunner.events.get(currentId);
+            if (newCommand != null) {
+                if (newCommand.getThrowable() != null) {
+                    throw new RuntimeException(newCommand.getThrowable());
+                }
+                if (newCommand.getResult() != null) {
+                    return (T) newCommand.getResult();
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("No command response within timeout of " + TIMEOUT + " ms.");
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RESTProtocolApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(RESTTestRunner.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTRemoteExtension.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTRemoteExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+
+public class RESTRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(CommandService.class, RESTCommandService.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.util.TestRunners;
+import org.jboss.arquillian.test.spi.TestResult;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+
+/**
+ * RESTTestRunner
+ * <p>
+ * The server side executor for the REST protocol impl.
+ * <p>
+ * Supports multiple output modes ("outputmode"):
+ * - html
+ * - serializedObject
+ * 
+ * A conversion of the ServletTestRunner to use RESTful Web Services instead.
+ */
+@Path("/ArquillianRESTRunnerEE9")
+public class RESTTestRunner {
+    public static final String PARA_METHOD_NAME = "methodName";
+    public static final String PARA_CLASS_NAME = "className";
+    public static final String PARA_OUTPUT_MODE = "outputMode";
+    public static final String PARA_CMD_NAME = "cmd";
+    public static final String OUTPUT_MODE_SERIALIZED = "serializedObject";
+    public static final String OUTPUT_MODE_HTML = "html";
+    public static final String CMD_NAME_TEST = "test";
+    public static final String CMD_NAME_EVENT = "event";
+    static ConcurrentHashMap<String, Command<?>> events = new ConcurrentHashMap<>();
+    static ThreadLocal<String> currentCall = new ThreadLocal<>();
+
+    @POST
+    public Response doPost(@QueryParam(PARA_OUTPUT_MODE) String outputMode, @QueryParam(PARA_CLASS_NAME) String className,
+            @QueryParam(PARA_METHOD_NAME) String methodName, @QueryParam(PARA_CMD_NAME) String cmd, byte[] cmdObject) throws WebApplicationException, IOException {
+        return execute(outputMode, className, methodName, cmd, cmdObject);
+    }
+
+    @GET
+    public Response doGet(@QueryParam(PARA_OUTPUT_MODE) String outputMode, @QueryParam(PARA_CLASS_NAME) String className,
+            @QueryParam(PARA_METHOD_NAME) String methodName, @QueryParam(PARA_CMD_NAME) String cmd) throws WebApplicationException, IOException {
+        return execute(outputMode, className, methodName, cmd, null);
+    }
+
+    protected Response execute(String outputMode, String className, String methodName, String cmd, byte[] cmdObject)
+        throws WebApplicationException, IOException {
+        if (outputMode == null) {
+            outputMode = OUTPUT_MODE_HTML;
+        }
+        if (cmd == null) {
+            cmd = CMD_NAME_TEST;
+        }
+        ResponseBuilder response = Response.ok();
+        try {
+
+            if (className == null) {
+                throw new IllegalArgumentException(PARA_CLASS_NAME + " must be specified");
+            }
+            if (methodName == null) {
+                throw new IllegalArgumentException(PARA_METHOD_NAME + " must be specified");
+            }
+
+            currentCall.set(className + methodName);
+
+            if (CMD_NAME_TEST.equals(cmd)) {
+                executeTest(response, outputMode, className, methodName);
+            } else if (CMD_NAME_EVENT.equals(cmd)) {
+                executeEvent(cmdObject, response, className, methodName);
+            } else {
+                throw new RuntimeException("Unknown value for parameter" + PARA_CMD_NAME + ": " + cmd);
+            }
+        } catch (Exception e) {
+            if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+                writeObject(createFailedResult(e), response);
+            } else {
+                response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getMessage());
+            }
+        } finally {
+            currentCall.remove();
+        }
+        return response.build();
+    }
+
+    public void executeTest(ResponseBuilder response, String outputMode, String className, String methodName)
+        throws ClassNotFoundException, IOException {
+        Class<?> testClass = SecurityActions.getThreadContextClassLoader().loadClass(className);
+        TestRunner runner = TestRunners.getTestRunner();
+        TestResult testResult = runner.execute(testClass, methodName);
+        if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+            writeObject(testResult, response);
+        } else {
+            // TODO: implement a html view of the result
+            response.type(MediaType.TEXT_HTML_TYPE);
+            response.status(Status.OK);
+            StringBuilder buffer = new StringBuilder();
+            buffer.append("<html>\n");
+            buffer.append("<head><title>TCK Report</title></head>\n");
+            buffer.append("<body>\n");
+            buffer.append("<h2>Configuration</h2>\n");
+            buffer.append("<table>\n");
+            buffer.append("<tr>\n");
+            buffer.append("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            buffer.append("</tr>\n");
+
+            buffer.append("</table>\n");
+            buffer.append("<h2>Tests</h2>\n");
+            buffer.append("<table>\n");
+            buffer.append("<tr>\n");
+            buffer.append("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            buffer.append("</tr>\n");
+
+            buffer.append("</table>\n");
+            buffer.append("</body>\n");
+            response.entity(buffer.toString());
+        }
+    }
+
+    public void executeEvent(byte[] cmdObject, ResponseBuilder response, String className,
+        String methodName)
+        throws ClassNotFoundException, IOException {
+        String eventKey = className + methodName;
+
+        if (cmdObject != null && cmdObject.length > 0) {
+            response.status(Status.NO_CONTENT);
+            ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(cmdObject));
+            Command<?> result = (Command<?>) input.readObject();
+            input.close();
+
+            events.put(eventKey, result);
+        } else {
+            if (events.containsKey(eventKey) && events.get(eventKey).getResult() == null) {
+                response.status(Status.OK);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream output = new ObjectOutputStream(baos);
+                output.writeObject(events.remove(eventKey));
+                output.flush();
+                response.type(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+                response.entity(baos.toByteArray());
+                output.close();
+            } else {
+                response.status(Status.NO_CONTENT);
+            }
+        }
+    }
+
+    private void writeObject(Object object, ResponseBuilder response) {
+        try {
+            response.status(Status.OK);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(object);
+            oos.flush();
+            response.type(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+            response.entity(baos.toByteArray());
+            oos.close();
+        } catch (Exception e) {
+            try {
+                response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getMessage());
+            } catch (Exception e2) {
+                throw new RuntimeException("Could not write to output", e2);
+            }
+        }
+    }
+
+    private TestResult createFailedResult(Throwable throwable) {
+        return TestResult.failed(throwable);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/SecurityActions.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * Copy of the servlet SecurityActions since it is package protected
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/protocols/rest-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/protocols/rest-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.rest.REST3Extension

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.runner.RESTProtocolApplication;
+import org.jboss.arquillian.protocol.rest.runner.RESTTestRunner;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * AbstractServerBase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class AbstractServerBase {
+    Server server;
+
+    @Before
+    public void setup() throws Exception {
+        int port = getAvailableLocalPort();
+        server = new Server(port);
+
+        ServletContextHandler root = new ServletContextHandler(server, "/arquillian-protocol", ServletContextHandler.SESSIONS);
+        ServletHolder holder = new ServletHolder(HttpServletDispatcher.class); 
+        holder.setInitParameter("jakarta.ws.rs.Application", RESTProtocolApplication.class.getName());
+		root.addServlet(holder, "/");
+        server.start();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        MockTestRunner.clear();
+        server.stop();
+    }
+
+    private int getAvailableLocalPort() throws IOException {
+        ServerSocket socket = null;
+        try {
+            socket = new ServerSocket(0);
+            return socket.getLocalPort();
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+
+    protected Collection<HTTPContext> createContexts() {
+        List<HTTPContext> context = new ArrayList<HTTPContext>();
+        context.add(createContext());
+        return context;
+    }
+
+    protected HTTPContext createContext() {
+        URI baseURI = createBaseURL();
+        HTTPContext context = new HTTPContext(baseURI.getHost(), baseURI.getPort());
+        context.add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, baseURI.getPath()));
+        return context;
+    }
+
+    protected URI createBaseURL() {
+        NetworkConnector conn0 = (NetworkConnector) server.getConnectors()[0];
+        return URI.create("http://localhost:" + conn0.getPort() + "/arquillian-protocol");
+    }
+
+    protected URL createURL(String outputMode, String testClass, String methodName) {
+        StringBuilder url = new StringBuilder(createBaseURL().toASCIIString() + RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
+        boolean first = true;
+        if (outputMode != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_OUTPUT_MODE).append("=").append(outputMode);
+        }
+        if (testClass != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_CLASS_NAME).append("=").append(testClass);
+        }
+        if (methodName != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_METHOD_NAME).append("=").append(methodName);
+        }
+
+        try {
+            return new URL(url.toString());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create url", e);
+        }
+    }
+
+    public static class MockTestExecutor implements TestMethodExecutor, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public void invoke(Object... parameters) throws Throwable {
+        }
+
+        public String getMethodName() {
+            return getMethod().getName();
+        }
+
+        public Method getMethod() {
+            try {
+                return this.getClass().getMethod("getMethod");
+            } catch (Exception e) {
+                throw new RuntimeException("Could not find my own method ?? ");
+            }
+        }
+
+        public Object getInstance() {
+            return this;
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/BaseRESTProtocolTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/BaseRESTProtocolTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BaseRESTProtocolTestCase {
+    @Test
+    public void shouldFindTestServletInMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8080/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/test", result.toString());
+    }
+
+    @Test
+    public void shouldMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8081/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "testY"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "testX"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/testX", result.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnMissingNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne));
+        handler.locateTestServlet(testMethod);
+    }
+
+    private Collection<HTTPContext> to(HTTPContext... inputs) {
+        List<HTTPContext> contexts = new ArrayList<HTTPContext>();
+        Collections.addAll(contexts, inputs);
+        return contexts;
+    }
+
+    private Method getTestMethod(String methodName) throws Exception {
+        return getClass().getDeclaredMethod(methodName);
+    }
+
+
+   /*
+    * Methods used for RESTURIHandler HTTPContext lookups. 
+    */
+
+    @SuppressWarnings("unused")
+    private void testNoAnnotations() {
+    }
+
+    @TargetsContainer("X")
+    private void testTargeted() {
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolDeploymentAppenderTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolDeploymentAppenderTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolDeploymentAppenderTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolDeploymentAppenderTestCase {
+
+    @Test
+    public void shouldGenerateDependencies() throws Exception {
+
+        Archive<?> archive = new RESTDeploymentAppender().createAuxiliaryArchive();
+
+        Assert.assertFalse(
+            "Should not have added web-fragment.xml",
+            archive.contains(ArchivePaths.create("META-INF/web-fragment.xml"))
+        );
+
+        Assert.assertTrue(
+            "Should have added " + RemoteLoadableExtension.class.getName(),
+            archive.contains(ArchivePaths.create("META-INF/services/" + RemoteLoadableExtension.class.getName()))
+        );
+
+        System.out.println(archive.toString(true));
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.net.URL;
+
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.test.TestCommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.rest.runner.RESTTestRunner;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolTestCase extends AbstractServerBase {
+
+    @Test
+    public void shouldReturnTestResult() throws Exception {
+        MockTestRunner.add(TestResult.passed());
+
+        RESTMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "No Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldUseLogicalMethodNameAndSupportUrlReservedCharactersInIt() throws Exception {
+        final String testMethodNameWithReservedUrlCharacters = "non standard!test&name";
+
+        MockTestRunner.add(TestResult.passed());
+
+        RESTMethodExecutor executor = createExecutor();
+        executor.invoke(new MockTestExecutor() {
+            @Override
+            public String getMethodName() {
+                return testMethodNameWithReservedUrlCharacters;
+            }
+        });
+
+        Assert.assertEquals(
+            "Should use the logical method name",
+            testMethodNameWithReservedUrlCharacters,
+            MockTestRunner.testRequests.get(0).getMethodName()
+        );
+    }
+
+    @Test
+    public void shouldReturnThrownException() throws Exception {
+        MockTestRunner.add(TestResult.failed(new Exception().fillInStackTrace()));
+
+        RESTMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingTestClassParameter() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, null, null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingMethodParameter() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenErrorLoadingClass() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", "test");
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof ClassNotFoundException);
+    }
+
+    protected RESTMethodExecutor createExecutor() {
+        return new RESTMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback());
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTCommandServiceTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTCommandServiceTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Field;
+
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.test.TestCommandCallback;
+import org.jboss.arquillian.protocol.rest.test.TestIntegerCommand;
+import org.jboss.arquillian.protocol.rest.test.TestStringCommand;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.rest.runner.RESTCommandService;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTCommandServiceTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RESTCommandServiceTestCase extends AbstractServerBase {
+    @Test
+    public void shouldBeAbleToTransfereCommand() throws Exception {
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.passed());
+        MockTestRunner.add(new TestStringCommand());
+        MockTestRunner.add(new TestIntegerCommand());
+
+        RESTMethodExecutor executor = new RESTMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[0],
+            MockTestRunner.commandResults.get(0));
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[1],
+            MockTestRunner.commandResults.get(1));
+    }
+
+    @Test
+    public void shouldDisableCommandService() throws Exception {
+        Field f = RESTCommandService.class.getDeclaredField("TIMEOUT");
+        f.setAccessible(true);
+        f.set(null, 500);
+
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setPullInMilliSeconds(0);
+
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.failed(null));
+        MockTestRunner.add(new TestStringCommand());
+
+        RESTMethodExecutor executor = new RESTMethodExecutor(
+            config,
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertTrue(
+            "Timeout exception should have been thrown",
+            result.getThrowable().getMessage().contains("timeout"));
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackagerTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackagerTestCase.java
@@ -1,0 +1,299 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.api.Testable;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTDeploymentPackagerTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RESTDeploymentPackagerTestCase {
+    @Test
+    public void shouldHandleJavaArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined JavaArchive using EE6 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-rest-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify that the applicationArchive is placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/applicationArchive.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleWebArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(WebArchive.class, "applicationArchive.war"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined WebArchive using EE9 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-rest-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .setApplicationXML(createApplicationDescriptor()),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        String applicationXmlContent =
+            TestUtil.convertToString(archive.get("META-INF/application.xml").getAsset().openStream());
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-rest-protocol.war was added to the application.xml",
+            applicationXmlContent.contains(String.format("<web-uri>%s</web-uri>", JarNameProcessor.jarName)));
+
+        // ARQ-670
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-rest-protocol.war has correct context-root in application.xml",
+            applicationXmlContent.contains(String.format("<context-root>%s</context-root>",
+                    JarNameProcessor.jarName.replaceFirst(".war$", ""))));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithWebArchive() throws Exception {
+        WebArchive applicationWar = ShrinkWrap.create(WebArchive.class, "applicationArchive.war");
+
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(applicationWar),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-rest-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            processors()
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(ShrinkWrap.create(WebArchive.class))
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithMultipleWebArchiveAndOneMarkedWebArchive() throws Exception {
+        WebArchive testableArchive = Testable.archiveToTest(ShrinkWrap.create(WebArchive.class));
+
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(testableArchive)
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-rest-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    private Collection<Archive<?>> createAuxiliaryArchives() {
+        List<Archive<?>> archives = new ArrayList<Archive<?>>();
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive1.jar"));
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive2.jar"));
+
+        return archives;
+    }
+
+    private Asset createApplicationDescriptor() {
+        return new StringAsset(
+            Descriptors.create(ApplicationDescriptor.class)
+                .version("6")
+                .ejbModule("test.jar")
+                .exportAsString());
+    }
+
+    private Collection<ProtocolArchiveProcessor> processors() {
+        List<ProtocolArchiveProcessor> pros = new ArrayList<ProtocolArchiveProcessor>();
+        pros.add(new DummyProcessor());
+        pros.add(new JarNameProcessor());
+        return pros;
+    }
+
+    private static class DummyProcessor implements ProtocolArchiveProcessor {
+        public static boolean wasCalled = false;
+
+        public DummyProcessor() {
+            wasCalled = false;
+        }
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            wasCalled = true;
+        }
+    }
+
+    private static class JarNameProcessor implements ProtocolArchiveProcessor {
+        static String jarName;
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            jarName = protocolArchive.getName();
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/TestUtil.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/TestUtil.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URL;
+
+/**
+ * TestUtil
+ * <p>
+ * Internal helper for testcase to do http request
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestUtil {
+    private TestUtil() {
+    }
+
+    public static Object execute(URL url) {
+        ObjectInputStream input = null;
+        try {
+            input = new ObjectInputStream(url.openStream());
+            return input.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not fetch url " + url);
+        } finally {
+            close(input);
+        }
+    }
+
+    private static void close(InputStream input) {
+        if (input == null) {
+            return;
+        }
+        try {
+            input.close();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    public static String convertToString(InputStream in) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        out.close();
+        in.close();
+        return new String(out.toByteArray(), "UTF-8");
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/MockTestRunner.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/MockTestRunner.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.protocol.rest.runner.RESTCommandService;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * MockTestRunner
+ * <p>
+ * TestRunner that will return what you want for testing
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class MockTestRunner implements TestRunner {
+    public static TestResult wantedResults;
+
+    public static List<Command<?>> commands = new ArrayList<Command<?>>();
+    public static List<Object> commandResults = new ArrayList<Object>();
+
+    public static List<TestRequest> testRequests = new ArrayList<TestRequest>();
+
+    public static void add(Command<?> command) {
+        commands.add(command);
+    }
+
+    public static void add(TestResult wantedTestResult) {
+        wantedResults = wantedTestResult;
+    }
+
+    public static void clear() {
+        wantedResults = null;
+        commands.clear();
+        commandResults.clear();
+        testRequests.clear();
+    }
+
+    public TestResult execute(Class<?> testClass, String methodName) {
+        testRequests.add(new TestRequest(testClass, methodName));
+        for (Command<?> command : commands) {
+            commandResults.add(new RESTCommandService().execute(command));
+        }
+
+        return wantedResults;
+    }
+
+    public static class TestRequest {
+        private final Class<?> testClass;
+        private final String methodName;
+
+        public TestRequest(Class<?> testClass, String methodName) {
+            this.testClass = testClass;
+            this.methodName = methodName;
+        }
+
+        public Class<?> getTestClass() {
+            return testClass;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestCommandCallback.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestCommandCallback.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+
+/**
+ * TestRemoteCommandCallback
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestCommandCallback implements CommandCallback {
+    private Object[] results;
+
+    private int invocationCount = 0;
+
+    public TestCommandCallback(Object... object) {
+        results = object;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void fired(Command event) {
+        event.setResult(results[invocationCount++]);
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestIntegerCommand.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestIntegerCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestIntegerCommand implements Command<Integer>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Integer result;
+    private Throwable throwable;
+
+    @Override
+    public Integer getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Integer result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestStringCommand.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestStringCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestStringCommand implements Command<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String result;
+    private Throwable throwable;
+
+    @Override
+    public String getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/rest-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
+++ b/protocols/rest-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.rest.test.MockTestRunner


### PR DESCRIPTION
#### Short description of what this resolves:
Today arquillian has a servlet dependency in order to run a test on the application server.  To test functions like CDI and RESTful Web Services that do not require servlet, this is not suitable since MicroProfile and now Core Profile in Jakarta EE 10 do not require the application server to expose servlet API and function in applications.  This PR provides a way to run a test on a server that does not have servlet enabled by using a RESTful Web Services resource instead. 

#### Changes proposed in this pull request:
- Create a RESTful Web Services arquillian protocol so do not need to depend on servlet in an application server in order to run tests on the server.
- Duplicate the servlet-jakarta tests in the rest protocol project and update them to test the REST protocol

Fixes #408
