### PR TITLE
[ARQ-2231] The JUnit 5 container does not work with manual mode tests

### DIFF
--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -96,7 +96,10 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     public void interceptBeforeEachMethod(Invocation<Void> invocation,
       ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
       if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-        invocation.proceed();
+        getManager(extensionContext).getAdaptor().before(
+            extensionContext.getRequiredTestInstance(),
+            extensionContext.getRequiredTestMethod(),
+                invocation::proceed);
       } else {
         invocation.skip();
       }
@@ -106,7 +109,10 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     public void interceptAfterEachMethod(Invocation<Void> invocation,
       ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
       if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-        invocation.proceed();
+          getManager(extensionContext).getAdaptor().after(
+              extensionContext.getRequiredTestInstance(),
+              extensionContext.getRequiredTestMethod(),
+              invocation::proceed);
       } else {
         invocation.skip();
       }


### PR DESCRIPTION
Resolves #543 

Opening this as a draft to discuss the solution as it seems a little hack-y to me @starksm64 

https://issues.redhat.com/browse/ARQ-2231
and
https://github.com/arquillian/arquillian-core/issues/543

The problem there is that Arquillian goes through several phases, each creating and removing contexts (as to why I have no idea, haven't found any docs). The error comes at the moment the BeforeEach method tries to deploy the deployment but is unable to find out just because the proper context has already been deactivated. I can't even activate the context without finding the correct deployment, which I cannot do since the context is deactivated.

In the end, the only solution I was able to find was to **not** deactivate the context just before the deployment and leave the deactivation for After class. I'm not sure if that would be a problem at all, but all other solutions failed - even closing the context after obtaining the deployment to deploy, seems like by that time the context is needed again and is not activated again.

For that reason I had to introduce the arquillian-junit5-core dependency, that is the closest it can get to the actual deployment without breaking anything