### PR TITLE
chore: replace deprecated org.jboss.arquillian.container.test.spi.TestDeployment constructor

### DIFF
--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackagerTestCase.java
@@ -50,6 +50,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleJavaArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
                 createAuxiliaryArchives()),
             processors());
@@ -79,6 +80,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleWebArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(WebArchive.class, "applicationArchive.war"),
                 createAuxiliaryArchives()),
             processors());
@@ -108,6 +110,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
                 createAuxiliaryArchives()),
             processors());
@@ -133,6 +136,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .setApplicationXML(createApplicationDescriptor()),
                 createAuxiliaryArchives()),
@@ -173,6 +177,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(applicationWar),
                 createAuxiliaryArchives()),
@@ -204,7 +209,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
-            new TestDeployment(ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
             processors()
         );
     }
@@ -213,6 +218,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(ShrinkWrap.create(WebArchive.class))
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -226,6 +232,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(testableArchive)
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -259,6 +266,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackagerTestCase.java
@@ -53,6 +53,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleJavaArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
                 createAuxiliaryArchives()),
             processors());
@@ -82,6 +83,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleWebArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(WebArchive.class, "applicationArchive.war")
                     .addClass(getClass()),
                 createAuxiliaryArchives()),
@@ -109,6 +111,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleWebArchiveWithWebXML() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(WebArchive.class, "applicationArchive.war")
                     .addClass(getClass())
                     .setWebXML(createWebDescriptor()),
@@ -138,6 +141,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
                 createAuxiliaryArchives()),
             processors());
@@ -163,6 +167,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .setApplicationXML(createApplicationDescriptor()),
                 createAuxiliaryArchives()),
@@ -202,6 +207,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(applicationWar),
                 createAuxiliaryArchives()),
@@ -232,7 +238,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
-            new TestDeployment(ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
             processors()
         );
     }
@@ -241,6 +247,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(ShrinkWrap.create(WebArchive.class))
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -254,6 +261,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(testableArchive)
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -286,6 +294,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackagerTestCase.java
@@ -50,6 +50,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleJavaArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
                 createAuxiliaryArchives()),
             processors());
@@ -79,6 +80,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleWebArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(WebArchive.class, "applicationArchive.war"),
                 createAuxiliaryArchives()),
             processors());
@@ -108,6 +110,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchive() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
                 createAuxiliaryArchives()),
             processors());
@@ -133,6 +136,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .setApplicationXML(createApplicationDescriptor()),
                 createAuxiliaryArchives()),
@@ -173,6 +177,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(applicationWar),
                 createAuxiliaryArchives()),
@@ -204,7 +209,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
-            new TestDeployment(ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
             processors()
         );
     }
@@ -213,6 +218,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(ShrinkWrap.create(WebArchive.class))
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -226,6 +232,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
 
         Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(testableArchive)
                     .addAsModule(ShrinkWrap.create(WebArchive.class)),
@@ -259,6 +266,7 @@ public class ServletProtocolDeploymentPackagerTestCase {
     public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
         new ServletProtocolDeploymentPackager().generateDeployment(
             new TestDeployment(
+                null,
                 ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
                     .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
@@ -83,7 +83,7 @@ public class BeansXMLProtocolProcessorTestCase {
         WebArchive protocol = ShrinkWrap.create(WebArchive.class);
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(protocol, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, protocol, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertFalse(protocol.contains("WEB-INF/beans.xml"));
     }
@@ -97,7 +97,7 @@ public class BeansXMLProtocolProcessorTestCase {
         WebArchive protocol = deployment.as(WebArchive.class);
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
 
@@ -117,7 +117,7 @@ public class BeansXMLProtocolProcessorTestCase {
             .addAsWebInfResource(new StringAsset(beansXmlContent), "beans.xml");
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
 
@@ -137,7 +137,7 @@ public class BeansXMLProtocolProcessorTestCase {
             .addAsManifestResource(new StringAsset(beansXmlContent), "beans.xml");
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("META-INF/beans.xml"));
 
@@ -157,7 +157,7 @@ public class BeansXMLProtocolProcessorTestCase {
 
     public void runAndAsset(Archive<?> deployment, Archive<?> protocol, boolean shouldBeFound, String expectedLocation) {
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         System.out.println(protocol.toString(true));
         Assert.assertEquals(

--- a/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
+++ b/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
@@ -83,7 +83,7 @@ public class BeansXMLProtocolProcessorTestCase {
         WebArchive protocol = ShrinkWrap.create(WebArchive.class);
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(protocol, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, protocol, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertFalse(protocol.contains("WEB-INF/beans.xml"));
     }
@@ -97,7 +97,7 @@ public class BeansXMLProtocolProcessorTestCase {
         WebArchive protocol = deployment.as(WebArchive.class);
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
 
@@ -117,7 +117,7 @@ public class BeansXMLProtocolProcessorTestCase {
             .addAsWebInfResource(new StringAsset(beansXmlContent), "beans.xml");
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
 
@@ -137,7 +137,7 @@ public class BeansXMLProtocolProcessorTestCase {
             .addAsManifestResource(new StringAsset(beansXmlContent), "beans.xml");
 
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         Assert.assertTrue(protocol.contains("META-INF/beans.xml"));
 
@@ -157,7 +157,7 @@ public class BeansXMLProtocolProcessorTestCase {
 
     public void runAndAsset(Archive<?> deployment, Archive<?> protocol, boolean shouldBeFound, String expectedLocation) {
         new BeansXMLProtocolProcessor().process(
-            new TestDeployment(deployment, new ArrayList<Archive<?>>()), protocol);
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
 
         System.out.println(protocol.toString(true));
         Assert.assertEquals(


### PR DESCRIPTION
replace it with the other constructor: 
```
TestDeployment(
    org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription, 
    org.jboss.shrinkwrap.api.Archive<?>, 
    java.util.Collection<org.jboss.shrinkwrap.api.Archive<?>>
)
```