### PR TITLE
Finish Subversion to Git SCM migration: remove "@version $Revision: $" since Git does not support automatic keyword substitution

### DIFF
--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ArquillianDescriptor.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ArquillianDescriptor.java
@@ -23,7 +23,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  * ArquillianDescriptor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ArquillianDescriptor extends Descriptor {
     EngineDef engine();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ContainerDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ContainerDef.java
@@ -23,7 +23,6 @@ import java.util.Map;
  * ContainerDescription
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ContainerDef extends ArquillianDescriptor {
     String getContainerName();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/DefaultProtocolDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/DefaultProtocolDef.java
@@ -22,7 +22,6 @@ import java.util.Map;
  * DefaultProtocolDescription
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DefaultProtocolDef extends ArquillianDescriptor {
     String getType();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/EngineDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/EngineDef.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.config.descriptor.api;
  * EngineDef
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface EngineDef extends ArquillianDescriptor {
 

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ExtensionDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ExtensionDef.java
@@ -22,7 +22,6 @@ import java.util.Map;
  * ExtensionDef
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ExtensionDef extends ArquillianDescriptor {
     String getExtensionName();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/GroupDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/GroupDef.java
@@ -22,7 +22,6 @@ import java.util.List;
  * GroupDescription
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface GroupDef extends ArquillianDescriptor {
     String getGroupName();

--- a/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ProtocolDef.java
+++ b/config/api/src/main/java/org/jboss/arquillian/config/descriptor/api/ProtocolDef.java
@@ -22,7 +22,6 @@ import java.util.Map;
  * ProtocolDescription
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ProtocolDef extends ContainerDef {
     String getType();

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorImpl.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.NodeDescriptorImplBase;
  * ArquillianDescriptor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArquillianDescriptorImpl extends NodeDescriptorImplBase implements ArquillianDescriptor {
     //-------------------------------------------------------------------------------------||

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ContainerDefImpl.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * ContainerDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerDefImpl extends ArquillianDescriptorImpl implements ContainerDef {
     private Node container;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/DefaultProtocolDefImpl.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * DefaultProtocolDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DefaultProtocolDefImpl extends ArquillianDescriptorImpl implements DefaultProtocolDef {
     private Node protocol;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/EngineDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/EngineDefImpl.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * EngineDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EngineDefImpl extends ArquillianDescriptorImpl implements EngineDef {
     private static final String exportPath = "property@name=deploymentExportPath";

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ExtensionDefImpl.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * ExtensionDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExtensionDefImpl extends ArquillianDescriptorImpl implements ExtensionDef {
     private Node extension;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupContainerDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupContainerDefImpl.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * ContainerDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class GroupContainerDefImpl extends ContainerDefImpl implements GroupDef {
     private Node group;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/GroupDefImpl.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * GroupDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class GroupDefImpl extends ArquillianDescriptorImpl implements GroupDef {
     private Node group;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/descriptor/impl/ProtocolDefImpl.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * ProtocolDefImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDefImpl extends ContainerDefImpl implements ProtocolDef {
     private Node protocol;

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigExtension.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * ConfigExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ConfigExtension implements LoadableExtension {
     @Override

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrar.java
@@ -39,7 +39,6 @@ import java.util.Properties;
  * Configurator
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ConfigurationRegistrar {
     public static final String ARQUILLIAN_XML_PROPERTY = "arquillian.xml";

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/FileUtils.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/FileUtils.java
@@ -28,7 +28,6 @@ import java.util.Properties;
  * FileUtils
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 class FileUtils {
     static Properties loadArquillianProperties(String propertyName, String defaultName) {

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/PropertiesParser.java
@@ -55,7 +55,6 @@ import org.jboss.arquillian.config.descriptor.api.ProtocolDef;
  *     arq.container.[qualifier].configuration.[property_name]=[ORIGINAL] new-values
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 class PropertiesParser {
     private static String ARQ_PROPERTY = "arq\\..*";

--- a/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/StringPropertyReplacer.java
+++ b/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/StringPropertyReplacer.java
@@ -31,7 +31,6 @@ import java.util.Properties;
  * @author <a href="claudio.vesco@previnet.it">Claudio Vesco</a>
  * @author <a href="mailto:adrian@jboss.com">Adrian Brock</a>
  * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
- * @version <tt>$Revision: 2898 $</tt>
  */
 public final class StringPropertyReplacer {
 

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/ArquillianDescriptorTestCase.java
@@ -40,7 +40,6 @@ import org.xml.sax.SAXParseException;
  * ArquillianDescriptorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArquillianDescriptorTestCase {
     private static final String CONTAINER_NAME_1 = "jbossas-remote";

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/AssertXPath.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/descriptor/impl/AssertXPath.java
@@ -30,7 +30,6 @@ import org.w3c.dom.NodeList;
  * Simple helper for Xpath related Assertions.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public final class AssertXPath {
     /**

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/ConfigurationRegistrarTestCase.java
@@ -47,7 +47,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ConfigurationRegistrarTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigurationRegistrarTestCase extends AbstractManagerTestBase {

--- a/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
+++ b/config/impl-base/src/test/java/org/jboss/arquillian/config/impl/extension/PropertiesParserTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Test;
  * SystemPropertiesReaderTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class PropertiesParserTestCase {
     private static final String ENGINE_PROP_DEPLOYMENTS = "arq.engine.deploymentExportPath";

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerCreationException.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerCreationException.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.impl;
  * ContainerCreationException
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerCreationException extends RuntimeException {
     private static final long serialVersionUID = 7783398740102071179L;

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerExtension.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerExtension.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * ContainerExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerExtension implements LoadableExtension {
     @Override

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerImpl.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ContainerImpl.java
@@ -46,7 +46,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * Container
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerImpl<T extends ContainerConfiguration> implements Container<T> {
     @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/DefaultServerKillProcessor.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/DefaultServerKillProcessor.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.spi.ServerKillProcessor;
  * DefaultServerKillProcessor
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class DefaultServerKillProcessor implements ServerKillProcessor {
     private final Logger log = Logger.getLogger(DefaultServerKillProcessor.class.getName());

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/FilteredURLClassLoader.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/FilteredURLClassLoader.java
@@ -23,7 +23,6 @@ import java.net.URLClassLoader;
  * FilteredURLClassLoader
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class FilteredURLClassLoader extends URLClassLoader {
 

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/LocalContainerRegistry.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/LocalContainerRegistry.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ContainerManager
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalContainerRegistry implements ContainerRegistry {
     private List<Container> containers;

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/MapObject.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.config.descriptor.api.Multiline;
  * MapObjectPopulator
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class MapObject {
 

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ThreadContext.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/ThreadContext.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
  * ThreadContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ThreadContext {
     private static ThreadLocal<ClassLoader> previousClassloader = new ThreadLocal<ClassLoader>();

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/ContainerDeploymentContextHandler.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/ContainerDeploymentContextHandler.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.core.spi.EventContext;
  * Activates and DeActivates the Container and Deployment contexts.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerDeploymentContextHandler {
     @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployController.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployController.java
@@ -56,7 +56,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  * and handle them inside the same context.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerDeployController {
     @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerLifecycleController.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerLifecycleController.java
@@ -39,7 +39,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  * ContainerController
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerLifecycleController {
     @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerOperationResult.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerOperationResult.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescriptio
  * OperationResult
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerOperationResult<T> {
     private List<Operation<T>> operations;

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
@@ -40,7 +40,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * ContainerRegistryCreator
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerRegistryCreator {
     static final String ARQUILLIAN_LAUNCH_PROPERTY = "arquillian.launch";

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandler.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandler.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * the {@link Deployment}.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentExceptionHandler {
     @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporter.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
  * Used for debugging the deployment.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArchiveDeploymentExporter {
     private static final Logger log = Logger.getLogger(ArchiveDeploymentExporter.class.getName());

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/SecurityActions.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/deployment/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/context/ContainerContextImpl.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/context/ContainerContextImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ContainerContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerContextImpl extends AbstractContext<String> implements ContainerContext {
     /* (non-Javadoc)

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/context/DeploymentContextImpl.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/context/DeploymentContextImpl.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ContainerContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentContextImpl extends AbstractContext<Deployment> implements DeploymentContext {
     /* (non-Javadoc)

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/ContainerRegistryTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/ContainerRegistryTestCase.java
@@ -42,7 +42,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * DomainModelTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerRegistryTestCase extends AbstractContainerTestBase {

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/MapObjectTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * MapObjectTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class MapObjectTestCase {
     private static final String VAL_STRING = "test123";

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
@@ -71,7 +71,6 @@ import static org.mockito.Mockito.when;
  * ContainerDeployControllerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 @RunWith(MockitoJUnitRunner.class)

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerLifecycleControllerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerLifecycleControllerTestCase.java
@@ -64,7 +64,6 @@ import static org.mockito.Mockito.when;
  * ContainerLifecycleControllerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 @RunWith(MockitoJUnitRunner.class)

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreatorTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreatorTestCase.java
@@ -39,7 +39,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ContainerRegistryCreatorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerRegistryCreatorTestCase extends AbstractContainerTestBase {

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandlerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/DeploymentExceptionHandlerTestCase.java
@@ -44,7 +44,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * DeploymentExceptionHandlerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DeploymentExceptionHandlerTestCase extends AbstractContainerTestBase {

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporterTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/deployment/ArchiveDeploymentExporterTestCase.java
@@ -41,7 +41,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Verify the behavior of the ArchiveDeploymentExporter
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ArchiveDeploymentExporterTestCase extends AbstractContainerTestBase {

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/test/AbstractContainerTestBase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/test/AbstractContainerTestBase.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.test.AbstractManagerTestBase;
  * AbstractContainerTestBase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractContainerTestBase extends AbstractManagerTestBase {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/ConfigurationException.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/ConfigurationException.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi;
  * ConfigurationException
  *
  * @author <a href="mailto:german.escobarc@gmail.com">German Escobar</a>
- * @version $Revision: $
  */
 public class ConfigurationException extends RuntimeException {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/Container.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/Container.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
  * ContainerT
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Container<T extends ContainerConfiguration> {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/ContainerRegistry.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/ContainerRegistry.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * ContainerRegistryA
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ContainerRegistry {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/ServerKillProcessor.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/ServerKillProcessor.java
@@ -24,7 +24,6 @@ package org.jboss.arquillian.container.spi;
  * this is dedicated for hard-kill of server instances.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public interface ServerKillProcessor {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/ContainerConfiguration.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/ContainerConfiguration.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.ConfigurationException;
  * Container configuration that can be validated
  *
  * @author <a href="mailto:german.escobarc@gmail.com">German Escobar</a>
- * @version $Revision: $
  */
 public interface ContainerConfiguration {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  * type of container needs setup or an explicit start and stop.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DeployableContainer<T extends ContainerConfiguration> {
     // ControllableContainer

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeploymentException.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeploymentException.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.client.container;
  * DeploymentException
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeploymentExceptionTransformer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeploymentExceptionTransformer.java
@@ -22,7 +22,6 @@ package org.jboss.arquillian.container.spi.client.container;
  * deployment exceptions. This should transform from the container specific exception to the real cause.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DeploymentExceptionTransformer {
     /**

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/LifecycleException.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/LifecycleException.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.client.container;
  * LifecycleException
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LifecycleException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Deployment.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Deployment.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.client.deployment;
  * Deployment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class Deployment {
     private boolean deployed = false;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentDescription.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentDescription.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  * Deployment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentDescription {
     private String name;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentScenario.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentScenario.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.Archive;
 
 /**
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentScenario {
     private final List<Deployment> deployments;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentTargetDescription.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentTargetDescription.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.client.deployment;
  * Target
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentTargetDescription {
     public static final DeploymentTargetDescription DEFAULT = new DeploymentTargetDescription("_DEFAULT_");

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/TargetDescription.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/TargetDescription.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.client.deployment;
  * Target
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TargetDescription {
     public static final TargetDescription DEFAULT = new TargetDescription("_DEFAULT_");

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Validate.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/Validate.java
@@ -33,7 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @author <a href="mailto:tommy.tynja@diabol.se">Tommy Tynj&auml;</a>
- * @version $Revision: $
  */
 public final class Validate {
     private static Map<Class<? extends Archive<?>>, String> archiveExpressions;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/ProtocolDescription.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/ProtocolDescription.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.client.protocol;
  * A simple named reference to a {@link Protocol}.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDescription {
     public static final ProtocolDescription DEFAULT = new ProtocolDescription("_DEFAULT_");

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/Validate.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/Validate.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.container.spi.ConfigurationException;
  * Validation utility
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 final class Validate {
     private Validate() {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/HTTPContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/HTTPContext.java
@@ -26,7 +26,6 @@ import java.util.Set;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:ian@ianbrandt.com">Ian Brandt</a>
- * @version $Revision: $
  */
 public class HTTPContext extends NamedContext {
     private final String host;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/JMXContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/JMXContext.java
@@ -33,7 +33,6 @@ import javax.management.remote.JMXServiceURL;
  * JMXContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JMXContext extends NamedContext {
     private static final Logger log = Logger.getLogger(JMXContext.class.getName());

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/NamedContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/NamedContext.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.client.protocol.metadata;
  * NamedContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class NamedContext {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
@@ -25,7 +25,6 @@ import java.util.List;
  * ProtocolMetaData
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolMetaData {
     private List<Object> contexts = new ArrayList<Object>();

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/RMIContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/RMIContext.java
@@ -22,7 +22,6 @@ import javax.naming.InitialContext;
  * RMIContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class RMIContext extends NamedContext {
     private String ip;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/Servlet.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/Servlet.java
@@ -24,7 +24,6 @@ import java.net.URI;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:ian@ianbrandt.com">Ian Brandt</a>
- * @version $Revision: $
  */
 public class Servlet {
     static final String HTTP_SCHEME = "http://";

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/ContainerContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/ContainerContext.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.context.IdBoundContext;
  * ContainerContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ContainerContext extends IdBoundContext<String> {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/DeploymentContext.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/DeploymentContext.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.context.IdBoundContext;
  * ContainerContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DeploymentContext extends IdBoundContext<Deployment> {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/annotation/ContainerScoped.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/annotation/ContainerScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * SuiteScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/annotation/DeploymentScoped.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/context/annotation/DeploymentScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * DeploymentScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/ContainerControlEvent.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/ContainerControlEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.event.Event;
  * ContainerControlEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class ContainerControlEvent implements Event {
     private Container container;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/ContainerMultiControlEvent.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/ContainerMultiControlEvent.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * ContainerMultiControlEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeployDeployment.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeployDeployment.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.spi.client.deployment.Deployment;
  * DeployToContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeployDeployment extends DeploymentEvent {
     public DeployDeployment(Container container, Deployment deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeployManagedDeployments.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeployManagedDeployments.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * DeployControlledDeployments
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeployManagedDeployments implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeploymentEvent.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/DeploymentEvent.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.container.spi.client.deployment.Deployment;
  * DeploymentEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class DeploymentEvent extends ContainerControlEvent {
     private Deployment deployment;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/KillContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/KillContainer.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.Container;
  * KillContainer
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class KillContainer extends ContainerControlEvent {
     public KillContainer(Container container) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/SetupContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/SetupContainer.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.Container;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class SetupContainer extends ContainerControlEvent {
     public SetupContainer(Container container) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/SetupContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/SetupContainers.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class SetupContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartClassContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartClassContainers.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.event;
  * StartClassContainers
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class StartClassContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartContainer.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.Container;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class StartContainer extends ContainerControlEvent {
     public StartContainer(Container container) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartSuiteContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StartSuiteContainers.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class StartSuiteContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopClassContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopClassContainers.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.spi.event;
  * StopClassContainers
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class StopClassContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopContainer.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.Container;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class StopContainer extends ContainerControlEvent {
     public StopContainer(Container container) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopManualContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopManualContainers.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * StopNonManagedContainers
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class StopManualContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopSuiteContainers.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/StopSuiteContainers.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * StartContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class StopSuiteContainers implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/UnDeployDeployment.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/UnDeployDeployment.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.spi.client.deployment.Deployment;
  * DeployToContainer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class UnDeployDeployment extends DeploymentEvent {
     public UnDeployDeployment(Container container, Deployment deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/UnDeployManagedDeployments.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/UnDeployManagedDeployments.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.spi.event;
  * DeployControlledDeployments
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class UnDeployManagedDeployments implements ContainerMultiControlEvent {
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterDeploy.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterDeploy.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescriptio
  * Event fired After DeployableContainer deployment.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterDeploy extends DeployerEvent {
     public AfterDeploy(DeployableContainer<?> deployableContainer, DeploymentDescription deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterKill.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterKill.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired After the DeployableContainer is killed.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class AfterKill extends ContainerEvent {
     public AfterKill(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterSetup.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterSetup.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired After the DeployableContainer is setup.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterSetup extends ContainerEvent {
     public AfterSetup(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterStart.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterStart.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired After the DeployableContainer is started.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterStart extends ContainerEvent {
     public AfterStart(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterStop.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterStop.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired After the DeployableContainer is stopped.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterStop extends ContainerEvent {
     public AfterStop(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterUnDeploy.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/AfterUnDeploy.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescriptio
  * Event fired After DeployableContainer undeployment.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterUnDeploy extends DeployerEvent {
     public AfterUnDeploy(DeployableContainer<?> deployableContainer, DeploymentDescription deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeDeploy.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeDeploy.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescriptio
  * Event fired Before DeployableContainer deployment.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeDeploy extends DeployerEvent {
     public BeforeDeploy(DeployableContainer<?> deployableContainer, DeploymentDescription deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeKill.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeKill.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired Before the DeployableContainer is killed.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class BeforeKill extends ContainerEvent {
     public BeforeKill(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeSetup.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeSetup.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired Before the DeployableContainer is setup.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeSetup extends ContainerEvent {
     public BeforeSetup(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeStart.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeStart.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired Before the DeployableContainer is started.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeStart extends ContainerEvent {
     public BeforeStart(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeStop.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeStop.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
  * Event fired Before the DeployableContainer is stopped.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeStop extends ContainerEvent {
     public BeforeStop(DeployableContainer<?> deployableContainer) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeUnDeploy.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/BeforeUnDeploy.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescriptio
  * Event fired Before DeployableContainer undeployment.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeUnDeploy extends DeployerEvent {
     public BeforeUnDeploy(DeployableContainer<?> deployableContainer, DeploymentDescription deployment) {

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/ContainerEvent.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/ContainerEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.event.Event;
  * Base for events fired in the Container life cycle
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerEvent implements Event {
     private DeployableContainer<?> deployableContainer;

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/DeployerEvent.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/event/container/DeployerEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * DeployerEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeployerEvent extends ContainerEvent {
     private DeploymentDescription deployment;

--- a/container/spi/src/test/java/org/jboss/arquillian/spi/client/deployment/DeploymentScenarioTestCase.java
+++ b/container/spi/src/test/java/org/jboss/arquillian/spi/client/deployment/DeploymentScenarioTestCase.java
@@ -33,7 +33,6 @@ import org.junit.Test;
  * DeploymentScenarioTest
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentScenarioTestCase {
     private static final String DEFAULT_NAME = DeploymentTargetDescription.DEFAULT.getName();

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Config.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Config.java
@@ -27,7 +27,6 @@ import java.util.Map;
  * {@link ContainerController#start(String, Map)}
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class Config {
     private Map<String, String> props;

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
@@ -54,7 +54,6 @@ import java.util.Map;
  * Only containers configured to be in mode manual or custom can be controlled via the ContainerController.
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public interface ContainerController {
     void start(String containerQualifier);

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployer.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
  * </code></pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Deployer {
     /**

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployment.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Deployment.java
@@ -50,7 +50,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </code></pre>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/DeploymentConfiguration.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/DeploymentConfiguration.java
@@ -10,7 +10,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  *
  * It wraps all possible annotations that can be used in a {@link Deployment } method.
  *
- * @version $Revision: $
  */
 public class DeploymentConfiguration {
 

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/OperateOnDeployment.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/OperateOnDeployment.java
@@ -78,7 +78,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </code></pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/OverProtocol.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/OverProtocol.java
@@ -55,7 +55,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </code></pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/RunAsClient.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/RunAsClient.java
@@ -49,7 +49,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </code></pre>
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Inherited
 @Documented

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ShouldThrowException.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ShouldThrowException.java
@@ -41,7 +41,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * will force a @{@link RunAsClient} test run mode, unless you explicitly mark <code>testable = true</code>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/TargetsContainer.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/TargetsContainer.java
@@ -59,7 +59,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * when targeting that container. Only one container can be set as default within a group.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Testable.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/Testable.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
  * in the context of this web module.
  *
  * @author robert.panzer
- * @version $Revision: $
  */
 public final class Testable {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ClientTestInstanceEnricher.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ClientTestInstanceEnricher.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.event.suite.Before;
  * ClientTestInstanceEnricher, a TestInstanceEnricher that is aware of RunModes.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClientTestInstanceEnricher extends TestInstanceEnricher {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestExtension.java
@@ -60,7 +60,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * This Extension Overrides the original TestExtension. Needed to change the behavior of TestEnricher to be RunMode aware
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerTestExtension implements LoadableExtension {
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestRemoteExtension.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/ContainerTestRemoteExtension.java
@@ -36,7 +36,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * ContainerTestExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerTestRemoteExtension extends TestExtension implements RemoteLoadableExtension {
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/MapObject.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/MapObject.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.config.descriptor.api.Multiline;
  * MapObjectPopulator
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class MapObject {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RemoteExtensionLoader.java
@@ -46,7 +46,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ServiceLoader implementation that use META-INF/services/interface files to registered Services.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class RemoteExtensionLoader implements ExtensionLoader {
     //-------------------------------------------------------------------------------------||

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RunModeUtils.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/RunModeUtils.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.spi.TestClass;
  * RunModeUtils
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public final class RunModeUtils {
     private static Logger log = Logger.getLogger(RunModeUtils.class.getName());

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/SecurityActions.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/ContainerEventController.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/ContainerEventController.java
@@ -54,7 +54,6 @@ import org.jboss.arquillian.test.spi.event.suite.TestEvent;
  * Event dispatcher between Test lifecyle events and Container control events.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerEventController {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/LocalCommandService.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/LocalCommandService.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.api.annotation.Inject;
  * LocalCommandService
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalCommandService implements CommandService {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerController.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerController.java
@@ -41,7 +41,6 @@ import org.jboss.arquillian.core.api.annotation.Inject;
  * ClientContainerController
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ClientContainerController implements ContainerController {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerControllerCreator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerControllerCreator.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  * ClientContainerControllerCreator
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ClientContainerControllerCreator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerController.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerController.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * ContainerContainerController
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ContainerContainerController implements ContainerController {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerControllerCreator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerControllerCreator.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
  * ContainerContainerControllerCreator
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ContainerContainerControllerCreator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerRestarter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerRestarter.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
  * {@link ArquillianDescriptor}<br/>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerRestarter {
     private int testClassesCount = 0;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/ContainerCommandObserver.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/ContainerCommandObserver.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.EventContext;
  * ContainerCommandObserver
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ContainerCommandObserver {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/ContainerStartedCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/ContainerStartedCommand.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.impl.client.deployment.command.Abstra
  * StartContainerCommand
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ContainerStartedCommand extends AbstractCommand<Boolean> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/KillContainerCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/KillContainerCommand.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.impl.client.deployment.command.Abstra
  * KillContainerCommand
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class KillContainerCommand extends AbstractCommand<String> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StartContainerCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StartContainerCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.impl.client.deployment.command.Abstra
  * StartContainerCommand
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class StartContainerCommand extends AbstractCommand<String> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StopContainerCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StopContainerCommand.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.impl.client.deployment.command.Abstra
  * StartContainerCommand
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class StopContainerCommand extends AbstractCommand<String> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGenerator.java
@@ -44,7 +44,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  * the standard Arquillian API annotations.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AnnotationDeploymentScenarioGenerator extends AbstractDeploymentScenarioGenerator implements DeploymentScenarioGenerator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AutomaticDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AutomaticDeploymentScenarioGenerator.java
@@ -17,7 +17,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * {@link DeploymentScenarioGenerator} that builds a {@link DeploymentScenario} based on
  * the {@link AutomaticDeployment} registered services.
  *
- * @version $Revision: $
  */
 public class AutomaticDeploymentScenarioGenerator extends AbstractDeploymentScenarioGenerator implements DeploymentScenarioGenerator {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployer.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployer.java
@@ -40,7 +40,6 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
  * ClientDeployer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClientDeployer implements Deployer {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerCreator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerCreator.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  * ClientDeployerRegister
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClientDeployerCreator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ContainerDeployer.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ContainerDeployer.java
@@ -35,7 +35,6 @@ import static java.security.AccessController.doPrivileged;
  * ContainerDeployer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerDeployer implements Deployer {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ContainerDeployerCreator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ContainerDeployerCreator.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
  * ClientDeployerRegister
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerDeployerCreator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGenerator.java
@@ -57,7 +57,6 @@ import org.jboss.shrinkwrap.api.container.ClassContainer;
  * DeploymentGenerator
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentGenerator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ThreadContext.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ThreadContext.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
  * ThreadContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ThreadContext {
     private static ThreadLocal<ClassLoader> previousClassloader = new ThreadLocal<ClassLoader>();

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ValidationException.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/ValidationException.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.test.impl.client.deployment;
  * ValidationException
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ValidationException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/AbstractCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/AbstractCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * AbstractCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractCommand<T> implements Command<T>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/DeployDeploymentCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/DeployDeploymentCommand.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.test.impl.client.deployment.command;
  * DeployDeployment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeployDeploymentCommand extends AbstractCommand<String> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/DeploymentCommandObserver.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/DeploymentCommandObserver.java
@@ -33,7 +33,6 @@ import org.jboss.arquillian.core.spi.EventContext;
  * DeployDeploymentObserver
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeploymentCommandObserver {
     private static final Logger log = Logger.getLogger(DeploymentCommandObserver.class.getName());

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/GetDeploymentCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/GetDeploymentCommand.java
@@ -19,7 +19,6 @@ package org.jboss.arquillian.container.test.impl.client.deployment.command;
 
 /**
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class GetDeploymentCommand extends AbstractCommand<byte[]> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/UnDeployDeploymentCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/command/UnDeployDeploymentCommand.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.test.impl.client.deployment.command;
  * DeployDeployment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class UnDeployDeploymentCommand extends AbstractCommand<String> {
     private static final long serialVersionUID = 1L;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/event/GenerateDeployment.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/event/GenerateDeployment.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.test.spi.TestClass;
  * GenerateDeployment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class GenerateDeployment implements Event {
     private TestClass testClass;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ArchiveDeploymentToolingExporter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ArchiveDeploymentToolingExporter.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * Used by tooling to show a view of the ShrinkWrap archive.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArchiveDeploymentToolingExporter {
     static final String ARQUILLIAN_TOOLING_DEPLOYMENT_FOLDER = "arquillian.tooling.deployment.folder";

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ToolingDeploymentFormatter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ToolingDeploymentFormatter.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.formatter.Formatter;
  * ToolingDeploymentFormatter
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ToolingDeploymentFormatter implements Formatter {
     private Class<?> testClass;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/ProtocolRegistryCreator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/ProtocolRegistryCreator.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * Responsible for creating and filling the ProtocolRegistry.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolRegistryCreator {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalContainerMethodExecutor.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalContainerMethodExecutor.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * LocalContainerMethodExecutor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalContainerMethodExecutor implements ContainerMethodExecutor {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalDeploymentPackager.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalDeploymentPackager.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * LocalDeploymentPackager
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalDeploymentPackager implements DeploymentPackager {
     /* (non-Javadoc)

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalProtocol.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalProtocol.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
  * A Protocol that invokes the {@link TestMethodExecutor#invoke()} directly.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalProtocol implements Protocol<LocalProtocolConfiguration> {
     public static final String NAME = "Local";

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalProtocolConfiguration.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/protocol/local/LocalProtocolConfiguration.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfigura
  * LocalProtocolConfiguration
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalProtocolConfiguration implements ProtocolConfiguration {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/deployment/ArquillianDeploymentAppender.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/deployment/ArquillianDeploymentAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * Appender to package up Arquillian api/spi/impl and ShrinkWrap api/spi/impl
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArquillianDeploymentAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolDefinition.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolDefinition.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ProtocolDefinition
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDefinition {
     private Protocol<?> protocol;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistry.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistry.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * A registry holding all found {@link Protocol}s.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolRegistry {
     private List<ProtocolDefinition> protocols;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerControllerProvider.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * ContainerControllerProvider
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 public class ContainerControllerProvider implements ResourceProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerURIResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerURIResourceProvider.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
  * URLResourceProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerURIResourceProvider extends ContainerURLResourceProvider {
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerURLResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/ContainerURLResourceProvider.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * URLResourceProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerURLResourceProvider implements ResourceProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/DeployerProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/DeployerProvider.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * InitialContextProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class DeployerProvider implements ResourceProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProvider.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
  * InitialContextProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InitialContextProvider extends OperatesOnDeploymentAwareProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProvider.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * OperatesOnDeploymentAwareProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class OperatesOnDeploymentAwareProvider implements ResourceProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URIResourceProvider.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
  * URIResourceProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class URIResourceProvider extends URLResourceProvider {
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProvider.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProvider.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.test.api.Secured;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="http://community.jboss.org/people/silenius">Samuel Santos</a>
- * @version $Revision: $
  */
 public class URLResourceProvider extends OperatesOnDeploymentAwareProvider {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/AfterLifecycleEventExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/AfterLifecycleEventExecuter.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.test.spi.event.suite.AfterTestLifecycleEvent;
  * not kept In Container.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  * @see BeforeLifecycleEventExecuter
  */
 public class AfterLifecycleEventExecuter {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/BeforeLifecycleEventExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/BeforeLifecycleEventExecuter.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeTestLifecycleEvent;
  * not kept In Container.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  * @see AfterLifecycleEventExecuter
  */
 public class BeforeLifecycleEventExecuter {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientBeforeAfterLifecycleEventExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientBeforeAfterLifecycleEventExecuter.java
@@ -43,7 +43,6 @@ import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
  * (compared to other Arquillian @Observers)<br/>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  * @see BeforeLifecycleEventExecuter
  */
 public class ClientBeforeAfterLifecycleEventExecuter {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuter.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.test.spi.event.suite.Test;
  * TestExecuter for running on the client side. Can switch between Local and Remote test execution.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClientTestExecuter {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ContainerTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/ContainerTestExecuter.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.test.spi.event.suite.Test;
  * TestExecutor for running in container.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContainerTestExecuter {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuter.java
@@ -39,7 +39,6 @@ import org.jboss.arquillian.test.spi.execution.ExecUtils;
  * {@link TestResult}<br/>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalTestExecuter {
     @Inject

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuter.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuter.java
@@ -53,7 +53,6 @@ import org.jboss.arquillian.test.spi.annotation.TestScoped;
  * {@link TestResult}<br/>
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  * @see DeployableContainer
  */
 public class RemoteTestExecuter {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/ExecutionEvent.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/ExecutionEvent.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
  * ExecutionEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ExecutionEvent extends Event {
 

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/LocalExecutionEvent.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/LocalExecutionEvent.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
  * LocalExecutionEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalExecutionEvent implements ExecutionEvent {
     private TestMethodExecutor executor;

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/RemoteExecutionEvent.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/execution/event/RemoteExecutionEvent.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
  * LocalExecutionEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class RemoteExecutionEvent implements ExecutionEvent {
     private TestMethodExecutor executor;

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/ContainerEventControllerTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/ContainerEventControllerTestCase.java
@@ -69,7 +69,6 @@ import static org.mockito.Mockito.when;
  * ContainerBeforeAfterControllerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerEventControllerTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerControllerTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerControllerTestCase.java
@@ -60,7 +60,6 @@ import static org.mockito.Mockito.when;
  * ClientContainerControllerTestCase
  *
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ClientContainerControllerTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/container/ContainerRestarterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/container/ContainerRestarterTestCase.java
@@ -32,7 +32,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ContainerRestarterTestCase
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerRestarterTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGeneratorTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/AnnotationDeploymentScenarioGeneratorTestCase.java
@@ -45,7 +45,6 @@ import org.junit.Test;
  * AnnotationDeploymentScenarioGeneratorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AnnotationDeploymentScenarioGeneratorTestCase {
 

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/ClientDeployerTestCase.java
@@ -44,7 +44,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ClientDeployerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ClientDeployerTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGeneratorTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/DeploymentGeneratorTestCase.java
@@ -85,7 +85,6 @@ import static org.mockito.Mockito.when;
  * DeploymentGeneratorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DeploymentGeneratorTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ArchiveDeploymentToolingExporterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ArchiveDeploymentToolingExporterTestCase.java
@@ -33,7 +33,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ArchiveDeploymentToolingExporterTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Ignore // not implemented
 @RunWith(MockitoJUnitRunner.class)

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ToolingDeploymentFormatterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/deployment/tool/ToolingDeploymentFormatterTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Test;
  * ToolingDeploymentFormatterTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ToolingDeploymentFormatterTestCase {
 

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/protocol/ProtocolRegistryCreatorTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/client/protocol/ProtocolRegistryCreatorTestCase.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.when;
  * ProtocolRegistryCreatorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ProtocolRegistryCreatorTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistryTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/domain/ProtocolRegistryTestCase.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
  * DomainModelTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ProtocolRegistryTestCase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProviderTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/InitialContextProviderTestCase.java
@@ -31,7 +31,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * ArquillianTestEnricherTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class InitialContextProviderTestCase extends OperatesOnDeploymentAwareProviderBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
@@ -52,7 +52,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * OperatesOnDeploymentAwareProviderTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public abstract class OperatesOnDeploymentAwareProviderBase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProviderTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/URLResourceProviderTestCase.java
@@ -36,7 +36,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="http://community.jboss.org/people/silenius">Samuel Santos</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class URLResourceProviderTestCase extends OperatesOnDeploymentAwareProviderBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/ClientTestExecuterTestCase.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
  * ClientTestExecuterTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ClientTestExecuterTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/LocalTestExecuterTestCase.java
@@ -35,7 +35,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * InContainerExecuterTestCase
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class LocalTestExecuterTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuterTestCase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/execution/RemoteTestExecuterTestCase.java
@@ -54,7 +54,6 @@ import org.mockito.stubbing.Answer;
  * TestExecutorHandlerTestCase
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteTestExecuterTestCase extends AbstractContainerTestTestBase {

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/test/AbstractContainerTestTestBase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/test/AbstractContainerTestTestBase.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.test.spi.context.TestContext;
  * AbstractTestTestBase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractContainerTestTestBase extends AbstractManagerTestBase {
     @Override

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/ContainerMethodExecutor.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/ContainerMethodExecutor.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * ie http/servlet, jmx, rmi etc.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ContainerMethodExecutor {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/RemoteLoadableExtension.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/RemoteLoadableExtension.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * {@link org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender}.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface RemoteLoadableExtension extends LoadableExtension {
 

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestDeployment.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestDeployment.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.Node;
  * With convenience methods for working / manipulating the Archives.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestDeployment {
     private DeploymentDescription deploymentDescription;

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestRunner.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestRunner.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * A Generic way to start the test framework.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface TestRunner {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/ApplicationArchiveProcessor.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/ApplicationArchiveProcessor.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * - Annotations to help define meta data for the deployment
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ApplicationArchiveProcessor {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AutomaticDeployment.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AutomaticDeployment.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.test.spi.TestClass;
 /**
  * SPI that all automatic deployment implementators must implements in order to generate the archive to be used by Arquillian deployer.
  *
- * @version $Revision: $
  */
 public interface AutomaticDeployment {
 

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AuxiliaryArchiveAppender.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AuxiliaryArchiveAppender.java
@@ -22,7 +22,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * SPI used for modules who need to add classes/resources to the deployed archive.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface AuxiliaryArchiveAppender {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AuxiliaryArchiveProcessor.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/AuxiliaryArchiveProcessor.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * - Add beans.xml to EE modules
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface AuxiliaryArchiveProcessor {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/CachedAuxilliaryArchiveAppender.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/CachedAuxilliaryArchiveAppender.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * CachedAuxilliaryArchiveAppender
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class CachedAuxilliaryArchiveAppender implements AuxiliaryArchiveAppender {
     private static Map<Class<?>, Archive<?>> cached = new HashMap<Class<?>, Archive<?>>();

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/DeploymentPackager.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/DeploymentPackager.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * - Create a EAR, WAR
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DeploymentPackager {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/DeploymentScenarioGenerator.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/DeploymentScenarioGenerator.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.test.spi.TestClass;
  * Extension point for extracting {@link DeploymentDescription}'s from a {@link TestClass}
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface DeploymentScenarioGenerator {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/ProtocolArchiveProcessor.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/deployment/ProtocolArchiveProcessor.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * This extension point allowed the CDI enricher to add a beans.xml to the protocol.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ProtocolArchiveProcessor {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/protocol/Protocol.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/protocol/Protocol.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandCallback;
  * Interface that defines a Arquillian Protocol.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Protocol<T extends ProtocolConfiguration> {
     /**

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/protocol/ProtocolConfiguration.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/client/protocol/ProtocolConfiguration.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.container.test.spi.client.protocol;
  * SPI Marker interface for auto configuration of protocol
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ProtocolConfiguration {
 

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/Command.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/Command.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.test.spi.command;
  * RemoteCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Command<T> {
     T getResult();

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/CommandCallback.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/CommandCallback.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.test.spi.command;
  * RemoteEventCallback
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface CommandCallback {
     void fired(Command<?> event);

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/CommandService.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/command/CommandService.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.container.test.spi.command;
  * CommandService
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface CommandService {
     <T> T execute(Command<T> command);

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/SecurityActions.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/TestRunners.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/util/TestRunners.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.TestRunner;
  * Helper factory for loading TestRunners in container.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public final class TestRunners {
     // Hide ctor

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/Event.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/Event.java
@@ -30,7 +30,6 @@ package org.jboss.arquillian.core.api;
  * </pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Event<T> {
     void fire(T event);

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/Injector.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/Injector.java
@@ -30,7 +30,6 @@ package org.jboss.arquillian.core.api;
  * </pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Injector {
     /**

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/Instance.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/Instance.java
@@ -38,7 +38,6 @@ package org.jboss.arquillian.core.api;
  * provided by Arquillian.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Instance<T> {
     T get();

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/InstanceProducer.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/InstanceProducer.java
@@ -42,7 +42,6 @@ package org.jboss.arquillian.core.api;
  * </pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface InstanceProducer<T> extends Instance<T> {
     void set(T value);

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/ApplicationScoped.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/ApplicationScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * A Global scope that last from manager start until manager shutdown.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Inject.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Inject.java
@@ -42,7 +42,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * appropriate lifecycle event observer.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observes.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Observes.java
@@ -37,7 +37,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * the sooner the observer is executed.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Scope.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/annotation/Scope.java
@@ -27,7 +27,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Scope
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/event/ManagerStarted.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/event/ManagerStarted.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.core.api.event;
  * The event fired during Manager startup
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerStarted {
 

--- a/core/api/src/main/java/org/jboss/arquillian/core/api/event/ManagerStopping.java
+++ b/core/api/src/main/java/org/jboss/arquillian/core/api/event/ManagerStopping.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.core.api.event;
  * The event fired during Manager shutdown
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerStopping {
 

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventContextImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventContextImpl.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * EventContextImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventContextImpl<T> implements EventContext<T> {
     private ManagerImpl manager;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventImpl.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.Manager;
  * EventImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventImpl<T> implements Event<T> {
     private Manager manager;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventPointImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/EventPointImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.spi.InvocationException;
  * EventPointImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventPointImpl implements EventPoint {
     private Object target;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ExtensionImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ExtensionImpl.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ExtensionImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExtensionImpl implements Extension {
     private Object target;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InjectionPointImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InjectionPointImpl.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.InvocationException;
  * FieldInjectionPointImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InjectionPointImpl implements InjectionPoint {
     private Object target;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InjectorImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InjectorImpl.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * InjectorImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InjectorImpl implements Injector {
     private Manager manager;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InstanceImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/InstanceImpl.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.api.InstanceProducer;
  * InstanceImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InstanceImpl<T> implements InstanceProducer<T> {
     private ManagerImpl manager;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ManagerImpl.java
@@ -50,7 +50,6 @@ import org.jboss.arquillian.core.spi.event.ManagerProcessing;
  * ManagerImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerImpl implements Manager {
     //-------------------------------------------------------------------------------------||

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/ObserverImpl.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.core.spi.ObserverMethod;
  * ObjectObserver
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ObserverImpl implements ObserverMethod, Comparable<ObserverMethod> {
     private static Logger log = Logger.getLogger(ObserverMethod.class.getName());

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/Reflections.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/Reflections.java
@@ -35,7 +35,6 @@ import org.jboss.arquillian.core.api.annotation.Scope;
  * Reflections
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 final class Reflections {
     private Reflections() {

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/SecurityActions.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/context/ApplicationContextImpl.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/context/ApplicationContextImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ApplicationContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ApplicationContextImpl extends AbstractContext<String> implements ApplicationContext {
     private static final String APP_CONTEXT_ID = "app";

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoader.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ServiceLoader implementation that use META-INF/services/interface files to registered Services.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JavaSPIExtensionLoader implements ExtensionLoader {
     //-------------------------------------------------------------------------------------||

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoader.java
@@ -38,7 +38,6 @@ import org.jboss.arquillian.core.spi.event.ManagerProcessing;
  * LoadableExtensionLoader
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LoadableExtensionLoader {
     private static Logger log = Logger.getLogger(LoadableExtensionLoader.class.getName());

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/SecurityActions.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistry.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistry.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author Davide D'Alto
- * @version $Revision: $
  */
 public class ServiceRegistry {
     private final Injector injector;

--- a/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoader.java
+++ b/core/impl-base/src/main/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoader.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
  * MixedServiceLoader
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServiceRegistryLoader implements ServiceLoader {
     private Injector injector;

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/EventFireTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/EventFireTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * EventFireTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventFireTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/EventImplTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/EventImplTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * EventImplTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventImplTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExceptionHandlingTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExceptionHandlingTestCase.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  * - re throw
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExceptionHandlingTestCase extends AbstractManagerTestBase {
     @Override

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExtensionOrderTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExtensionOrderTestCase.java
@@ -33,7 +33,6 @@ import org.junit.Test;
  * TODO: this should be implemented looking at Producers and Consumers, but currently a simple precedence is used.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExtensionOrderTestCase {
     private static List<String> callOrder = new ArrayList<String>();

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExtensionParseTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ExtensionParseTestCase.java
@@ -33,7 +33,6 @@ import org.junit.Test;
  * ExtensionParseTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExtensionParseTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InjectionPointImplTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InjectionPointImplTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * InjectionPointImplTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InjectionPointImplTestCase {
     @SuppressWarnings("unused")

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InjectorTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InjectorTestCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
  * InjectorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InjectorTestCase extends AbstractManagerTestBase {
     @Override

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InstanceImplTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/InstanceImplTestCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
  * InstanceImplTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InstanceImplTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/IntegrationTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/IntegrationTestCase.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  * IntegrationTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class IntegrationTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerImplTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerImplTestCase.java
@@ -34,7 +34,6 @@ import org.junit.Test;
  * ManagerImplTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerImplTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerProcessingTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ManagerProcessingTestCase.java
@@ -27,7 +27,6 @@ import org.junit.Test;
  * ManagerProcessingTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerProcessingTestCase {
     static {

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ObserverInterceptorTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ObserverInterceptorTestCase.java
@@ -29,7 +29,6 @@ import org.junit.Test;
  * ObserverInterceptorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ObserverInterceptorTestCase extends AbstractManagerTestBase {
     public static List<String> callStack = new ArrayList<String>();

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ObserverMethodAvailabilityFilterTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/ObserverMethodAvailabilityFilterTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Test;
  * ObserverMethodAvailabilityFilterTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ObserverMethodAvailabilityFilterTestCase extends AbstractManagerTestBase {
     @Override

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/context/ContextActivationTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/context/ContextActivationTestCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
  * ContextActivationTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ContextActivationTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoaderTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/JavaSPIExtensionLoaderTestCase.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  * JavaSPIExtensionLoaderTestCase
  *
  * @author Davide D'Alto
- * @version $Revision: $
  */
 public class JavaSPIExtensionLoaderTestCase {
 

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoaderTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/LoadableExtensionLoaderTestCase.java
@@ -23,7 +23,6 @@ import org.junit.Test;
  * LoadableExtensionLoaderTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LoadableExtensionLoaderTestCase {
 

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoaderTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryLoaderTestCase.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  * Verify the behavior of the ServiceLoader exposed by the ServiceRegistry.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServiceRegistryLoaderTestCase extends AbstractManagerTestBase {
     @Inject

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/impl/loadable/ServiceRegistryTestCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
  * Test cases for ServiceRegistry.
  *
  * @author "Davide D'Alto"
- * @version $Revision: $
  */
 public class ServiceRegistryTestCase {
     @Test

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/AbstractManagerTestBase.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/AbstractManagerTestBase.java
@@ -42,7 +42,6 @@ import org.junit.Before;
  * AbstractManagerTestBase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractManagerTestBase {
     private static ManagerImpl manager;

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2Context.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2Context.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.context.IdBoundContext;
  * ManagerTestContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ManagerTest2Context extends IdBoundContext<String> {
 

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2ContextImpl.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2ContextImpl.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ManagerTestContextImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerTest2ContextImpl extends AbstractContext<String> implements ManagerTest2Context {
     /* (non-Javadoc)

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2Scoped.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTest2Scoped.java
@@ -29,7 +29,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ManagerTestScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestContext.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestContext.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.context.NonIdBoundContext;
  * ManagerTestContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ManagerTestContext extends NonIdBoundContext {
 

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestContextImpl.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestContextImpl.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ManagerTestContextImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerTestContextImpl extends AbstractContext<String> implements ManagerTestContext {
     private static final String SUITE_CONTEXT_ID = "managerTest";

--- a/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestScoped.java
+++ b/core/impl-base/src/test/java/org/jboss/arquillian/core/test/context/ManagerTestScoped.java
@@ -29,7 +29,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ManagerTestScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/EventContext.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/EventContext.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.core.spi;
  * EventContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface EventContext<T> {
     T getEvent();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/EventPoint.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/EventPoint.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.api.Event;
  * EventPoint
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface EventPoint extends Typed {
     void set(Event<?> value) throws InvocationException;

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Extension.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Extension.java
@@ -22,7 +22,6 @@ import java.util.List;
  * Extension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Extension {
     List<InjectionPoint> getInjectionPoints();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/ExtensionLoader.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/ExtensionLoader.java
@@ -25,7 +25,6 @@ import java.util.Set;
  * Extension point used to load the boot strap extensions.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ExtensionLoader {
     Collection<LoadableExtension> load();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/HashObjectStore.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/HashObjectStore.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.context.ObjectStore;
  * ObjectStore
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class HashObjectStore implements ObjectStore {
     private ConcurrentHashMap<Class<?>, Object> store;

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/InjectionPoint.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/InjectionPoint.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.api.Instance;
  * FieldInjectionPoint
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface InjectionPoint extends Typed {
     Class<? extends Annotation> getScope();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/InvocationException.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/InvocationException.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.core.spi;
  * {@link InjectionPoint#set(Instance)}
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InvocationException extends RuntimeException {
     private static final long serialVersionUID = -3326267058243382414L;

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/LoadableExtension.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/LoadableExtension.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.core.spi.context.Context;
  * {@code AuxilliaryArchiveAppender}.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface LoadableExtension {
     /**

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Manager.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Annotation;
  * Manager
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Manager {
     // Event

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/ManagerBuilder.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/ManagerBuilder.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.core.spi.context.Context;
  * ManagerBuilder
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ManagerBuilder {
     private static final String MANAGER_IMPL_CLASS = "org.jboss.arquillian.core.impl.ManagerImpl";

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/NonManagedObserver.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/NonManagedObserver.java
@@ -25,7 +25,6 @@ package org.jboss.arquillian.core.spi;
  * The NonManagedObserver is executed inside the interceptor chain but after all other observers.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface NonManagedObserver<T> {
     void fired(T event);

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/ObserverMethod.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/ObserverMethod.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
  * Observer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ObserverMethod extends Typed, Comparable<ObserverMethod> {
     boolean invoke(Manager manager, Object object) throws InvocationException;

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/SecurityActions.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/ServiceLoader.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/ServiceLoader.java
@@ -39,7 +39,6 @@ import java.util.Collection;
  * </pre>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ServiceLoader {
     /**

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Typed.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Typed.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Type;
  * Typed
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Typed {
     Type getType();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/Validate.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/Validate.java
@@ -22,7 +22,6 @@ package org.jboss.arquillian.core.spi;
  * Validation utility
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public final class Validate {
     private Validate() {

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/AbstractContext.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/AbstractContext.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * AbstractContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractContext<T> implements Context, IdBoundContext<T> {
     private static Logger log = Logger.getLogger("Context");

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/ApplicationContext.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/ApplicationContext.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.core.spi.context;
  * ApplicationContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ApplicationContext extends NonIdBoundContext {
 

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/Context.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/Context.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Annotation;
  * Context
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Context {
     Class<? extends Annotation> getScope();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/IdBoundContext.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/IdBoundContext.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.core.spi.context;
  * IdBoundContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface IdBoundContext<T> extends Context {
     T getActiveId();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/NonIdBoundContext.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/NonIdBoundContext.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.core.spi.context;
  * IdBoundContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface NonIdBoundContext extends Context {
     void activate();

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/ObjectStore.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/context/ObjectStore.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.core.spi.context;
  * ObjectStore
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ObjectStore {
 

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/event/Event.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/event/Event.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.core.spi.event;
  * Event
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface Event {
 }

--- a/core/spi/src/main/java/org/jboss/arquillian/core/spi/event/ManagerProcessing.java
+++ b/core/spi/src/main/java/org/jboss/arquillian/core/spi/event/ManagerProcessing.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.context.Context;
  * ManagerStarting
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ManagerProcessing {
     ManagerProcessing observer(Class<?> handler);

--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitContainerExtension.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitContainerExtension.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
 
 /**
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitContainerExtension implements LoadableExtension {
     @Override

--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppender.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * Package up the JUnit / Arquillian JUnit related dependencies.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitDeploymentAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitRemoteExtension.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitRemoteExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.junit.RulesEnricher;
  * JUnitRemoteExtension
  *
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
- * @version $Revision: $
  */
 public class JUnitRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
+++ b/junit/container/src/main/java/org/jboss/arquillian/junit/container/JUnitTestRunner.java
@@ -37,7 +37,6 @@ import org.junit.runner.notification.RunListener;
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @author thomas.diesler@jboss.com
- * @version $Revision: $
  */
 public class JUnitTestRunner implements TestRunner {
     /**

--- a/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppenderTestCase.java
+++ b/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitDeploymentAppenderTestCase.java
@@ -25,7 +25,6 @@ import org.junit.Test;
  * JUnitDeploymentAppenderTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitDeploymentAppenderTestCase {
 

--- a/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitTestBaseClass.java
+++ b/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitTestBaseClass.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.doAnswer;
  * JUnitTestBaseClass
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitTestBaseClass {
     /*

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/Arquillian.java
@@ -43,7 +43,6 @@ import org.junit.runners.model.Statement;
  * Main Arquillian JUnit runner
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class Arquillian extends BlockJUnit4ClassRunner {
     private TestRunnerAdaptor adaptor;
@@ -335,7 +334,6 @@ public class Arquillian extends BlockJUnit4ClassRunner {
      * fail, a {@link MultipleFailureException} will be thrown.
      *
      * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
-     * @version $Revision: $
      */
     private void multiExecute(Statement... statements) throws Throwable {
         List<Throwable> exceptions = new ArrayList<Throwable>();

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/InSequence.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/InSequence.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Annotation used to order the execution flow of the @Test methods defined in a JUnit test class.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/InSequenceSorter.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/InSequenceSorter.java
@@ -24,7 +24,6 @@ import org.junit.runners.model.FrameworkMethod;
  * InOrderSorter
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 class InSequenceSorter implements Comparator<FrameworkMethod> {
     @Override

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/JavaSPILoader.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/JavaSPILoader.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.core.spi.Validate;
  * ServiceLoader implementation that use META-INF/services/interface files to registered Services.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 class JavaSPILoader {
     //-------------------------------------------------------------------------------------||

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/RulesEnricher.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/RulesEnricher.java
@@ -44,7 +44,6 @@ import org.junit.rules.TestRule;
  * about to be executed<br/>
  *
  * @author <a href="mailto:mjobanek@redhat.com">Matous Jobanek</a>
- * @version $Revision: $
  */
 public class RulesEnricher {
 

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
@@ -24,7 +24,6 @@ import org.junit.runners.model.FrameworkField;
  * State
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class State {
     /*

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/InSequenceSorterTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/InSequenceSorterTestCase.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.mock;
  * InOrderSorterTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class InSequenceSorterTestCase extends JUnitTestBaseClass {

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/InitializationExceptionTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/InitializationExceptionTestCase.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.verify;
  * Only run first test, ignore the rest
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class InitializationExceptionTestCase extends JUnitTestBaseClass {

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/InitializationExceptionWithRuleTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/InitializationExceptionWithRuleTestCase.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
  * Only run first test, ignore the rest
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class InitializationExceptionWithRuleTestCase extends JUnitTestBaseClass {

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationTestCase.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.when;
  * Verify the that JUnit integration adaptor fires the expected events even when Handlers are failing.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JUnitIntegrationTestCase extends JUnitTestBaseClass {

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationWithRuleTestCase.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationWithRuleTestCase.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
  * Verify the that JUnit integration adaptor fires the expected events even when Handlers are failing.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JUnitIntegrationWithRuleTestCase extends JUnitTestBaseClass {

--- a/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitTestBaseClass.java
+++ b/junit/core/src/test/java/org/jboss/arquillian/junit/JUnitTestBaseClass.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.doAnswer;
  * JUnitTestBaseClass
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitTestBaseClass {
     /*

--- a/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/JUnitStandaloneExtension.java
+++ b/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/JUnitStandaloneExtension.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * JUnitStandaloneExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitStandaloneExtension implements LoadableExtension {
     @Override

--- a/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/LocalTestMethodExecutor.java
+++ b/junit/standalone/src/main/java/org/jboss/arquillian/junit/standalone/LocalTestMethodExecutor.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.test.spi.execution.ExecUtils;
  * LocalTestMethodExecutor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalTestMethodExecutor {
     @Inject

--- a/junit/standalone/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationTestCase.java
+++ b/junit/standalone/src/test/java/org/jboss/arquillian/junit/JUnitIntegrationTestCase.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.verify;
  * Verify the that JUnit integration adaptor fires the expected events even when Handlers are failing.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JUnitIntegrationTestCase extends JUnitTestBaseClass {

--- a/junit/standalone/src/test/java/org/jboss/arquillian/junit/JUnitTestBaseClass.java
+++ b/junit/standalone/src/test/java/org/jboss/arquillian/junit/JUnitTestBaseClass.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.doAnswer;
  * JUnitTestBaseClass
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitTestBaseClass {
     /*

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterDeploymentAppenderTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterDeploymentAppenderTestCase.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
  * JUnitJupiterDeploymentAppenderTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitJupiterDeploymentAppenderTestCase {
 

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitTestBaseClass.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitTestBaseClass.java
@@ -47,7 +47,6 @@ import static org.mockito.Mockito.doAnswer;
  * JUnitTestBaseClass
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JUnitTestBaseClass {
     /*

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXCommandService.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXCommandService.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandService;
  * JMXCommandService
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JMXCommandService implements CommandService {
     private static long TIMEOUT = 30000;

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXExtension.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandService;
  * JMXExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JMXExtension implements RemoteLoadableExtension {
     @Override

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXProtocolConfiguration.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXProtocolConfiguration.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfigura
  * JMXProtocolConfiguration
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JMXProtocolConfiguration implements ProtocolConfiguration {
 }

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/Serializer.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/Serializer.java
@@ -27,7 +27,6 @@ import java.io.ObjectOutputStream;
  * Serializer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 final class Serializer {
     public static byte[] toByteArray(Object object) {

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/JMXTestTestRunner.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/JMXTestTestRunner.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * Override send on original JMXTestRunner so we can simulate multi threaded behavior when running in container.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class JMXTestTestRunner extends org.jboss.arquillian.protocol.jmx.JMXTestRunner {
     public JMXTestTestRunner(TestClassLoader classLoader) {

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/MockTestRunner.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/MockTestRunner.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * TestRunner that will return what you want for testing
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class MockTestRunner implements TestRunner {
     public static TestResult wantedResults;

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestCommandCallback.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestCommandCallback.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandCallback;
  * TestRemoteCommandCallback
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestCommandCallback implements CommandCallback {
     private Object[] results;

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestIntegerCommand.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestIntegerCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * TestRemoteCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestIntegerCommand implements Command<Integer>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestStringCommand.java
+++ b/protocols/jmx/src/test/java/org/jboss/arquillian/protocol/jmx/test/TestStringCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * TestRemoteCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestStringCommand implements Command<String>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocol.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocol.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandCallback;
  * BaseServletProtocol
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class BaseServletProtocol implements Protocol<ServletProtocolConfiguration> {
     /* (non-Javadoc)

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/Processor.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/Processor.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * Processor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class Processor {
     private TestDeployment deployment;

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletExtension.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletExtension.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * ServletExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletExtension implements LoadableExtension {
     @Override

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletMethodExecutor.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletMethodExecutor.java
@@ -42,7 +42,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * ServletMethodExecutor
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletMethodExecutor implements ContainerMethodExecutor {
     public static final String ARQUILLIAN_SERVLET_NAME = "ArquillianServletRunner";

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletProtocolConfiguration.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletProtocolConfiguration.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfigura
  * ServletProtocolConfiguration
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocolConfiguration implements ProtocolConfiguration {
     private String scheme = null;

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletURIHandler.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletURIHandler.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
  * ServletURIHandler
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletURIHandler {
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletUtil.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/ServletUtil.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.ArchivePaths;
  * ServletUtil
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public final class ServletUtil {
     public static final ArchivePath WEB_XML_PATH = ArchivePaths.create("WEB-INF/web.xml");

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/application/ApplicationDescriptor.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/application/ApplicationDescriptor.java
@@ -22,7 +22,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
  * DSL Grammar to construct / alter Application XML Descriptors
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ApplicationDescriptor extends Descriptor {
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/web/InitParamDef.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/web/InitParamDef.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.protocol.servlet.arq514hack.descriptors.api.web;
  * FilterDef
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface InitParamDef extends WebAppDescriptor {
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/web/ServletMappingDef.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/api/web/ServletMappingDef.java
@@ -23,7 +23,6 @@ import java.util.List;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * @version $Revision: $
  */
 public interface ServletMappingDef extends ServletDef {
     String getServletName();

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/impl/application/ApplicationDescriptorImpl.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/arq514hack/descriptors/impl/application/ApplicationDescriptorImpl.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.descriptor.spi.node.NodeDescriptorImplBase;
  * ApplicationDescriptorImpl
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ApplicationDescriptorImpl extends NodeDescriptorImplBase implements ApplicationDescriptor {
     // -------------------------------------------------------------------------------------||

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/SecurityActions.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletCommandService.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletCommandService.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandService;
  * ServletRemoteEventService
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletCommandService implements CommandService {
     private static long TIMEOUT = 30000;

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletRemoteExtension.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletRemoteExtension.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * ServletRemoteExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/runner/ServletTestRunner.java
@@ -42,7 +42,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * - serializedObject
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletTestRunner extends HttpServlet {
     public static final String PARA_METHOD_NAME = "methodName";

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ProtocolDeploymentAppender.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ProtocolDeploymentAppender.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  * in container.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDeploymentAppender implements AuxiliaryArchiveAppender {
     @Override

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocol.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocol.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.protocol.servlet.BaseServletProtocol;
  * ServletProtocol
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocol extends BaseServletProtocol {
     private static final String PROTOCOL_NAME = "Servlet 2.5";

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackager.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackager.java
@@ -45,7 +45,6 @@ import static org.jboss.arquillian.protocol.servlet.ServletUtil.WEB_XML_PATH;
  * ServletProtocolDeploymentPackager
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocolDeploymentPackager implements DeploymentPackager {
 

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/WebUtils.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_2_5/WebUtils.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
  * Common util for Web.xml 2.5 manipulation
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 class WebUtils {
     private WebUtils() {

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ProtocolDeploymentAppender.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ProtocolDeploymentAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * in container.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDeploymentAppender implements AuxiliaryArchiveAppender {
     @Override

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocol.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocol.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.protocol.servlet.BaseServletProtocol;
  * ServletProtocol
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocol extends BaseServletProtocol {
     private static final String PROTOCOL_NAME = "Servlet 3.0";

--- a/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackager.java
+++ b/protocols/servlet/src/main/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackager.java
@@ -44,7 +44,6 @@ import static org.jboss.arquillian.protocol.servlet.ServletUtil.APPLICATION_XML_
  * ServletProtocolDeploymentPackager
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocolDeploymentPackager implements DeploymentPackager {
     /* (non-Javadoc)

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/AbstractServerBase.java
@@ -43,7 +43,6 @@ import org.junit.Before;
  * AbstractServerBase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AbstractServerBase {
     private Server server;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocolTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/BaseServletProtocolTestCase.java
@@ -33,7 +33,6 @@ import org.junit.Test;
  * ServletProtocolTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BaseServletProtocolTestCase {
     @Test

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ProtocolTestCase.java
@@ -29,7 +29,6 @@ import org.junit.Test;
  * ProtocolTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolTestCase extends AbstractServerBase {
 

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ServletCommandServiceTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/ServletCommandServiceTestCase.java
@@ -31,7 +31,6 @@ import org.junit.Test;
  * ServletCommandServiceTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletCommandServiceTestCase extends AbstractServerBase {
     @Test

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/TestUtil.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/TestUtil.java
@@ -27,7 +27,6 @@ import java.net.URL;
  * Internal helper for testcase to do http request
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestUtil {
     private TestUtil() {

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/MockTestRunner.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/MockTestRunner.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.test.spi.TestResult;
  * TestRunner that will return what you want for testing
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class MockTestRunner implements TestRunner {
     public static TestResult wantedResults;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestCommandCallback.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestCommandCallback.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.CommandCallback;
  * TestRemoteCommandCallback
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestCommandCallback implements CommandCallback {
     private Object[] results;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestIntegerCommand.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestIntegerCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * TestRemoteCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestIntegerCommand implements Command<Integer>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestStringCommand.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/test/TestStringCommand.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.container.test.spi.command.Command;
  * TestRemoteCommand
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestStringCommand implements Command<String>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ProtocolDeploymentAppenderTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ProtocolDeploymentAppenderTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * ProtocolDeploymentAppenderTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDeploymentAppenderTestCase {
 

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_2_5/ServletProtocolDeploymentPackagerTestCase.java
@@ -46,7 +46,6 @@ import org.junit.Test;
  * ServletProtocolDeploymentPackagerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocolDeploymentPackagerTestCase {
     @Test

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ProtocolDeploymentAppenderTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ProtocolDeploymentAppenderTestCase.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * ProtocolDeploymentAppenderTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ProtocolDeploymentAppenderTestCase {
 

--- a/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet/src/test/java/org/jboss/arquillian/protocol/servlet/v_3/ServletProtocolDeploymentPackagerTestCase.java
@@ -43,7 +43,6 @@ import org.junit.Test;
  * ServletProtocolDeploymentPackagerTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ServletProtocolDeploymentPackagerTestCase {
     @Test

--- a/test/api/src/main/java/org/jboss/arquillian/test/api/ArquillianResource.java
+++ b/test/api/src/main/java/org/jboss/arquillian/test/api/ArquillianResource.java
@@ -50,7 +50,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </code></pre>
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Inherited
 @Documented

--- a/test/api/src/main/java/org/jboss/arquillian/test/api/Secured.java
+++ b/test/api/src/main/java/org/jboss/arquillian/test/api/Secured.java
@@ -34,7 +34,6 @@ import java.lang.annotation.Target;
  * </code></pre>
  *
  * @author <a href="http://community.jboss.org/people/silenius">Samuel Santos</a>
- * @version $Revision: $
  */
 @Documented
 @Retention(RUNTIME)

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptor.java
@@ -49,7 +49,6 @@ import org.jboss.arquillian.test.spi.execution.TestExecutionDecider;
  * EventTestRunnerAdaptor
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EventTestRunnerAdaptor implements TestRunnerAdaptor {
     private Manager manager;

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestContextHandler.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestContextHandler.java
@@ -42,7 +42,6 @@ import org.jboss.arquillian.test.spi.event.suite.TestEvent;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * @version $Revision: $
  */
 public class TestContextHandler {
     @Inject

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestExtension.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestExtension.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.TestEnricher;
  * TestExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestExtension implements LoadableExtension {
     @Override

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestInstanceEnricher.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/TestInstanceEnricher.java
@@ -33,7 +33,6 @@ import org.jboss.arquillian.test.spi.event.suite.Before;
  * A Handler for enriching the Test instance.<br/>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestInstanceEnricher {
     @Inject

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/ClassContextImpl.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/ClassContextImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.test.spi.context.ClassContext;
  * ClassContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClassContextImpl extends AbstractContext<Class<?>> implements ClassContext {
     /* (non-Javadoc)

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/SuiteContextImpl.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/SuiteContextImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.test.spi.context.SuiteContext;
  * SuiteContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class SuiteContextImpl extends AbstractContext<String> implements SuiteContext {
     private static final String SUITE_CONTEXT_ID = "suite";

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/TestContextImpl.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/context/TestContextImpl.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.test.spi.context.TestContext;
  * TestContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestContextImpl extends AbstractContext<Object> implements TestContext {
     /* (non-Javadoc)

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricher.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricher.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * ArquillianTestEnricher
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ArquillianResourceTestEnricher implements TestEnricher {
 

--- a/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/SecurityActions.java
+++ b/test/impl-base/src/main/java/org/jboss/arquillian/test/impl/enricher/resource/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptorTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/EventTestRunnerAdaptorTestCase.java
@@ -49,7 +49,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Verifies that the {@link EventTestRunnerAdaptor} creates and fires the proper events.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EventTestRunnerAdaptorTestCase extends AbstractTestTestBase {

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/TestInstanceEnricherTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/TestInstanceEnricherTestCase.java
@@ -35,7 +35,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  * Verifies that the TestEnricher SPI is called.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class TestInstanceEnricherTestCase extends AbstractTestTestBase {

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
@@ -56,7 +56,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author Vineet Reynolds
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase {

--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/test/AbstractTestTestBase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/test/AbstractTestTestBase.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.test.spi.context.TestContext;
  * AbstractTestTestBase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public abstract class AbstractTestTestBase extends AbstractManagerTestBase {
     @Override

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/LifecycleMethodExecutor.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/LifecycleMethodExecutor.java
@@ -22,7 +22,6 @@ package org.jboss.arquillian.test.spi;
  * Used to e.g. veto invocation of @Before/@After methods on the Client side.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface LifecycleMethodExecutor {
     LifecycleMethodExecutor NO_OP = () -> {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/SecurityActions.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestClass.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestClass.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
  * Wraps a class to be run, providing method validation and annotation searching.
  *
  * @author thomas.diesler@jboss.com
- * @version $Revision: $
  */
 public class TestClass {
     private Class<?> testClass;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestEnricher.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestEnricher.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
  * SPI used to enrich the runtime test object.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface TestEnricher {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestMethodExecutor.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestMethodExecutor.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
  * TestMethodExecutor
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface TestMethodExecutor {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestRunnerAdaptor.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestRunnerAdaptor.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
  * Need to be Thread-safe
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface TestRunnerAdaptor {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestRunnerAdaptorBuilder.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestRunnerAdaptorBuilder.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.ManagerBuilder;
  * DeployableTestBuilder
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestRunnerAdaptorBuilder {
     private static final String DEFAULT_EXTENSION_CLASS =

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/ClassScoped.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/ClassScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * SuiteScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/SuiteScoped.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/SuiteScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * SuiteScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/TestScoped.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/annotation/TestScoped.java
@@ -28,7 +28,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * TestScoped
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Scope
 @Documented

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/ClassContext.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/ClassContext.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.context.IdBoundContext;
  * ClassContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ClassContext extends IdBoundContext<Class<?>> {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/SuiteContext.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/SuiteContext.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.context.NonIdBoundContext;
  * SuiteContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface SuiteContext extends NonIdBoundContext {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/TestContext.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/context/TestContext.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.context.IdBoundContext;
  * TestContext
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface TestContext extends IdBoundContext<Object> {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/enricher/resource/ResourceProvider.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/enricher/resource/ResourceProvider.java
@@ -29,7 +29,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ResourceProvider
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface ResourceProvider {
     boolean canProvide(Class<?> type);

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/AfterEnrichment.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/AfterEnrichment.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
  * AfterEnrichment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterEnrichment extends EnrichmentEvent {
     public AfterEnrichment(Object instance) {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/BeforeEnrichment.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/BeforeEnrichment.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
  * BeforeEnrichment
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeEnrichment extends EnrichmentEvent {
     public BeforeEnrichment(Object instance) {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/EnrichmentEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/enrichment/EnrichmentEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.event.Event;
  * EnrichmentEvent
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EnrichmentEvent implements Event {
     private Object instance;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/After.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/After.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Event fired After the Test method execution.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class After extends AfterTestLifecycleEvent {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterClass.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterClass.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Event fired After the Class execution.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterClass extends ClassLifecycleEvent {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterSuite.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterSuite.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.test.spi.event.suite;
  * Event fired After the Suite execution.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterSuite extends SuiteEvent {
     public AfterSuite() {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterTestLifecycleEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/AfterTestLifecycleEvent.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Events fired After the Test method execution
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AfterTestLifecycleEvent extends TestLifecycleEvent {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Before.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Before.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Event fired Before the Test method execution
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class Before extends BeforeTestLifecycleEvent {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeClass.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeClass.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Event fired Before the Class execution.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeClass extends ClassLifecycleEvent {
 

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeSuite.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeSuite.java
@@ -20,7 +20,6 @@ package org.jboss.arquillian.test.spi.event.suite;
  * Event fired Before the Suite execution.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeSuite extends SuiteEvent {
     public BeforeSuite() {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeTestLifecycleEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/BeforeTestLifecycleEvent.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Events fired Before the Test method execution
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeforeTestLifecycleEvent extends TestLifecycleEvent {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/ClassEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/ClassEvent.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.TestClass;
  * Base for events fired in the Test Class execution cycle.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClassEvent extends SuiteEvent {
     private TestClass testClass;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/ClassLifecycleEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/ClassLifecycleEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.test.spi.TestClass;
  * TestClass.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ClassLifecycleEvent extends ClassEvent implements LifecycleEvent {
     private LifecycleMethodExecutor executor;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/LifecycleEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/LifecycleEvent.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Describes a Event with the capability of Vetoing the execution of a method.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public interface LifecycleEvent extends Event {
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/SuiteEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/SuiteEvent.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.core.spi.event.Event;
  * Base for events fired in the Suite execution cycle.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class SuiteEvent implements Event {
     public SuiteEvent() {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Test.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Test.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.test.spi.TestMethodExecutor;
  * Event fired to execute the Test method
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class Test extends TestEvent {
     private TestMethodExecutor testMethodExecutor;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestEvent.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
  * Base for events fired in the Test execution cycle.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestEvent extends ClassEvent {
     private Object testInstance;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestLifecycleEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestLifecycleEvent.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
  * Test instance.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestLifecycleEvent extends TestEvent implements LifecycleEvent {
     private LifecycleMethodExecutor executor;

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Validate.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/Validate.java
@@ -22,7 +22,6 @@ package org.jboss.arquillian.test.spi.event.suite;
  * Validation utility
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 final class Validate {
     private Validate() {

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxySerializationTestCase.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxySerializationTestCase.java
@@ -32,7 +32,6 @@ import org.junit.Test;
  * ObjectDeserialization
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExceptionProxySerializationTestCase {
 

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
@@ -42,7 +42,6 @@ import org.junit.Test;
  * thrown from a server was not on the client classpath.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ExceptionProxyTestCase {
     public static String MSG = "_TEST_";

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/UnknownException.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/UnknownException.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.test.spi;
  * UnknownException
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class UnknownException extends Exception {
     private static final UnknownObject serialVersionUID = new UnknownObject();

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/UnknownObject.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/UnknownObject.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
  * UnknownObject
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class UnknownObject implements Serializable {
 

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.test.spi.annotation.TestScoped;
  * Enricher that provide JSR-299 CDI class and method argument injection.
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class CDIInjectionEnricher implements TestEnricher {
     private static final String ANNOTATION_NAME = "javax.inject.Inject";

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/CreationalContextDestroyer.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/CreationalContextDestroyer.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.spi.event.suite.After;
  * CreationalContextDestroyer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class CreationalContextDestroyer {
     @SuppressWarnings("rawtypes")

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
@@ -37,7 +37,6 @@ import javax.enterprise.util.AnnotationLiteral;
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
  * @author Pete Muir
- * @version $Revision: $
  */
 public class MethodParameterInjectionPoint<T> implements InjectionPoint {
     private Method method;

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/BeansXMLProtocolProcessor.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/BeansXMLProtocolProcessor.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  * deployment.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeansXMLProtocolProcessor implements ProtocolArchiveProcessor {
     /* (non-Javadoc)

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherArchiveAppender.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherArchiveAppender.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * CDIEnricherArchiveAppender
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class CDIEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherExtension.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherExtension.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.testenricher.cdi.CreationalContextDestroyer;
  * CDIEnricherExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class CDIEnricherExtension implements LoadableExtension {
     @Override

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.core.api.annotation.Observes;
  * BeanManagerLookup
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeanManagerProducer {
     private static final String STANDARD_BEAN_MANAGER_JNDI_NAME = "java:comp/BeanManager";

--- a/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIEnricherRemoteExtension.java
+++ b/testenrichers/cdi/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIEnricherRemoteExtension.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.testenricher.cdi.CreationalContextDestroyer;
  * CDIEnricherRemoteExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class CDIEnricherRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
+++ b/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  * BeansXMLProtocolProcessorTestCase
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class BeansXMLProtocolProcessorTestCase {
 

--- a/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/AbstractService.java
+++ b/testenrichers/cdi/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/AbstractService.java
@@ -23,7 +23,6 @@ import javax.annotation.PreDestroy;
  * AbstractService
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class AbstractService<T> implements Service<T> {
     private boolean released = false;

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
@@ -35,7 +35,6 @@ import org.jboss.arquillian.test.spi.TestEnricher;
  * Enricher that provide EJB class and setter method injection.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EJBInjectionEnricher implements TestEnricher {
     private static final String ANNOTATION_NAME = "javax.ejb.EJB";

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherArchiveAppender.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherArchiveAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * EJBEnricherArchiveAppender
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EJBEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherExtension.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherExtension.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.testenricher.ejb.EJBInjectionEnricher;
  * EJBEnricherExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EJBEnricherExtension implements LoadableExtension {
     @Override

--- a/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/container/EJBEnricherRemoteExtension.java
+++ b/testenrichers/ejb/src/main/java/org/jboss/arquillian/testenricher/ejb/container/EJBEnricherRemoteExtension.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.testenricher.ejb.EJBInjectionEnricher;
  * EJBEnricherRemoteExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class EJBEnricherRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/InitialContextProducer.java
+++ b/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/InitialContextProducer.java
@@ -30,7 +30,6 @@ import org.jboss.arquillian.core.api.event.ManagerStarted;
  * ContainerInitialContextProducer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InitialContextProducer {
     @Inject

--- a/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/client/InitialContextArchiveAppender.java
+++ b/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/client/InitialContextArchiveAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * InitialContextArchiveAppender
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InitialContextArchiveAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/client/InitialContextExtension.java
+++ b/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/client/InitialContextExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * InitialContextExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InitialContextExtension implements LoadableExtension {
     @Override

--- a/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/container/InitialContextRemoteExtension.java
+++ b/testenrichers/initialcontext/src/main/java/org/jboss/arquillian/testenricher/initialcontext/container/InitialContextRemoteExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.testenricher.initialcontext.InitialContextProducer;
  * InitialContextExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class InitialContextRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
@@ -36,7 +36,6 @@ import org.jboss.arquillian.test.spi.TestEnricher;
  * Field Resources will only be injected if the current value is NULL or primitive default value.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ResourceInjectionEnricher implements TestEnricher {
     private static final String RESOURCE_LOOKUP_PREFIX = "java:comp/env";

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
@@ -32,7 +32,6 @@ import java.util.List;
  * A set of privileged actions that are not to leak out
  * of this package
  *
- * @version $Revision: $
  */
 final class SecurityActions {
 

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherArchiveAppender.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherArchiveAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * ResourceEnricherArchiveAppender
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ResourceEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherExtension.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherExtension.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.testenricher.resource.ResourceInjectionEnricher;
  * ResourceEnricherExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ResourceEnricherExtension implements LoadableExtension {
     @Override

--- a/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/container/ResourceEnricherRemoteExtension.java
+++ b/testenrichers/resource/src/main/java/org/jboss/arquillian/testenricher/resource/container/ResourceEnricherRemoteExtension.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.testenricher.resource.ResourceInjectionEnricher;
  * ResourceEnricherRemoteExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class ResourceEnricherRemoteExtension implements RemoteLoadableExtension {
     @Override

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/RemoveDependsOnTransformer.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/RemoveDependsOnTransformer.java
@@ -26,7 +26,6 @@ import org.testng.annotations.ITestAnnotation;
  * RemoveDependsOnMethodTransformer
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class RemoveDependsOnTransformer implements IAnnotationTransformer {
 

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestListener.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestListener.java
@@ -25,7 +25,6 @@ import org.testng.ITestResult;
  * TestListener
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestListener implements ITestListener {
 

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGContainerExtension.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGContainerExtension.java
@@ -24,7 +24,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * TestNGContainerExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGContainerExtension implements LoadableExtension {
     @Override

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppender.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppender.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * TestNGDeploymentAppender
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGDeploymentAppender extends CachedAuxilliaryArchiveAppender {
     @Override

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/TestNGTestRunner.java
@@ -31,7 +31,6 @@ import org.testng.xml.XmlTest;
  * TestNGTestRunner
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGTestRunner implements TestRunner {
 

--- a/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppenderTestCase.java
+++ b/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGDeploymentAppenderTestCase.java
@@ -25,7 +25,6 @@ import org.junit.Test;
  * TestNGDeploymentAppenderTestCase
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGDeploymentAppenderTestCase {
 

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/Arquillian.java
@@ -45,7 +45,6 @@ import org.testng.annotations.Listeners;
  * Arquillian
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @Listeners(Arquillian.UpdateResultListener.class)
 public abstract class Arquillian implements IHookable {

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/State.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/State.java
@@ -21,7 +21,6 @@ package org.jboss.arquillian.testng;
  * State
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class State {
     private static ThreadLocal<Throwable> caughtExceptionAfter = new ThreadLocal<Throwable>();

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/TestDataProviderTransformer.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/TestDataProviderTransformer.java
@@ -29,7 +29,6 @@ import org.testng.internal.annotations.TestAnnotation;
  * to the given test method to enable method argument injection support.
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestDataProviderTransformer implements IAnnotationTransformer {
 

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/TestEnricherDataProvider.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/TestEnricherDataProvider.java
@@ -23,7 +23,6 @@ import org.testng.annotations.DataProvider;
  * TestEnricherDataProvider
  *
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestEnricherDataProvider {
 

--- a/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGIntegrationTestCase.java
+++ b/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGIntegrationTestCase.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
  * Verify the that JUnit integration adaptor fires the expected events even when Handlers are failing.
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 @RunWith(MockitoJUnitRunner.class)
 public class TestNGIntegrationTestCase extends TestNGTestBaseClass {

--- a/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGTestBaseClass.java
+++ b/testng/core/src/test/java/org/jboss/arquillian/testng/TestNGTestBaseClass.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.doAnswer;
  * JUnitTestBaseClass
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGTestBaseClass {
     /*

--- a/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/LocalTestMethodExecutor.java
+++ b/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/LocalTestMethodExecutor.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.test.spi.execution.ExecUtils;
  * LocalTestMethodExecutor
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class LocalTestMethodExecutor {
     @Inject

--- a/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/TestNGStandaloneExtension.java
+++ b/testng/standalone/src/main/java/org/jboss/arquillian/testng/standalone/TestNGStandaloneExtension.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * JTestNGStandaloneExtension
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
- * @version $Revision: $
  */
 public class TestNGStandaloneExtension implements LoadableExtension {
     @Override


### PR DESCRIPTION
Sorry, but this has been grinding my gears for far too long. It is a result of an incomplete SVN-to-Git SCM migration. Moreover, this isn't just an invisible issue; it is incorrectly rendered in the resulting Javadocs, which is simply silly.