### PR TITLE
Add support for ArquillianResource param injection on @Deployment methods

### DIFF
--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
@@ -90,6 +90,7 @@ public class ContainerTestExtension implements LoadableExtension {
         builder.observer(ContainerEventController.class)
             .observer(ContainerRestarter.class)
             .observer(DeploymentGenerator.class)
+            .observer(AnnotationDeploymentScenarioGenerator.class)
             .observer(ArchiveDeploymentToolingExporter.class)
             .observer(ProtocolRegistryCreator.class)
             .observer(ClientContainerControllerCreator.class)

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuter.java
@@ -16,8 +16,6 @@
  */
 package org.jboss.arquillian.container.test.impl.execution;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
 import org.jboss.arquillian.container.test.impl.execution.event.LocalExecutionEvent;
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
@@ -28,6 +26,7 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.annotation.TestScoped;
+import org.jboss.arquillian.test.spi.execution.ExecUtils;
 
 /**
  * A Handler for executing the Test Method.<br/>
@@ -53,10 +52,10 @@ public class LocalTestExecuter {
     public void execute(@Observes LocalExecutionEvent event) throws Exception {
         TestResult result = TestResult.passed();
         try {
-            event.getExecutor().invoke(
-                enrichArguments(
-                    event.getExecutor().getMethod(),
-                    serviceLoader.get().all(TestEnricher.class)));
+            Object[] args = ExecUtils.enrichArguments(
+                event.getExecutor().getMethod(),
+                serviceLoader.get().all(TestEnricher.class));
+            event.getExecutor().invoke(args);
         } catch (Throwable e) {
             result = TestResult.failed(e);
         } finally {
@@ -65,36 +64,4 @@ public class LocalTestExecuter {
         testResult.set(result);
     }
 
-    /**
-     * Enrich the method arguments of a method call.<br/>
-     * The Object[] index will match the method parameterType[] index.
-     *
-     * @return the argument values
-     */
-    private Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers) {
-        Object[] values = new Object[method.getParameterTypes().length];
-        if (method.getParameterTypes().length == 0) {
-            return values;
-        }
-        for (TestEnricher enricher : enrichers) {
-            mergeValues(values, enricher.resolve(method));
-        }
-        return values;
-    }
-
-    private void mergeValues(Object[] values, Object[] resolvedValues) {
-        if (resolvedValues == null || resolvedValues.length == 0) {
-            return;
-        }
-        if (values.length != resolvedValues.length) {
-            throw new IllegalStateException("TestEnricher resolved wrong argument count, expected " +
-                values.length + " returned " + resolvedValues.length);
-        }
-        for (int i = 0; i < resolvedValues.length; i++) {
-            Object resvoledValue = resolvedValues[i];
-            if (resvoledValue != null && values[i] == null) {
-                values[i] = resvoledValue;
-            }
-        }
-    }
 }

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/LoadableExtension.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/LoadableExtension.java
@@ -22,7 +22,7 @@ import org.jboss.arquillian.core.spi.context.Context;
 /**
  * LoadableExtension.
  * <p>
- * Loadable extensions are loaded on the local side of Arquillan. For extensions, components, observers etc to run on
+ * Loadable extensions are loaded on the local side of Arquillian. For extensions, components, observers etc to run on
  * the remote side, use {@code RemoteLoadableExtension} instead, and provide it via an
  * {@code AuxilliaryArchiveAppender}.
  *
@@ -58,6 +58,9 @@ public interface LoadableExtension {
          * Register an observer for events. This observer will be injected according to any
          * {@link org.jboss.arquillian.core.api.annotation.Inject} annotated
          * {@link org.jboss.arquillian.core.api.Instance} fields.
+         * Note: the handler does not have to have any use of {@link org.jboss.arquillian.core.api.annotation.Observer}
+         * and this can be used to simply register a class that has needs to be instantiated and injected.
+         * @param handler A class with observer methods and/or Instance fields
          */
         ExtensionBuilder observer(Class<?> handler);
 

--- a/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/LocalTestMethodExecutor.java
+++ b/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/LocalTestMethodExecutor.java
@@ -17,8 +17,6 @@
  */
 package org.jboss.arquillian.junit.standalone;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -28,6 +26,7 @@ import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.jboss.arquillian.test.spi.event.suite.Test;
