### PR TITLE
[312] Initial attempt to allow Arquillian to inject method parameters.

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/AbstractArquillianResourceTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/AbstractArquillianResourceTest.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -65,7 +64,6 @@ abstract class AbstractArquillianResourceTest {
     }
 
     @Test
-    @Disabled("https://github.com/arquillian/arquillian-core/issues/312")
     public void checkParameterUrl(@ArquillianResource final URL url) {
         Assertions.assertNotNull(url, "The URL should have been injected");
         Assertions.assertEquals(TestEnvironment.protocol(), url.getProtocol());
@@ -83,7 +81,6 @@ abstract class AbstractArquillianResourceTest {
     }
 
     @Test
-    @Disabled("https://github.com/arquillian/arquillian-core/issues/312")
     public void checkParameterUri(@ArquillianResource final URI uri) {
         Assertions.assertNotNull(uri, "The URI should have been injected");
         checkHost(uri.getHost());

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/ClientArquillianResourceTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/ClientArquillianResourceTest.java
@@ -19,11 +19,29 @@
 
 package org.jboss.arquillian.integration.test.resource.injection;
 
+import java.net.URL;
+import java.nio.file.Path;
+
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.integration.test.common.TestEnvironment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @RunAsClient
 public class ClientArquillianResourceTest extends AbstractArquillianResourceTest {
+
+    @Test
+    public void checkMultipleParameters(@ArquillianResource final URL url, @TempDir final Path tempDir) {
+        Assertions.assertNotNull(url, "The URL should have been injected");
+        Assertions.assertEquals(TestEnvironment.protocol(), url.getProtocol());
+        checkHost(url.getHost());
+        Assertions.assertEquals(TestEnvironment.port(), url.getPort());
+        Assertions.assertEquals("/" + DEPLOYMENT_NAME + "/", url.getPath());
+        Assertions.assertNotNull(tempDir, "The temp dir should have been injected");
+    }
 }

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/InContainerArquillianResourceTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/InContainerArquillianResourceTest.java
@@ -19,13 +19,16 @@
 
 package org.jboss.arquillian.integration.test.resource.injection;
 
+import java.net.URL;
+import java.nio.file.Path;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 
+import org.jboss.arquillian.integration.test.common.TestEnvironment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -46,7 +49,6 @@ public class InContainerArquillianResourceTest extends AbstractArquillianResourc
     }
 
     @Test
-    @Disabled("https://github.com/arquillian/arquillian-core/issues/312")
     public void checkContextParameter(@ArquillianResource final Context context) throws Exception {
         Assertions.assertNotNull(context, "The Context should have been injected");
         final Object bm = context.lookup("java:comp/BeanManager");
@@ -61,10 +63,19 @@ public class InContainerArquillianResourceTest extends AbstractArquillianResourc
     }
 
     @Test
-    @Disabled("https://github.com/arquillian/arquillian-core/issues/312")
     public void checkInitialContextParameter(@ArquillianResource final InitialContext initialContext) throws Exception {
         Assertions.assertNotNull(initialContext, "The InitialContext should have been injected");
         final Object bm = initialContext.lookup("java:comp/BeanManager");
         Assertions.assertNotNull(bm);
+    }
+
+    @Test
+    public void checkMultipleParameters(@ArquillianResource final URL url, @TempDir final Path tempDir) {
+        Assertions.assertNotNull(url, "The URL should have been injected");
+        Assertions.assertEquals(TestEnvironment.protocol(), url.getProtocol());
+        checkHost(url.getHost());
+        Assertions.assertEquals(TestEnvironment.port(), url.getPort());
+        Assertions.assertEquals("/" + DEPLOYMENT_NAME + "/", url.getPath());
+        Assertions.assertNotNull(tempDir, "The temp dir should have been injected");
     }
 }

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/InContainerArquillianResourceTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/resource/injection/InContainerArquillianResourceTest.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.integration.test.common.TestEnvironment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -49,6 +50,7 @@ public class InContainerArquillianResourceTest extends AbstractArquillianResourc
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "javax.naming.Context.parameter", matches = "skip")
     public void checkContextParameter(@ArquillianResource final Context context) throws Exception {
         Assertions.assertNotNull(context, "The Context should have been injected");
         final Object bm = context.lookup("java:comp/BeanManager");
@@ -63,6 +65,7 @@ public class InContainerArquillianResourceTest extends AbstractArquillianResourc
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "javax.naming.Context.parameter", matches = "skip")
     public void checkInitialContextParameter(@ArquillianResource final InitialContext initialContext) throws Exception {
         Assertions.assertNotNull(initialContext, "The InitialContext should have been injected");
         final Object bm = initialContext.lookup("java:comp/BeanManager");

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -257,6 +257,7 @@
           <groupId>fish.payara.arquillian</groupId>
           <artifactId>arquillian-payara-server-managed</artifactId>
           <version>${version.fish.payara.arquillian}</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
 
@@ -292,6 +293,7 @@
               <systemPropertyVariables>
                 <payara.home>${payara.home}</payara.home>
                 <arq.host>localhost</arq.host>
+                <javax.naming.Context.parameter>skip</javax.naming.Context.parameter>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterDeploymentAppender.java
+++ b/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterDeploymentAppender.java
@@ -1,6 +1,7 @@
 package org.jboss.arquillian.junit5.container;
 
 
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.container.test.spi.TestRunner;
 import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
@@ -22,6 +23,8 @@ public class JUnitJupiterDeploymentAppender extends CachedAuxilliaryArchiveAppen
                 .addAsServiceProvider(
                         TestRunner.class,
                         JUnitJupiterTestRunner.class)
-                .addAsServiceProvider(TestEngine.class, JupiterTestEngine.class);
+                .addAsServiceProvider(TestEngine.class, JupiterTestEngine.class)
+                // The remote extension for in-container tests
+                .addAsServiceProvider(RemoteLoadableExtension.class, JUnitJupiterRemoteExtension.class);
     }
 }

