### PR TITLE
Improve the handling of exception propagation

### DIFF
--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/IdentifiedTestException.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/IdentifiedTestException.java
@@ -8,10 +8,16 @@ public class IdentifiedTestException extends RuntimeException {
     private final Map<String, Throwable> collectedExceptions;
 
     public IdentifiedTestException(Map<String, Throwable> exceptions) {
+        super(exceptions.values().stream().findFirst().orElse(null));
         this.collectedExceptions = exceptions;
     }
 
     public Map<String, Throwable> getCollectedExceptions() {
         return collectedExceptions;
+    }
+
+    @Override
+    public String toString() {
+        return "IdentifiedTestException [collectedExceptions=" + collectedExceptions + "]";
     }
 }

--- a/test/spi/README.md
+++ b/test/spi/README.md
@@ -1,0 +1,6 @@
+The tests in this module use a custom maven compiler configuration to simulate a class that exists on the server side but not on the client side to validate the behavior seen in issue
+https://github.com/arquillian/arquillian-core/issues/641.
+
+To be able to run these tests from within Intellij, one has to configure the 
+"Settings | Build, Execution, Deployment | Build Tools | Maven | Runner" to have the "Delegate IDE build/run actions to Maven" box checked.
+

--- a/test/spi/pom.xml
+++ b/test/spi/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Parent -->
   <parent>
@@ -53,5 +55,46 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Configure the compiler plugin to not compile the SomeNonClientSideException class into
+      the test-classes directory so that the standard test runtime will not see it.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Override the default-testCompile execution to exclude SomeNonClientSideException.java -->
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <testExcludes>
+                <testExclude>org/jboss/arquillian/test/spi/serveronly/**</testExclude>
+              </testExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- A custom test-compile execution to output the SomeNonClientSideException.class to target/serveronly-classes -->
+            <id>serveronly-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <testIncludes>
+                <testInclude>org/jboss/arquillian/test/spi/serveronly/**</testInclude>
+              </testIncludes>
+              <outputDirectory>${project.build.directory}/serveronly-classes</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/ArquillianProxyException.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/ArquillianProxyException.java
@@ -16,9 +16,11 @@
  */
 package org.jboss.arquillian.test.spi;
 
