### PR TITLE
Add --add-opens to surefire for running tests on Java SE 17+

### DIFF
--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -119,5 +119,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            --add-opens java.base/java.lang=ALL-UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
-

--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -27,6 +27,7 @@
     <version.javax-el>2.2</version.javax-el>
     <version.slf4j>2.0.12</version.slf4j>
 
+    <java11.opensargs></java11.opensargs>
   </properties>
 
   <!-- Dependencies -->
@@ -119,7 +120,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -127,10 +128,22 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            --add-opens java.base/java.lang=ALL-UNNAMED
+            ${java11.opensargs}
           </argLine>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>not-java8</id>
+      <activation>
+        <jdk>[11,]</jdk>
+      </activation>
+      <properties>
+        <java11.opensargs>--add-opens java.base/java.lang=ALL-UNNAMED</java11.opensargs>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
#### Short description of what this resolves:
The CDIInjectionEnricherTestCase relies on Weld being able to make protected/private fields accessible. This requires additional access permissions when running under Java SE 17+

#### Changes proposed in this pull request:
Add an override to the surefire plugin configuration to include a `--add-opens java.base/java.lang=ALL-UNNAMED`


Fixes #564 
