### PR TITLE
fix(protocols):  Fix rest-jakarta protocol to not conflict with other REST Applications in war file

### DIFF
--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/ArquillianRESTRunnerEE9")
 public class RESTProtocolApplication extends Application {
 
     @Override

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
@@ -47,7 +47,7 @@ import jakarta.ws.rs.core.Response.Status;
  * 
  * A conversion of the ServletTestRunner to use RESTful Web Services instead.
  */
-@Path("/ArquillianRESTRunnerEE9")
+@Path("")
 public class RESTTestRunner {
     public static final String PARA_METHOD_NAME = "methodName";
     public static final String PARA_CLASS_NAME = "className";

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
@@ -58,7 +58,8 @@ public class AbstractServerBase {
         ServletContextHandler root = new ServletContextHandler(server, "/arquillian-protocol", ServletContextHandler.SESSIONS);
         ServletHolder holder = new ServletHolder(HttpServletDispatcher.class); 
         holder.setInitParameter("jakarta.ws.rs.Application", RESTProtocolApplication.class.getName());
-		root.addServlet(holder, "/");
+        holder.setInitParameter("resteasy.servlet.mapping.prefix", RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
+		root.addServlet(holder, RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
         server.start();
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

When an application has a REST Application with an ApplicationPath of /, the rest-jakarta conflicts with it causing 404 errors because only one Application starts.

#### Changes proposed in this pull request:

- Switch @ApplicationPath and @Path path values.

Fixes #436
