### PR TITLE
fix: propagates failures with TestNG 7.6.1+

### DIFF
--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -240,6 +240,7 @@ public abstract class Arquillian implements IHookable {
                     break;
             }
         } catch (Exception e) {
+            testResult.setStatus(ITestResult.FAILURE);
             testResult.setThrowable(e);
         }
     }

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -213,6 +213,10 @@ public abstract class Arquillian implements IHookable {
                     return Arquillian.this;
                 }
             });
+
+            // calculate test end time. this is overwritten in the testng invoker..
+            testResult.setEndMillis((result.getStart() - result.getEnd()) + testResult.getStartMillis());
+
             Throwable throwable = result.getThrowable();
             if (throwable != null) {
                 if (result.getStatus() == Status.SKIPPED) {
@@ -224,20 +228,18 @@ public abstract class Arquillian implements IHookable {
 
                 // setting status as failed.
                 testResult.setStatus(ITestResult.FAILURE);
-            }
-
-            // calculate test end time. this is overwritten in the testng invoker..
-            testResult.setEndMillis((result.getStart() - result.getEnd()) + testResult.getStartMillis());
-            switch(result.getStatus()) {
-                case PASSED:
-                    testResult.setStatus(ITestResult.SUCCESS);
-                    break;
-                case FAILED:
-                    testResult.setStatus(ITestResult.FAILURE);
-                    break;
-                case SKIPPED:
-                    testResult.setStatus(ITestResult.SKIP);
-                    break;
+            } else {
+                switch (result.getStatus()) {
+                    case PASSED:
+                        testResult.setStatus(ITestResult.SUCCESS);
+                        break;
+                    case FAILED:
+                        testResult.setStatus(ITestResult.FAILURE);
+                        break;
+                    case SKIPPED:
+                        testResult.setStatus(ITestResult.SKIP);
+                        break;
+                }
             }
         } catch (Exception e) {
             testResult.setStatus(ITestResult.FAILURE);

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -228,6 +228,17 @@ public abstract class Arquillian implements IHookable {
 
             // calculate test end time. this is overwritten in the testng invoker..
             testResult.setEndMillis((result.getStart() - result.getEnd()) + testResult.getStartMillis());
+            switch(result.getStatus()) {
+                case PASSED:
+                    testResult.setStatus(ITestResult.SUCCESS);
+                    break;
+                case FAILED:
+                    testResult.setStatus(ITestResult.FAILURE);
+                    break;
+                case SKIPPED:
+                    testResult.setStatus(ITestResult.SKIP);
+                    break;
+            }
         } catch (Exception e) {
             testResult.setThrowable(e);
         }


### PR DESCRIPTION
fixes https://github.com/arquillian/arquillian-core/issues/427
fixes https://github.com/flowlogix/test-arq-suite/pull/49

Short description of what this resolves:

After upgrading to TestNG 7.6.1+ Arquillian no longer works

Changes proposed in this pull request:

Sets status for TestNG tests when tests succeed, fail or skipped.
Previously TestNG status was only set on failure