### PR TITLE
Enable snapshots from jboss.snapshots.repo.url

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven Java ${{ matrix.java }} - ${{ matrix.os }}
         run:  |
-          ./mvnw -V clean install -U -B -fae '-Pwildfly' '-T1' '-Pintegration-tests'
+          ./mvnw -V clean install -U -B -fae '-Pwildfly' '-T1' '-Pintegration-tests' '-Pallow-snapshots'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -71,7 +71,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven Java ${{ matrix.java }} - ${{ matrix.os }}
         run:  |
-          ./mvnw -V clean install -U -B -fae '-Ppayara' '-T1' '-Pintegration-tests'
+          ./mvnw -V clean install -U -B -fae '-Ppayara' '-T1' '-Pintegration-tests' '-Pallow-snapshots'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -155,6 +155,18 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>allow-snapshots</id>
+      <activation><activeByDefault>true</activeByDefault></activation>
+      <repositories>
+        <repository>
+          <id>snapshots-repo</id>
+          <url>${jboss.snapshots.repo.url}</url>
+          <releases><enabled>false</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
 
     <profile>
       <id>wildfly</id>


### PR DESCRIPTION
#### Short description of what this resolves:
We need to enable snapshots from jboss.snapshots.repo.url since the integration-tests relies on a snapshot build of arquillian-core


#### Changes proposed in this pull request:
Add allow-snapshots profile which is activeByDefault 