+import java.io.PrintStream;
+
 /**
  * Exception class used when a proxied exception cannot be created. This
- * exception type is is thrown instead and contains information about the
+ * exception type is thrown instead and contains information about the
  * proxied class and a hint about why it could not be thrown.
  *
  * @author <a href="mailto:contact@andygibson.net">Andy Gibson</a>
@@ -58,5 +60,10 @@ public class ArquillianProxyException extends RuntimeException {
      */
     public ArquillianProxyException(String message, String exceptionClassName, String reason, Throwable cause) {
         this(String.format("%s : %s [Proxied because : %s]", exceptionClassName, message, reason), cause);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
     }
 }

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
@@ -75,6 +75,7 @@ public class ExceptionProxy implements Externalizable {
     private List<String> causeHierarchy;
 
     public static class Version implements Serializable {
+        private static final long serialVersionUID = 1L;
         int version = 2;
     }
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
@@ -25,7 +25,10 @@ import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Takes an exception class and creates a proxy that can be used to rebuild the
@@ -50,32 +53,43 @@ import java.lang.reflect.InvocationTargetException;
  * @author <a href="mailto:contact@andygibson.net">Andy Gibson</a>
  */
 public class ExceptionProxy implements Externalizable {
-
+    // The serialVersionUID of the ExceptionProxy that existed in Arquillian 1.9.1.Final
     private static final long serialVersionUID = 2321010311438950147L;
 
+    // This is the className of the exception in the container passed into TestResult#setThrowable(Throwable)
     private String className;
-
+    // This is the message of the exception in the container passed into TestResult#setThrowable(Throwable)
     private String message;
-
+    // This is the stack trace of the exception in the container passed into TestResult#setThrowable(Throwable)
     private StackTraceElement[] trace;
-
+    // This is a proxy to the cause exception in the container, not used post 1.9.1.Final
     private ExceptionProxy causeProxy;
-
+    // This is the causeProxy#createException() instance
     private Throwable cause;
-
+    // This only exists if the original container exception could be deserialized in the client
     private Throwable original;
-
+    // This would exist if the original exception could not be serialized in the container
     private Throwable serializationProcessException = null;
+    // New fields added in 1.9.2.Final
+    private Version version;
+    private List<String> causeHierarchy;
+
+    public static class Version implements Serializable {
+        int version = 2;
+    }
 
     public ExceptionProxy() {
+        version = new Version();
     }
 
     public ExceptionProxy(Throwable throwable) {
+        this.version = new Version();
         this.className = throwable.getClass().getName();
         this.message = throwable.getMessage();
         this.trace = throwable.getStackTrace();
-        this.causeProxy = ExceptionProxy.createForException(throwable.getCause());
+        //this.causeProxy = ExceptionProxy.createForException(throwable.getCause());
         this.original = throwable;
+        this.causeHierarchy = getExceptionHierarchy(throwable);
     }
 
     /**
@@ -106,7 +120,8 @@ public class ExceptionProxy implements Externalizable {
 
     /**
      * Constructs an instance of the proxied exception based on the class name,
-     * message, stack trace and if applicable, the cause.
+     * message, stack trace and if applicable, and the cause if the cause could be
+     * deserialized in the client. Otherwise, this returns an ArquillianProxyException
      *
      * @return The constructed {@link Throwable} instance
      */
@@ -143,7 +158,7 @@ public class ExceptionProxy implements Externalizable {
                 cause = causeProxy.createException();
             }
         }
-        return cause;
+        return serializationProcessException;
     }
 
     /**
@@ -162,7 +177,44 @@ public class ExceptionProxy implements Externalizable {
      */
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        className = (String) in.readObject();
+        // Read the first object to see if it is the version object
+        Object firstObject = in.readObject();
+        if (firstObject instanceof Version) {
+            version = (Version) firstObject;
+            className = (String) in.readObject();
+            message = (String) in.readObject();
+            trace = (StackTraceElement[]) in.readObject();
+            causeHierarchy = (List<String>) in.readObject();
+            // Try to deserialize the original exception
+            try {
+                byte[] originalExceptionData = (byte[]) in.readObject();
+                if (originalExceptionData != null && originalExceptionData.length > 0) {
+                    ByteArrayInputStream originalIn = new ByteArrayInputStream(originalExceptionData);
+                    ObjectInputStream input = new ObjectInputStream(originalIn);
+                    original = (Throwable) input.readObject();
+                }
+            } catch (Throwable e) {
+                this.serializationProcessException = e;
+            }
+            // Override with the remote serialization issue cause if exists
+            Throwable tmpSerializationProcessException = (Throwable) in.readObject();
+            if (tmpSerializationProcessException != null) {
+                serializationProcessException = tmpSerializationProcessException;
+            }
+
+            //
+            if(serializationProcessException == null && original == null) {
+                original = buildOriginalException();
+            }
+        } else {
+            // If it is not the version object this is an old version of the ExceptionProxy
+            readExternal_191Final((String) firstObject, in);
+        }
+    }
+
+    // No longer used in 1.9.2.Final+, can be removed in 2.0.0.Final
+    protected void readExternal_191Final(String className, ObjectInput in) throws IOException, ClassNotFoundException {
+        this.className = className;
         message = (String) in.readObject();
         trace = (StackTraceElement[]) in.readObject();
         causeProxy = (ExceptionProxy) in.readObject();
@@ -208,6 +260,32 @@ public class ExceptionProxy implements Externalizable {
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeObject(version);
+        out.writeObject(className);
+        out.writeObject(message);
+        out.writeObject(trace);
+        out.writeObject(causeHierarchy);
+        byte[] originalBytes = new byte[0];
+        try {
+            /* Try to serialize the original exception. Here we do it in a separate try-catch block to avoid
+            because default serialization will serialize whatever it can and leave non-serializable fields out.
+            We have to make the write of the root exception atomic.
+            */
+            ByteArrayOutputStream originalOut = new ByteArrayOutputStream();
+            ObjectOutputStream output = new ObjectOutputStream(originalOut);
+            output.writeObject(original);
+            output.flush();
+            originalBytes = originalOut.toByteArray();
+        } catch (NotSerializableException e) {
+            // ignore, could not serialize original exception
+            this.serializationProcessException = e;
+        }
+        out.writeObject(originalBytes);
+        out.writeObject(serializationProcessException);
+    }
+
+    // No longer used in 1.9.2.Final+, can be removed in 2.0.0.Final
+    protected void writeExternal_191Final(ObjectOutput out) throws IOException {
         out.writeObject(className);
         out.writeObject(message);
         out.writeObject(trace);
@@ -240,5 +318,48 @@ public class ExceptionProxy implements Externalizable {
     @Override
     public String toString() {
         return super.toString() + String.format("[class=%s, message=%s],cause = %s", className, message, causeProxy);
+    }
+
+    /**
+     * Get the exception hierarchy for the exception class
+     *
+     * @return list of exception types in the hierarchy
+     */
+    protected List<String> getExceptionHierarchy(Throwable t) {
+        List<String> hierarchy = new ArrayList<>();
+        Class<?> tclass = t.getClass();
+        while(Throwable.class.isAssignableFrom(tclass)) {
+            hierarchy.add(tclass.getName());
+            tclass = tclass.getSuperclass();
+        }
+        return hierarchy;
+    }
+    /**
+     * Build the original exception based on the exception class name. This first
+     * tries to use a ctor with a message, then a default ctor.
+     *
+     * @return the original exception
+     */
+    protected Throwable buildOriginalException() {
+        Throwable original = null;
+        for(String tclassName : causeHierarchy) {
+            try {
+                Class<? extends Throwable> tclass = Class.forName(tclassName).asSubclass(Throwable.class);
+                try {
+                    original = tclass.getDeclaredConstructor(String.class).newInstance(message);
+                    break;
+                } catch (Exception e) {
+                    try {
+                        original = tclass.getDeclaredConstructor().newInstance();
+                        break;
+                    } catch (Exception ex) {
+                        // ignore, could not load class on client side, try next base class
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+                // ignore, could not load class on client side, try next base class
+            }
+        }
+        return original;
     }
 }

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/ExceptionProxy.java
@@ -105,6 +105,7 @@ public class ExceptionProxy implements Externalizable {
         if (throwable == null) {
             return null;
         }
+        //System.out.println("ExceptionProxy.createForException, throwable=" + throwable);
         return new ExceptionProxy(throwable);
     }
 
@@ -128,6 +129,7 @@ public class ExceptionProxy implements Externalizable {
         if (!hasException()) {
             return null;
         }
+        //System.out.println("ExceptionProxy.createException, this=" + this);
         if (original != null) {
             return original;
         }
@@ -191,6 +193,37 @@ public class ExceptionProxy implements Externalizable {
 
     public List<String> getExceptionHierarchy() {
         return exceptionHierarchy;
+    }
+
+    /**
+     * Override to provide the full details of the exception being proxied
+     * @return The full details of the exception being proxied
+     */
+    @Override
+    public String toString() {
+        StringBuilder tmp = new StringBuilder();
+        tmp.append("ExceptionProxy("+className+")");
+        if(message != null) {
+            tmp.append("msg: ").append(message);
+        }
+        if(causeProxy != null) {
+            tmp.append("\ncause: ").append(causeProxy);
+        }
+        if(trace != null) {
+            for(StackTraceElement element : trace) {
+                tmp.append("\n\tat ").append(element);
+            }
+        }
+        if(exceptionHierarchy != null) {
+            tmp.append("\nexceptionHierarchy: ");
+            for(String t : exceptionHierarchy) {
+                tmp.append("\n\t").append(t);
+            }
+        }
+        if(serializationProcessException != null) {
+            tmp.append("\nserializationProcessException: ").append(serializationProcessException);
+        }
+        return tmp.toString();
     }
 
     /**
@@ -267,11 +300,6 @@ public class ExceptionProxy implements Externalizable {
         }
         out.writeObject(originalBytes);
         out.writeObject(serializationProcessException);
-    }
-
-    @Override
-    public String toString() {
-        return super.toString() + String.format("[class=%s, message=%s],cause = %s", className, message, causeProxy);
     }
 
     /**

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
@@ -62,34 +62,48 @@ public class ExceptionProxyTestCase {
         proxy(new UnsatisfiedResolutionException(new Exception(MSG)));
     }
 
+    /**
+     * This tests that an exception that fails to serialize can be proxied and
+     * the client can see the message
+     * @throws Exception
+     */
     @Test
     public void shouldSerializeNonSerializableExceptions() throws Exception {
         ExceptionProxy proxy = serialize(ExceptionProxy.createForException(new NonSerializableException()));
         Throwable t = proxy.createException();
 
-        Assert.assertEquals(ArquillianProxyException.class, t.getClass());
+        Assert.assertEquals(NonSerializableException.class, t.getClass());
         Assert.assertTrue(
-            "Verify Proxy message contain root exception of serialization problem",
-            t.getMessage().contains("java.io.NotSerializableException"));
+            "NonSerializableException should have a message",
+            t.getMessage().contains("UnsupportedOperationException"));
+        // Since the cause is set by the NonSerializableException.ctor, this should be seen
+        Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
+        // The proxy should have a serializationProcessException
         Assert.assertTrue(
-            "Verify Proxy message contain root cause of serialization problem",
-            t.getMessage().contains("BufferedInputStream"));
+            "Verify Proxy message contain root cause of deserialization problem",
+            proxy.getSerializationProcessException().getMessage().contains("BufferedInputStream"));
     }
 
+    /**
+     * This tests that an exception that fails to de-serialize
+     * can be proxied and the client can see the message
+     * @throws Exception
+     */
     @Test
     public void shouldSerializeNonDeSerializableExceptions() throws Exception {
         ExceptionProxy proxy = serialize(ExceptionProxy.createForException(new NonDeserializableExtension("Test")));
         Throwable t = proxy.createException();
 
-        Assert.assertEquals(ArquillianProxyException.class, t.getClass());
+        Assert.assertEquals(NonDeserializableExtension.class, t.getClass());
         Assert.assertTrue(
-            "Verify Proxy message contain root exception of deserialization problem",
-            t.getMessage().contains("NonDeserializableExtension"));
+            "The exception should have original message",
+            t.getMessage().contains("Test"));
+        // Since the cause is set by the NonDeserializableExtension.ctor, this should be seen
+        Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
+        // The proxy should have a serializationProcessException
         Assert.assertTrue(
             "Verify Proxy message contain root cause of deserialization problem",
-            t.getMessage().contains("Could not de-serialize"));
-        // This is not valid if the exception is not serializable
-        //Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
+            proxy.getSerializationProcessException().getMessage().contains("Could not de-serialize"));
     }
 
     @Test
@@ -103,8 +117,14 @@ public class ExceptionProxyTestCase {
         Assert.assertEquals(ClassNotFoundException.class, t.getCause().getCause().getClass());
     }
 
+    /**
+     * Test that the client can handle a server exception that is not on the client classpath by
+     * being able to see the common exception supertypes that are on the client classpath.
+     * @throws Throwable
+     */
     @Test
     public void handleExceptionClassNotOnClientClasspath() throws Throwable {
+        // Create the exception using a classloader that is not the client classloader
         Throwable serverException = causeServerException();
         System.out.println("Loaded server exception: " + serverException);
         ExceptionProxy proxy = serialize(ExceptionProxy.createForException(serverException));
@@ -112,8 +132,8 @@ public class ExceptionProxyTestCase {
         System.out.println("Client exception from proxy: " + t);
         System.out.println("Client exception trace from proxy:");
         t.printStackTrace();
-        Assert.assertEquals(ArquillianProxyException.class, t.getClass());
-        Assert.assertEquals(ClassNotFoundException.class, t.getCause().getClass());
+        Assert.assertEquals(IException.class, t.getClass());
+        //Assert.assertEquals(ClassNotFoundException.class, t.getCause().getClass());
     }
 
     private Throwable causeServerException() throws Exception {

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
@@ -20,6 +20,7 @@ package org.jboss.arquillian.test.spi;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInput;
@@ -28,11 +29,17 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * ExceptionProxyTestCase
+ * Updated for https://github.com/arquillian/arquillian-core/issues/641
+ * where the exception seen by a client that did not have the exception class
+ * thrown from a server was not on the client classpath.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
@@ -67,7 +74,6 @@ public class ExceptionProxyTestCase {
         Assert.assertTrue(
             "Verify Proxy message contain root cause of serialization problem",
             t.getMessage().contains("BufferedInputStream"));
-        Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
     }
 
     @Test
@@ -82,7 +88,8 @@ public class ExceptionProxyTestCase {
         Assert.assertTrue(
             "Verify Proxy message contain root cause of deserialization problem",
             t.getMessage().contains("Could not de-serialize"));
-        Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
+        // This is not valid if the exception is not serializable
+        //Assert.assertEquals(UnsupportedOperationException.class, t.getCause().getClass());
     }
 
     @Test
@@ -96,12 +103,44 @@ public class ExceptionProxyTestCase {
         Assert.assertEquals(ClassNotFoundException.class, t.getCause().getCause().getClass());
     }
 
+    @Test
+    public void handleExceptionClassNotOnClientClasspath() throws Throwable {
+        Throwable serverException = causeServerException();
+        System.out.println("Loaded server exception: " + serverException);
+        ExceptionProxy proxy = serialize(ExceptionProxy.createForException(serverException));
+        Throwable t = proxy.createException();
+        System.out.println("Client exception from proxy: " + t);
+        System.out.println("Client exception trace from proxy:");
+        t.printStackTrace();
+        Assert.assertEquals(ArquillianProxyException.class, t.getClass());
+        Assert.assertEquals(ClassNotFoundException.class, t.getCause().getClass());
+    }
+
+    private Throwable causeServerException() throws Exception {
+        // Create a ClassLoader for the target/serveronly-classes dir
+        File serverOnlyClasses = new File("target/serveronly-classes");
+        Assert.assertTrue("target/serveronly-classes should exist", serverOnlyClasses.exists());
+        URL[] serveronlyCP = {serverOnlyClasses.toURL()};
+        URLClassLoader classLoader = new URLClassLoader(serveronlyCP, getClass().getClassLoader());
+        Class<IBean> exClass = (Class<IBean>) classLoader.loadClass("org.jboss.arquillian.test.spi.serveronly.SomeBean");
+        IBean bean = exClass.newInstance();
+        Throwable exception = null;
+        try {
+            bean.invoke();
+        } catch (Exception e) {
+            exception = e;
+        }
+        return exception;
+    }
+
     private ExceptionProxy serialize(ExceptionProxy proxy) throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ObjectOutputStream out = new ObjectOutputStream(output);
         out.writeObject(proxy);
+        out.close();
+        byte[] data = output.toByteArray();
 
-        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()));
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(data));
         return (ExceptionProxy) in.readObject();
     }
 
