### PR TITLE
MethodParameterObserver.injectParameters: handle null result of TestEnricher.resolve

### DIFF
--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterObserver.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameterObserver.java
@@ -76,9 +76,11 @@ public class MethodParameterObserver {
             final Collection<TestEnricher> testEnrichers = serviceLoader.get().all(TestEnricher.class);
             for (TestEnricher enricher : testEnrichers) {
                 final Object[] values = enricher.resolve(testMethod);
-                for (int i = 0; i < values.length; i++) {
-                    if (values[i] != null) {
-                        methodParameters.add(i, values[i]);
+                if (values != null) {
+                    for (int i = 0; i < values.length; i++) {
+                        if (values[i] != null) {
+                            methodParameters.add(i, values[i]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This resolves #688: in the arquillian-extension-warp test suite, there is a TestEnricher implementation whose `resolve` returns null. This causes an exception with arquillian 1.9.2. So this commit adds a null check.

According to the comments of `TestEnricher.resolve`, I am not sure whether null is a allowed return value.  But the code in `org.jboss.arquillian.test.spi.execution.ExecUtils.enrichArguments` also checks for null.