### PR TITLE
fix (release): Update bom to include new protocol-rest-jakarta artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -198,6 +198,11 @@
         <artifactId>arquillian-protocol-jmx</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.protocol</groupId>
+        <artifactId>arquillian-protocol-rest-jakarta</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Enrichers -->
       <dependency>


### PR DESCRIPTION
#### Short description of what this resolves:

The bom does not include the new protocol-rest-jakarta project.

#### Changes proposed in this pull request:

- Add protocol-rest-jakarta artifact to the bom.

Fixes #418
