### PR TITLE
fix(release): changes javadoc settings for JDK 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,9 @@
 
   <properties>
     <!-- jboss-parent override -->
-    <!-- 3.8.1-jboss-1 is causing issues with test deps -->
-    <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
-
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <version.javadoc.plugin>3.4.0</version.javadoc.plugin>
 
     <!-- External Deps -->
     <version.shrinkwrap_shrinkwrap>1.2.6</version.shrinkwrap_shrinkwrap>
@@ -128,11 +126,11 @@
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <doclet>org.jboss.apiviz.APIviz</doclet>
+              <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
               <docletArtifact>
-                <groupId>org.jboss.apiviz</groupId>
-                <artifactId>apiviz</artifactId>
-                <version>1.3.2.GA</version>
+                <groupId>nl.talsmasoftware</groupId>
+                <artifactId>umldoclet</artifactId>
+                <version>2.0.18</version>
               </docletArtifact>
               <useStandardDocletOptions>true</useStandardDocletOptions>
               <charset>UTF-8</charset>


### PR DESCRIPTION
  * updates maven-javadoc-plugin to latest 3.4.0
  * swaps UML doclet to alternative working with latest JDKs
  * removes jboss-compiler overwrite as it's been fixed

Fixes #414