### PR TITLE
Avoid file leak in RemoteExtensionLoader

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,7 +186,10 @@ public class RemoteExtensionLoader implements ExtensionLoader {
             Enumeration<URL> enumeration = loader.getResources(serviceFile);
             while (enumeration.hasMoreElements()) {
                 final URL url = enumeration.nextElement();
-                final InputStream is = url.openStream();
+                URLConnection jarConnection = url.openConnection();
+                //Don't cache the file (avoids file leaks on GlassFish).
+                jarConnection.setUseCaches(false);
+                final InputStream is = jarConnection.getInputStream();
                 BufferedReader reader = null;
 
                 try {
@@ -222,6 +226,9 @@ public class RemoteExtensionLoader implements ExtensionLoader {
                 } catch (IOException exc) {
                     throw new RuntimeException("Could not read file: " + url);
                 } finally {
+                    if (is != null) {
+                       is.close();
+                    }
                     if (reader != null) {
                         reader.close();
                     }


### PR DESCRIPTION
This problem was found as part of https://github.com/arquillian/arquillian-extension-warp/issues/131 - full details see there.

When deploying a test using arquillian-extension-warp to GlassFish 4.1 or newer **running on a Windows machine** (no problem on linux), all Jars that are inside "WEB-INF\lib" of the deployed app are locked and the app has a long delay until GlassFish performs the "undeploy" operation.
Using [File Leak Detector](https://github.com/jenkinsci/lib-file-leak-detector/), I found that `org.jboss.arquillian.container.test.impl.RemoteExtensionLoader` is one of the culprits for this leak: `URL.openStream` creates a `java.net.JarConnection` that caches opened files by default.
As those files are accessed only once in Arquillian, there is no performance reason to cache them.

This pull request switches off caching and closed the file afterwards.

Unfortunately, this does not help against the undeploy problems, because GlassFish seems to have a bug, and another piece of code also does not close the file properly. Hopefully, this was fixed with GlassFish 6, but I cannot test it, as "arquillian-extension-warp" would have to be updated to JakartaEE first.

WildFly is not affected by this problem because of the underlying VFS implementation. But GlassFish accesses the files directly.