--- a/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterRemoteExtension.java
+++ b/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterRemoteExtension.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.junit5.container;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.junit5.MethodParameterObserver;
+
+/**
+ * The remote extension for JUnit 5 in-container tests.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JUnitJupiterRemoteExtension implements RemoteLoadableExtension {
+
+    @Override
+    public void register(LoadableExtension.ExtensionBuilder builder) {
+        builder.observer(MethodParameterObserver.class);
+    }
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
@@ -1,10 +1,10 @@
 package org.jboss.arquillian.junit5;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 class ContextStore {
     private static final String NAMESPACE_KEY = "arquillianNamespace";
@@ -12,6 +12,8 @@ class ContextStore {
     private static final String INTERCEPTED_TEMPLATE_NAMESPACE_KEY = "interceptedTestTemplates";
 
     private static final String RESULT_NAMESPACE_KEY = "results";
+
+    private static final String PARAMETER_NAMESPACE_KEY = "methodParameters";
 
     private final ExtensionContext context;
 
@@ -59,5 +61,35 @@ class ContextStore {
     Optional<Throwable> getResult(String uniqueId) {
         final ExtensionContext.Store resultStore = getResultStore();
         return Optional.ofNullable(resultStore.getOrDefault(uniqueId, Throwable.class, null));
+    }
+
+    /**
+     * Creates a new method parameter holder and stores it in the current context.
+     *
+     * @return the method parameters holder
+     */
+    MethodParameters createMethodParameters() {
+        final MethodParameters methodParameters = new MethodParameters();
+        context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, PARAMETER_NAMESPACE_KEY))
+            .put(PARAMETER_NAMESPACE_KEY, methodParameters);
+        return methodParameters;
+    }
+
+    /**
+     * Gets the method parameters holder.
+     *
+     * @return the method parameters holder or {@code null} if one was not created
+     */
+    MethodParameters getMethodParameters() {
+        return context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, PARAMETER_NAMESPACE_KEY))
+            .get(PARAMETER_NAMESPACE_KEY, MethodParameters.class);
+    }
+
+    /**
+     * Removes the method parameters holder.
+     */
+    void removeMethodParameters() {
+        context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, PARAMETER_NAMESPACE_KEY))
+            .remove(PARAMETER_NAMESPACE_KEY);
     }
 }

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterObserver.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterObserver.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.junit5;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
+import org.jboss.arquillian.test.spi.event.enrichment.AfterEnrichment;
+import org.jboss.arquillian.test.spi.event.enrichment.BeforeEnrichment;
+import org.jboss.arquillian.test.spi.event.enrichment.EnrichmentEvent;
+import org.jboss.arquillian.test.spi.event.suite.Before;
+
+/**
+ * The observer used to process method parameters provided by Arquillian.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class MethodParameterObserver {
+
+    @Inject
+    private Instance<ServiceLoader> serviceLoader;
+
+    @Inject
+    private Event<EnrichmentEvent> enrichmentEvent;
+
+    @Inject
+    @TestScoped
+    private InstanceProducer<MethodParameters> methodParametersProducer;
+
+    /**
+     * Updates the stored {@link MethodParameters} for method parameters which can be provided by Arquillian.
+     *
+     * @param event the fired event
+     */
+    public void injectParameters(@Observes final Before event) {
+        final Object testInstance = event.getTestInstance();
+        final Method testMethod = event.getTestMethod();
+        enrichmentEvent.fire(new BeforeEnrichment(testInstance, testMethod));
+        final MethodParameters methodParameters = methodParametersProducer.get();
+        final Collection<TestEnricher> testEnrichers = serviceLoader.get().all(TestEnricher.class);
+        for (TestEnricher enricher : testEnrichers) {
+            final Object[] values = enricher.resolve(testMethod);
+            for (int i = 0; i < values.length; i++) {
+                if (values[i] != null) {
+                    methodParameters.add(i, values[i]);
+                }
+            }
+        }
+        enrichmentEvent.fire(new AfterEnrichment(testEnrichers, testMethod));
+    }
+
+    /**
+     * Sets the {@link MethodParameters} instance.
+     *
+     * @param event the fired event
+     */
+    public void injectParameters(@Observes MethodParameterProducerEvent event) {
+        methodParametersProducer.set(event.getTestParameterHolder());
+    }
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterProducerEvent.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterProducerEvent.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.junit5;
+
+import java.lang.reflect.Method;
+
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
+
+/**
+ * An event which is fired and allows an observer to set the {@link MethodParameters} on a producer for later usage
+ * in {@link org.jboss.arquillian.test.spi.event.suite.Before} events.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class MethodParameterProducerEvent extends TestLifecycleEvent {
+
+    private final MethodParameters testParameterHolder;
+
+    MethodParameterProducerEvent(final Object testInstance, final Method testMethod, final MethodParameters testParameterHolder) {
+        super(testInstance, testMethod, LifecycleMethodExecutor.NO_OP);
+        this.testParameterHolder = testParameterHolder;
+    }
+
+    MethodParameters getTestParameterHolder() {
+        return testParameterHolder;
+    }
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameters.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameters.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.junit5;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A simple holder for method parameters resolved by a {@link org.jboss.arquillian.test.spi.TestEnricher} and their
+ * index.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class MethodParameters implements ExtensionContext.Store.CloseableResource {
+    private final Map<Integer, Object> parameters;
+
+    MethodParameters() {
+        this.parameters = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Adds a parameter value with the given index.
+     *
+     * @param index the index of the parameter
+     * @param value the value for the parameter
+     */
+    void add(final int index, final Object value) {
+        parameters.put(index, value);
+    }
+
+    /**
+     * Gets the parameter value based on the index.
+     *
+     * @param index the index of the parameter to get the value for
+     *
+     * @return the value for the parameter or {@code null} if one was not registered at the provided index
+     */
+    Object get(final int index) {
+        return parameters.get(index);
+    }
+
+    @Override
+    public void close() {
+        parameters.clear();
+    }
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/extension/JUnitJupiterCoreExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/extension/JUnitJupiterCoreExtension.java
@@ -1,10 +1,12 @@
 package org.jboss.arquillian.junit5.extension;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.junit5.MethodParameterObserver;
 
 public class JUnitJupiterCoreExtension implements LoadableExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
+        builder.observer(MethodParameterObserver.class);
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Allows method parameters which are provided by Arquillian to be injected. The parameters are resolved from `TestEnricher`'s. 

Note that for in-container tests, a `ParameterResolver` outside of Arquillian does not work. In other words, you can't inject a method parameter like `@TempDir final Path path` because two resolvers will be found. One being the real resolver, the other being the `ArquillianExtension`. This seems to be due to the fact that the parameter resolver is executed twice for in-container tests. Once for invoking the test from client and once executing in the container itself.

To work around the above, I created a `@Vetoed` annotation which can be set on those parameters to allow Arquillian to ignore them. Note I don't know if using the same name as the CDI annotation is good or not, but I couldn't think of a better name :)


#### Changes proposed in this pull request:

- Add a `ParameterResolver` for resolved method parameters which Arquillian can provide. For example a `@ArquillianResource URI uri`.
- This works both on the client and in the container, with some limitations

Fixes #312 
