### PR TITLE
Fixed slf4j NoClassDefFoundError for TestNG 7.5+ Used in Target Container 

### DIFF
--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppender.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppender.java
@@ -59,6 +59,12 @@ public class TestNGDeploymentAppender extends CachedAuxilliaryArchiveAppender {
             Filters.includeAll(),
             "com.beust");
 
+        // Attempt to add org.slf4j, internal TestNG package 7.5+ use slf4j
+        optionalPackages(
+            archive,
+            Filters.includeAll(),
+            "org.slf4j");
+
         return archive;
     }
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
I encounter a `java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory` when I use `TestNG` 7.5+ version. TestNG requires slf4j package however the target container (Payara-Micro) does not have it

#### Changes proposed in this pull request:
- Update TestNG Auxilliary Appender to add org.slf4j package

#### Bug Reproducer
https://github.com/arieki/arquillian-reproducer
