### PR TITLE
preserve first exception in writeObject

### DIFF
--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
@@ -201,7 +201,9 @@ public class ServletTestRunner extends HttpServlet {
             try {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
             } catch (Exception e2) {
-                throw new RuntimeException("Could not write to output", e2);
+                RuntimeException runtimeException = new RuntimeException("Could not write to output", e2);
+                runtimeException.addSuppressed(e);
+                throw runtimeException;
             }
         }
     }


### PR DESCRIPTION
#### Short description of what this resolves:
If `response.sendError` fails the first exception `e` will be lost entirely and all the developer will see is the reason why `response.sendError`failed. A small change will ensure the data from `e` and `e2` are both available when looking at server log files.

#### Changes proposed in this pull request:

- A simple addSuppresed statement to prevent a useful exception from being unreported