### PR TITLE
CI: add JDK 17 testing; run CI on all branches; cleanup ci.yml.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ "master" ]
+    branches:
+      - '*'
 
 jobs:
 
@@ -14,27 +16,23 @@ jobs:
     timeout-minutes: 10
     outputs:
       SNAPSHOT_VERSION: ${{ steps.arq-version.outputs.SNAPSHOT_VERSION }}
-
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        name: JDK 8 setup
+      - name: Checkout arquillian-core
+        uses: actions/checkout@v4
+      - name: Setup JDK 8
+        uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
-
       - name: Build with Maven
-        run: mvn clean -B install
-
+        run: mvn --batch-mode --no-transfer-progress clean verify
       - name: Version save
         id: arq-version
         run: |
           VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           echo "SNAPSHOT_VERSION=$VERSION" >> $GITHUB_OUTPUT        
           echo "Arquillian version: $VERSION"
-
       - name: Artifact upload
         uses: actions/upload-artifact@v4
         with:
@@ -45,47 +43,56 @@ jobs:
     name: Integration - JDK 11
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        name: JDK 11 setup
+      - name: Build with Maven
+        uses: actions/checkout@v4
+      - name: Setup JDK 11
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
-
       - name: Build with Maven
-        run: mvn clean -B install
+        run: mvn --batch-mode --no-transfer-progress clean verify
+
+  arquillian-build-jdk17:
+    name: Integration - JDK 17
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Build with Maven
+        uses: actions/checkout@v4
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: maven
+      - name: Build with Maven
+        run: mvn --batch-mode --no-transfer-progress clean verify
 
   integration-wildfly-job:
     runs-on: ubuntu-latest
     name: Integration verification for WildFly
     needs: arquillian-build-jdk8
     timeout-minutes: 300
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           name: arquillian
           path: ~/.m2/repository/org/jboss
-
-      - uses: actions/setup-java@v4
-        name: JDK 17 setup
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'temurin'
+          distribution: temurin
           cache: maven
-
-      - uses: actions/checkout@v4
-        name: Checkout WildFly
+      - name: Checkout WildFly
+        uses: actions/checkout@v4
         with:
           repository: wildfly/wildfly
-
-      - name: WildFly integration
+      - name: Run WildFly Integration Testsuite
         env:
           SNAPSHOT_VERSION: ${{ needs.arquillian-build-jdk8.outputs.SNAPSHOT_VERSION }}
         run: |


### PR DESCRIPTION
Follow up on https://github.com/arquillian/arquillian-core/pull/565 - we can now run tests with JDK 17.