### PR TITLE
Add support for specifying a custom mapper implementation for a DeployableContainer.

### DIFF
--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/Container.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/Container.java
@@ -30,7 +30,7 @@ import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
  */
-public interface Container {
+public interface Container<T extends ContainerConfiguration> {
 
     /**
      * @return the name
@@ -40,7 +40,7 @@ public interface Container {
     /**
      * @return the deployableContainer
      */
-    DeployableContainer<?> getDeployableContainer();
+    DeployableContainer<T> getDeployableContainer();
 
     /**
      * @return the containerConfiguration
@@ -50,7 +50,7 @@ public interface Container {
     /**
      * @return the configuration
      */
-    ContainerConfiguration createDeployableConfiguration() throws Exception;
+    T createDeployableConfiguration() throws Exception;
 
     boolean hasProtocolConfiguration(ProtocolDescription description);
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/ConfigurationMapper.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/ConfigurationMapper.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2024 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.spi.client.container;
+
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+
+/**
+ * An interface that {@link DeployableContainer<T>} can use to control how the mapping
+ * from the externalized container definition, as found in an arquillian.xml file
+ * for example, is applied to the {@link ContainerConfiguration} instances
+ *
+ * @param <T> the type of ContainerConfiguration
+ */
+public interface ConfigurationMapper<T extends ContainerConfiguration> {
+    /**
+     *
+     * @param containerConfiguration - the deployable container configuration instance to populate
+     * @param definition - the container definition from the ArquillianDescriptor that
+     *                   was parsed
+     */
+    void populateConfiguration(T containerConfiguration, ContainerDef definition);
+}

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
@@ -37,6 +37,17 @@ public interface DeployableContainer<T extends ContainerConfiguration> {
     // ControllableContainer
     Class<T> getConfigurationClass();
 
+    /**
+     * Provide a mapping instance that takes the {@link org.jboss.arquillian.config.descriptor.api.ContainerDef}
+     * for the arquillian.xml or other configured descriptor and populates the container configuration
+     * instance from the descriptor values.
+     *
+     * @return A possibly null ConfigurationMapper. If null, the default logic to map from string based
+     * properties as implemented in org.jboss.arquillian.container.impl.MapObject will be used.
+     */
+    default ConfigurationMapper getConfigurationMapper() {
+        return null;
+    }
     default void setup(T configuration) {
     }
 


### PR DESCRIPTION
…
Fixes #552

#### Short description of what this resolves:
This addresses #552 

#### Changes proposed in this pull request:

- Add a new ConfigurationMapper interface that is returned from DeployableContainer
- Improve the ContainerConfiguration generic type usage to avoid casts
- Add test showing mapping of String property def to String[] in a CustomContainerConfiguration


