### PR TITLE
chore: Define a single junit5 version across the project; i.e. don't …

### DIFF
--- a/integration-tests/common/pom.xml
+++ b/integration-tests/common/pom.xml
@@ -31,16 +31,12 @@
   <name>Arquillian Core: Common integration tests</name>
   <description />
 
-  <properties>
-    <version.org.junit>5.12.1</version.org.junit>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${version.org.junit}</version>
+        <version>${version.junit5}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/integration-tests/junit5-tests/pom.xml
+++ b/integration-tests/junit5-tests/pom.xml
@@ -30,16 +30,12 @@
   <artifactId>junit5-tests</artifactId>
   <name>Arquillian Core: JUnit 5 Integration Tests</name>
 
-  <properties>
-    <version.org.junit>5.12.1</version.org.junit>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${version.org.junit}</version>
+        <version>${version.junit5}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,16 +20,15 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <groupId>org.jboss</groupId>
-    <artifactId>jboss-parent</artifactId>
-    <version>49</version>
-    <relativePath />
+    <groupId>org.jboss.arquillian</groupId>
+    <artifactId>arquillian-build</artifactId>
+    <version>1.9.5.Final-SNAPSHOT</version>
+    <relativePath>../build/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.jboss.arquillian</groupId>
   <artifactId>integration-tests</artifactId>
-  <version>1.9.5.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Core: Implementation Integration Tests</name>
   <description>Tests for implementations of Arquillian Core</description>


### PR DESCRIPTION
…maintain a separate version for ITs
