### PR TITLE
ARQ-2231 The JUnit 5 container does not work with manual mode tests

### DIFF
--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -93,23 +93,28 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     }
 
     @Override
-    public void interceptBeforeEachMethod(Invocation<Void> invocation,
-      ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-      if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-        invocation.proceed();
-      } else {
-        invocation.skip();
-      }
+    public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
+            // Since the invocation is going to proceed, the invocation must happen within the context of SPI before()
+            getManager(extensionContext).getAdaptor().before(
+                extensionContext.getRequiredTestInstance(),
+                extensionContext.getRequiredTestMethod(),
+                invocation::proceed);
+        } else {
+            invocation.skip();
+        }
     }
 
     @Override
-    public void interceptAfterEachMethod(Invocation<Void> invocation,
-      ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-      if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-        invocation.proceed();
-      } else {
-        invocation.skip();
-      }
+    public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
+            getManager(extensionContext).getAdaptor().after(
+                extensionContext.getRequiredTestInstance(),
+                extensionContext.getRequiredTestMethod(),
+                invocation::proceed);
+        } else {
+            invocation.skip();
+        }
     }
 
     @Override


### PR DESCRIPTION
Restoring the fix for https://issues.redhat.com/browse/ARQ-2231 which was inadvertently reverted along restoring the BeforeEachCallback, AfterEachCallback callbacks which turned out to be necessary in some cases. The reproducer attached to ARQ-2231 passes now.