### PR TITLE
[647] Upgrade the WildFly Maven Plugin to version 5.1.0.Beta2 in orde…

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest ]
-        java: ['11', '17', '21']
+        java: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -172,8 +172,8 @@
         <skip.provision.server>${skipTests}</skip.provision.server>
 
         <!-- Versions -->
-        <version.org.wildfly.arquillian>5.1.0.Beta4</version.org.wildfly.arquillian>
-        <version.wildfly-maven-plugin>5.0.0.Final</version.wildfly-maven-plugin>
+        <version.org.wildfly.arquillian>5.1.0.Beta7</version.org.wildfly.arquillian>
+        <version.wildfly-maven-plugin>5.1.0.Beta2</version.wildfly-maven-plugin>
 
         <jboss.home>${project.build.directory}${file.separator}wildfly</jboss.home>
       </properties>


### PR DESCRIPTION
…r to provision WildFly 35.

Change WildFly integration CI to run on 17+ as WildFly 35 now requires Java SE 17.

Also upgrade WildFly Arquillian to the latest beta.


Fixes #647 
