### PR TITLE
Fix usages of deprecated junit methods (org.junit.internal.Assumption…

### DIFF
--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
@@ -22,7 +22,7 @@ import org.jboss.arquillian.container.test.spi.TestRunner;
 import org.jboss.arquillian.junit.State;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;

--- a/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitTestRunnerTestCase.java
+++ b/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitTestRunnerTestCase.java
@@ -24,7 +24,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.ExpectedException;
 
 public class JUnitTestRunnerTestCase {
@@ -145,6 +145,7 @@ public class JUnitTestRunnerTestCase {
 
         public static Exception exceptionThrownInAfter;
 
+        @SuppressWarnings("deprecation")
         @Rule
         public ExpectedException e = ExpectedException.none();
 

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
@@ -22,27 +22,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import org.jboss.arquillian.junit.event.AfterRules;
 import org.jboss.arquillian.junit.event.BeforeRules;
 import org.jboss.arquillian.junit.event.RulesEnrichment;
 import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
-import org.jboss.arquillian.test.spi.TestMethodExecutor;
-import org.jboss.arquillian.test.spi.TestResult;
-import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
-import org.jboss.arquillian.test.spi.execution.SkippedTestExecutionException;
-import org.junit.internal.AssumptionViolatedException;
-import org.junit.internal.runners.model.MultipleFailureException;
 import org.junit.internal.runners.model.ReflectiveCallable;
 import org.junit.internal.runners.statements.Fail;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runner.Result;
-import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/MethodInvoker.java
@@ -5,7 +5,7 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
 import org.jboss.arquillian.test.spi.execution.SkippedTestExecutionException;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runners.model.FrameworkMethod;
 
 abstract class MethodInvoker {

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/extension/UpdateTestResultBeforeAfter.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/extension/UpdateTestResultBeforeAfter.java
@@ -22,7 +22,7 @@ import org.jboss.arquillian.junit.State;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.test.spi.event.suite.AfterTestLifecycleEvent;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 
 /**
  * Update the TestResult based on result After going through the JUnit chain.

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/ClassWithArquillianClassAndMethodRuleWithExpectedExceptionRule.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/ClassWithArquillianClassAndMethodRuleWithExpectedExceptionRule.java
@@ -20,6 +20,7 @@ public class ClassWithArquillianClassAndMethodRuleWithExpectedExceptionRule {
     @Rule
     public ArquillianTest arquillianTest = new ArquillianTest();
 
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException e = ExpectedException.none();
 

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/ClassWithArquillianRunnerWithExpectedExceptionRule.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/ClassWithArquillianRunnerWithExpectedExceptionRule.java
@@ -30,6 +30,7 @@ import static org.jboss.arquillian.junit.JUnitTestBaseClass.wasCalled;
 
 @RunWith(Arquillian.class)
 public class ClassWithArquillianRunnerWithExpectedExceptionRule {
+    @SuppressWarnings("deprecation")
     @Rule
     public ExpectedException e = ExpectedException.none();
 

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/extension/UpdateTestResultBeforeAfterTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/extension/UpdateTestResultBeforeAfterTestCase.java
@@ -23,7 +23,7 @@ import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestResult.Status;
 import org.jboss.arquillian.test.spi.event.suite.AfterTestLifecycleEvent;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;

--- a/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher40TestCase.java
+++ b/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher40TestCase.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for {@link EJBInjectionEnricher}.

--- a/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher30TestCase.java
+++ b/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher30TestCase.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for {@link EJBInjectionEnricher}.

--- a/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher31TestCase.java
+++ b/testenrichers/ejb/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher31TestCase.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for {@link EJBInjectionEnricher}.


### PR DESCRIPTION
…ViolatedException, ExpectedException.none(), org.junit.runners.model.MultipleFailureException, org.junit.Assert.assertThat)