### PR TITLE
Fix for the Jetty bypass vulnerability fixed in version 9.4.51.v20230217

### DIFF
--- a/protocols/servlet/pom.xml
+++ b/protocols/servlet/pom.xml
@@ -22,7 +22,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.jetty_jetty>8.1.2.v20120308</version.jetty_jetty>
+    <version.jetty_jetty>9.4.51.v20230217</version.jetty_jetty>
 
   </properties>
 

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
@@ -26,6 +26,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
@@ -88,7 +91,13 @@ public class AbstractServerBase {
     }
 
     protected URI createBaseURL() {
-        return URI.create("http://localhost:" + server.getConnectors()[0].getPort() + "/arquillian-protocol");
+        int port = 8080;
+        Connector defaultConn = server.getConnectors()[0];
+        if (defaultConn instanceof NetworkConnector) {
+            NetworkConnector net = (NetworkConnector) defaultConn;
+            port = net.getLocalPort();
+        }
+        return URI.create("http://localhost:" + port + "/arquillian-protocol");
     }
 
     protected URL createURL(String outputMode, String testClass, String methodName) {


### PR DESCRIPTION
#### Short description of what this resolves:
Jetty 8.1.2.v20120308 bypass vulnerability

#### Changes proposed in this pull request:
- Upgrade to the Jetty 9.4.51.v20230217 version that includes the fix
- Update how the base URI obtains the connector server port for changes in Jetty 9
-


Fixes #
Replaces the #485 PR which does not compile