@@ -122,7 +161,10 @@ public class ExceptionProxyTestCase {
         }
     }
 
-    // Simulate org.jboss.weld.exceptions.IllegalArgumentException
+    /** Simulate org.jboss.weld.exceptions.IllegalArgumentException
+     * Note, this does not simulate the case of weld implementation classes not
+     * being on the test client classpath, which is the norm.
+     */
     private static class ExtendedIllegalArgumentException extends IllegalArgumentException {
         private static final long serialVersionUID = 1L;
 

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/IBean.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/IBean.java
@@ -1,0 +1,5 @@
+package org.jboss.arquillian.test.spi;
+
+public interface IBean {
+    String invoke();
+}

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/IException.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/IException.java
@@ -1,0 +1,12 @@
+package org.jboss.arquillian.test.spi;
+
+/**
+ * An exception class that is common to both the client and server container side.
+ */
+public class IException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public IException(String message) {
+        super(message);
+    }
+}

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/serveronly/SomeBean.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/serveronly/SomeBean.java
@@ -1,0 +1,20 @@
+package org.jboss.arquillian.test.spi.serveronly;
+
+import org.jboss.arquillian.test.spi.IBean;
+
+/**
+ * A simple bean that throws an exception. This is loaded by a custom classloader
+ * in the test client so that the exception thrown is not available on the client.
+ */
+public class SomeBean implements IBean {
+    public String invoke() {
+        return invokeImpl();
+    }
+
+    private String invokeImpl() {
+        return invokeImplNested();
+    }
+    private String invokeImplNested() throws SomeNonClientSideException {
+        throw new SomeNonClientSideException();
+    }
+}

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/serveronly/SomeNonClientSideException.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/serveronly/SomeNonClientSideException.java
@@ -1,0 +1,10 @@
+package org.jboss.arquillian.test.spi.serveronly;
+
+import org.jboss.arquillian.test.spi.IException;
+
+public class SomeNonClientSideException extends IException {
+    private static final long serialVersionUID = 1L;
+    public SomeNonClientSideException() {
+        super("The server side reason for this exception");
+    }
+}


### PR DESCRIPTION
This is a first step that preserves the current unit tests, but I think we need to be more aggressive at restoring the original exception from the type hierarchy and almost never actually see an `ArquillianProxyException`.  The only time it would be seen is if none of the exception types could be loaded on the client.

Fixes #641 