+import org.jboss.arquillian.test.spi.execution.ExecUtils;
 
 /**
  * LocalTestMethodExecutor
@@ -46,10 +45,10 @@ public class LocalTestMethodExecutor {
     public void execute(@Observes Test event) throws Exception {
         TestResult result = TestResult.passed();
         try {
-            event.getTestMethodExecutor().invoke(
-                enrichArguments(
-                    event.getTestMethod(),
-                    serviceLoader.get().all(TestEnricher.class)));
+            Object[] args = ExecUtils.enrichArguments(
+                event.getTestMethodExecutor().getMethod(),
+                serviceLoader.get().all(TestEnricher.class));
+            event.getTestMethodExecutor().invoke(args);
         } catch (Throwable e) {
             result = TestResult.failed(e);
         } finally {
@@ -58,36 +57,4 @@ public class LocalTestMethodExecutor {
         testResult.set(result);
     }
 
-    /**
-     * Enrich the method arguments of a method call.<br/>
-     * The Object[] index will match the method parameterType[] index.
-     *
-     * @return the argument values
-     */
-    private Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers) {
-        Object[] values = new Object[method.getParameterTypes().length];
-        if (method.getParameterTypes().length == 0) {
-            return values;
-        }
-        for (TestEnricher enricher : enrichers) {
-            mergeValues(values, enricher.resolve(method));
-        }
-        return values;
-    }
-
-    private void mergeValues(Object[] values, Object[] resolvedValues) {
-        if (resolvedValues == null || resolvedValues.length == 0) {
-            return;
-        }
-        if (values.length != resolvedValues.length) {
-            throw new IllegalStateException("TestEnricher resolved wrong argument count, expected " +
-                values.length + " returned " + resolvedValues.length);
-        }
-        for (int i = 0; i < resolvedValues.length; i++) {
-            Object resvoledValue = resolvedValues[i];
-            if (resvoledValue != null && values[i] == null) {
-                values[i] = resvoledValue;
-            }
-        }
-    }
 }

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/execution/ExecUtils.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/execution/ExecUtils.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.test.spi.execution;
+
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+/**
+ * A utility class that provides methods for enriching method arguments.
+ */
+public class ExecUtils {
+
+    /**
+     * Generate the enriched the method arguments of a method call.<br/>
+     * The Object[] index will match the method parameterType[] index.
+     *
+     * @return the enriched argument values to use
+     */
+    public static Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        if (method.getParameterTypes().length == 0) {
+            return values;
+        }
+        for (TestEnricher enricher : enrichers) {
+            mergeValues(values, enricher.resolve(method));
+        }
+        return values;
+    }
+
+    /**
+     * Called for each {@link TestEnricher} to merge the resolved values into the values array.
+     * Since differeent TestEnrichers can resolve different arguments, we need to merge the values.
+     * @param values - the current values
+     * @param resolvedValues - the values from the last TestEnricher
+     */
+    private static void mergeValues(Object[] values, Object[] resolvedValues) {
+        if (resolvedValues == null || resolvedValues.length == 0) {
+            return;
+        }
+        if (values.length != resolvedValues.length) {
+            throw new IllegalStateException("TestEnricher resolved wrong argument count, expected " +
+                values.length + " returned " + resolvedValues.length);
+        }
+        for (int i = 0; i < resolvedValues.length; i++) {
+            Object resvoledValue = resolvedValues[i];
+            if (resvoledValue != null && values[i] == null) {
+                values[i] = resvoledValue;
+            }
+        }
+    }
+}

--- a/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/LocalTestMethodExecutor.java
+++ b/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/LocalTestMethodExecutor.java
@@ -17,8 +17,6 @@
  */
 package org.jboss.arquillian.testng.standalone;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -28,6 +26,7 @@ import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.jboss.arquillian.test.spi.event.suite.Test;
+import org.jboss.arquillian.test.spi.execution.ExecUtils;
 
 /**
  * LocalTestMethodExecutor
@@ -46,10 +45,10 @@ public class LocalTestMethodExecutor {
     public void execute(@Observes Test event) throws Exception {
         TestResult result = TestResult.passed();
         try {
-            event.getTestMethodExecutor().invoke(
-                enrichArguments(
-                    event.getTestMethod(),
-                    serviceLoader.get().all(TestEnricher.class)));
+            Object[] args = ExecUtils.enrichArguments(
+                event.getTestMethodExecutor().getMethod(),
+                serviceLoader.get().all(TestEnricher.class));
+            event.getTestMethodExecutor().invoke(args);
         } catch (Throwable e) {
             result = TestResult.failed(e);
         } finally {
@@ -58,36 +57,4 @@ public class LocalTestMethodExecutor {
         testResult.set(result);
     }
 
-    /**
-     * Enrich the method arguments of a method call.<br/>
-     * The Object[] index will match the method parameterType[] index.
-     *
-     * @return the argument values
-     */
-    private Object[] enrichArguments(Method method, Collection<TestEnricher> enrichers) {
-        Object[] values = new Object[method.getParameterTypes().length];
-        if (method.getParameterTypes().length == 0) {
-            return values;
-        }
-        for (TestEnricher enricher : enrichers) {
-            mergeValues(values, enricher.resolve(method));
-        }
-        return values;
-    }
-
-    private void mergeValues(Object[] values, Object[] resolvedValues) {
-        if (resolvedValues == null || resolvedValues.length == 0) {
-            return;
-        }
-        if (values.length != resolvedValues.length) {
-            throw new IllegalStateException("TestEnricher resolved wrong argument count, expected " +
-                values.length + " returned " + resolvedValues.length);
-        }
-        for (int i = 0; i < resolvedValues.length; i++) {
-            Object resvoledValue = resolvedValues[i];
-            if (resvoledValue != null && values[i] == null) {
-                values[i] = resvoledValue;
-            }
-        }
-    }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Add support for `@ArquillianResource` param injection on `@Deployment` methods
Aggregate the `TestEnricher` argument generation into a single util class
Improve some of the javadoc



Fixes #601 
