### PR TITLE
Expanded fix for #725

### DIFF
--- a/junit5/container/pom.xml
+++ b/junit5/container/pom.xml
@@ -95,6 +95,18 @@
       <artifactId>junit-platform-testkit</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
+      <version>${version.junit5.platform}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-engine</artifactId>
+      <version>${version.junit5.platform}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunner.java
+++ b/junit5/container/src/main/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunner.java
@@ -24,6 +24,9 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.opentest4j.TestAbortedException;
 
+/**
+ * An Arquillian TestRunner implementation for JUnit Jupiter.
+ */
 public class JUnitJupiterTestRunner implements TestRunner {
 
     @Override
@@ -67,7 +70,9 @@ public class JUnitJupiterTestRunner implements TestRunner {
     }
 
     private static class ArquillianTestMethodExecutionListener implements TestExecutionListener {
+        // Map of test identifier to exception
         private final Map<String, Throwable> exceptions = new HashMap<>();
+        // The test execution failure or a general error if the test result has no exception but is not successful
         private Throwable fatalError;
 
         public void executionSkipped(TestIdentifier testIdentifier, String reason) {

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ExampleSuite.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ExampleSuite.java
@@ -1,0 +1,17 @@
+package org.jboss.arquillian.junit5.container;
+
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SuiteDisplayName("Junit5 Suite with failures and excludes")
+@IncludeTags("shouldInclude")
+@ExcludeTags({"shouldExclude", "failOnFirst", "failOnSecond"})
+@SelectClasses({
+    TestsWithIncludesExcludes.class
+})
+public class ExampleSuite {
+}

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitIntegrationTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitIntegrationTestCase.java
@@ -41,4 +41,21 @@ public class JUnitIntegrationTestCase extends JUnitTestBaseClass {
         assertCycle(1, Cycle.BEFORE_RULE, Cycle.BEFORE_CLASS, Cycle.BEFORE, Cycle.TEST, Cycle.AFTER, Cycle.AFTER_CLASS,
             Cycle.AFTER_RULE, Cycle.BEFORE_CLASS_RULE, Cycle.AFTER_CLASS_RULE);
     }
+
+    @Test
+    public void runJunit5Suite() throws Exception {
+        // given
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+
+        // when
+        TestExecutionSummary result = runSuite(adaptor, ExampleSuite.class);
+
+        // then
+        Assertions.assertEquals(4, result.getTestsFoundCount());
+        Assertions.assertEquals(1, result.getTestsSucceededCount());
+        Assertions.assertEquals(1, result.getTestsFailedCount());
+        Assertions.assertEquals(1, result.getTestsSkippedCount());
+        Assertions.assertEquals(1, result.getTestsAbortedCount());
+    }
 }

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitTestBaseClass.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitTestBaseClass.java
@@ -129,6 +129,24 @@ public class JUnitTestBaseClass {
         }
     }
 
+    protected TestExecutionSummary runSuite(TestRunnerAdaptor adaptor, Class<?> suiteClass) throws Exception {
+        try {
+            setAdaptor(adaptor);
+
+            LauncherDiscoveryRequestBuilder builder = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(suiteClass));
+            LauncherDiscoveryRequest request = builder.build();
+            SummaryGeneratingListener summaryListener = new SummaryGeneratingListener();
+
+            Launcher launcher = LauncherFactory.create();
+            launcher.registerTestExecutionListeners(summaryListener);
+            launcher.execute(request);
+            return summaryListener.getSummary();
+        } finally {
+            setAdaptor(null);
+        }
+    }
+
     // force set the TestRunnerAdaptor to use
     private void setAdaptor(TestRunnerAdaptor adaptor) throws Exception {
         Method method = TestRunnerAdaptorBuilder.class.getMethod("set", TestRunnerAdaptor.class);

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/TestsWithIncludesExcludes.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/TestsWithIncludesExcludes.java
@@ -1,0 +1,48 @@
+package org.jboss.arquillian.junit5.container;
+
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@ArquillianTest
+public class TestsWithIncludesExcludes {
+    @Test
+    @Tag("shouldInclude")
+    public void functionATest() {
+        System.out.println("TestsWithIncludesExcludes.functionATest executed...");
+    }
+
+    @Test
+    @Tag("shouldInclude")
+    public void badTest() {
+        System.out.println("TestsWithIncludesExcludes.badTest executed...");
+        fail("badTest is expected to fail");
+    }
+
+    @Test
+    @Tag("shouldInclude")
+    public void failedAssumptionShouldAbort() {
+        assumeTrue(false);
+        fail("fail should be skipped");
+    }
+    @Test
+    @Disabled
+    @Tag("shouldInclude")
+    public void disabledTestShouldSkip() {
+        System.out.println("TestsWithIncludesExcludes.functionCTest executed...");
+        fail("fail should not called");
+    }
+
+// All tests below should not run for various reasons
+    @Test
+    @Tag("shouldExclude")
+    public void functionBTest() {
+        System.out.println("TestsWithIncludesExcludes.functionBTest executed...");
+        fail("fail should not called");
+    }
+
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -1,8 +1,7 @@
 package org.jboss.arquillian.junit5;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.jboss.arquillian.junit5.extension.RunModeEvent;
@@ -21,21 +20,25 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
-import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
-import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.ExceptionUtils;
+import org.opentest4j.TestAbortedException;
 
-import static org.jboss.arquillian.junit5.ContextStore.getContextStore;
 import static org.jboss.arquillian.junit5.JUnitJupiterTestClassLifecycleManager.getManager;
 
-public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, BeforeTestExecutionCallback, InvocationInterceptor, TestExecutionExceptionHandler, ParameterResolver {
+/**
+ * Implments serveral Junit5 extension API interfaces to adapt Juni5 tests into Arquillian.
+ */
+public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, BeforeTestExecutionCallback, InvocationInterceptor, ParameterResolver {
     public static final String RUNNING_INSIDE_ARQUILLIAN = "insideArquillian";
-
-    private static final String CHAIN_EXCEPTION_MESSAGE_PREFIX = "Chain of InvocationInterceptors never called invocation";
 
     private static final Predicate<ExtensionContext> IS_INSIDE_ARQUILLIAN = (context -> Boolean.parseBoolean(context.getConfigurationParameter(RUNNING_INSIDE_ARQUILLIAN)
         .orElse("false")));
 
+    /**
+     * Called before all tests in the test class are executed.
+     *
+     * @param context the current extension context
+     * @throws Exception if any error occurs
+     */
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         getManager(context).getAdaptor().beforeClass(
@@ -43,6 +46,12 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
             LifecycleMethodExecutor.NO_OP);
     }
 
+    /**
+     * Called after all tests in the test class have been executed.
+     *
+     * @param context the current extension context
+     * @throws Exception if any error occurs
+     */
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
         getManager(context).getAdaptor().afterClass(
@@ -50,6 +59,12 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
             LifecycleMethodExecutor.NO_OP);
     }
 
+    /**
+     * Called before each test method is executed.
+     *
+     * @param context the current extension context
+     * @throws Exception if any error occurs
+     */
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         // Get the adapter, test instance and method
@@ -67,6 +82,12 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
             LifecycleMethodExecutor.NO_OP);
     }
 
+    /**
+     * Called after each test method has been executed.
+     *
+     * @param context the current extension context
+     * @throws Exception if any error occurs
+     */
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         try {
@@ -79,6 +100,12 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Called before the execution of a test method (but after beforeEach).
+     *
+     * @param context the current extension context
+     * @throws Exception if any error occurs
+     */
     @Override
     public void beforeTestExecution(final ExtensionContext context) throws Exception {
         // Get the adapter, test instance and method
@@ -89,38 +116,73 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         adapter.fireCustomLifecycle(new BeforeTestExecutionEvent(instance, method));
     }
 
+    /**
+     * Intercepts the execution of a test template method (e.g., @RepeatedTest, @ParameterizedTest).
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptTestTemplateMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
         if (IS_INSIDE_ARQUILLIAN.test(extensionContext)) {
             // run inside arquillian
             invocation.proceed();
         } else {
-            ContextStore contextStore = getContextStore(extensionContext);
+            ContextStore contextStore = ContextStore.getContextStore(extensionContext);
+            TestResult result = null;
             if (isRunAsClient(extensionContext)) {
                 // Run as client
-                interceptInvocation(invocationContext, extensionContext);
+                result = interceptInvocation(invocation, extensionContext);
             } else {
                 // Run as container (but only once)
                 if (!contextStore.isRegisteredTemplate(invocationContext.getExecutable())) {
-                    interceptInvocation(invocationContext, extensionContext);
+                    result = interceptInvocation(invocation, extensionContext);
                 }
             }
-            contextStore.getResult(extensionContext.getUniqueId())
-                .ifPresent(ExceptionUtils::throwAsUncheckedException);
+            if (result != null && result.getStatus() != TestResult.Status.PASSED) {
+                if(result.getThrowable() != null) {
+                    throw result.getThrowable();
+                } else {
+                    throw new TestAbortedException(result.getDescription());
+                }
+            }
         }
     }
 
+    /**
+     * Intercepts the execution of a test method.
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
         if (IS_INSIDE_ARQUILLIAN.test(extensionContext)) {
             invocation.proceed();
         } else {
-            interceptInvocation(invocationContext, extensionContext);
-            getContextStore(extensionContext).getResult(extensionContext.getUniqueId())
-                .ifPresent(ExceptionUtils::throwAsUncheckedException);
+            TestResult result = interceptInvocation(invocation, extensionContext);
+            if (result.getStatus() != TestResult.Status.PASSED) {
+                if(result.getThrowable() != null) {
+                    throw result.getThrowable();
+                } else {
+                    throw new TestAbortedException(result.getDescription());
+                }
+            }
         }
     }
 
+    /**
+     * Intercepts the execution of a @BeforeEach method.
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
         if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
@@ -134,6 +196,14 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Intercepts the execution of an @AfterEach method.
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
         if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
@@ -146,6 +216,14 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Intercepts the execution of a @BeforeAll method.
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptBeforeAllMethod(Invocation<Void> invocation,
                                          ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
@@ -156,6 +234,14 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Intercepts the execution of an @AfterAll method.
+     *
+     * @param invocation the invocation to proceed or skip
+     * @param invocationContext the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
     @Override
     public void interceptAfterAllMethod(Invocation<Void> invocation,
                                         ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
@@ -166,16 +252,17 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
-    @Override
-    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        if (throwable instanceof JUnitException && throwable.getMessage().startsWith(CHAIN_EXCEPTION_MESSAGE_PREFIX)) {
-            return;
-        }
-        throw throwable;
-    }
-
-    private void interceptInvocation(ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        TestResult result = getManager(extensionContext).getAdaptor().test(new TestMethodExecutor() {
+    /**
+     * Intercepts the invocation of a test method, running it through the Arquillian TestRunnerAdaptor.
+     *
+     * @param invocation the reflective invocation context
+     * @param extensionContext the current extension context
+     * @throws Throwable if any error occurs
+     */
+     private TestResult interceptInvocation(Invocation<?> invocation, ExtensionContext extensionContext) throws Throwable {
+            final AtomicBoolean proceedInvoked = new AtomicBoolean(false);
+        TestRunnerAdaptor adaptor = getManager(extensionContext).getAdaptor();
+        TestResult result = adaptor.test(new TestMethodExecutor() {
             @Override
             public String getMethodName() {
                 return extensionContext.getRequiredTestMethod().getName();
@@ -192,27 +279,26 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
             }
 
             @Override
-            public void invoke(Object... parameters) throws InvocationTargetException, IllegalAccessException {
-                Method method = getMethod();
-                method.setAccessible(true);
-                method.invoke(getInstance(), invocationContext.getArguments().toArray());
+            public void invoke(Object... parameters) throws Throwable {
+                proceedInvoked.set(true);
+                invocation.proceed();
             }
         });
-        populateResults(result, extensionContext);
+         // Check if Invocation.proceed() was invoked. If it was, we don't need to execute any further. If it wasn't,
+         // we will skip the rest of the interceptors as the interceptors should have been run in the container.
+         if (!proceedInvoked.get()) {
+             invocation.skip();
+         }
+         return result;
     }
 
-    private void populateResults(TestResult result, ExtensionContext context) {
-        if (Optional.ofNullable(result.getThrowable()).isPresent()) {
-            ContextStore contextStore = getContextStore(context);
-            if (result.getThrowable() instanceof IdentifiedTestException) {
-                ((IdentifiedTestException) result.getThrowable()).getCollectedExceptions()
-                    .forEach(contextStore::storeResult);
-            } else {
-                contextStore.storeResult(context.getUniqueId(), result.getThrowable());
-            }
-        }
-    }
-
+    /**
+     * Determines if the current test should be run as client.
+     *
+     * @param extensionContext the current extension context
+     * @return true if the test should be run as client, false otherwise
+     * @throws Exception if any error occurs
+     */
     private boolean isRunAsClient(ExtensionContext extensionContext) throws Exception {
         RunModeEvent runModeEvent = new RunModeEvent(extensionContext.getRequiredTestInstance(), extensionContext.getRequiredTestMethod());
         final JUnitJupiterTestClassLifecycleManager manager = getManager(extensionContext);
@@ -220,6 +306,14 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         return runModeEvent.isRunAsClient();
     }
 
+    /**
+     * Determines if the given parameter is supported for injection.
+     *
+     * @param parameterContext the parameter context
+     * @param extensionContext the current extension context
+     * @return true if the parameter is supported, false otherwise
+     * @throws ParameterResolutionException if parameter resolution fails
+     */
     @Override
     public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
         try {
@@ -234,6 +328,14 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Resolves the value for the given parameter.
+     *
+     * @param parameterContext the parameter context
+     * @param extensionContext the current extension context
+     * @return the resolved parameter value
+     * @throws ParameterResolutionException if parameter resolution fails
+     */
     @Override
     public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext) throws ParameterResolutionException {
         try {
@@ -248,6 +350,13 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
     }
 
+    /**
+     * Creates a ParameterResolutionException with a detailed message and optional cause.
+     *
+     * @param parameterContext the parameter context
+     * @param cause the cause of the exception, may be null
+     * @return a new ParameterResolutionException
+     */
     private static ParameterResolutionException createParameterResolutionException(final ParameterContext parameterContext, final Throwable cause) {
         final String msg = String.format("Failed to resolve parameter %s", parameterContext.getParameter().getName());
         if (cause == null) {

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -25,7 +25,7 @@ import org.opentest4j.TestAbortedException;
 import static org.jboss.arquillian.junit5.JUnitJupiterTestClassLifecycleManager.getManager;
 
 /**
- * Implments serveral Junit5 extension API interfaces to adapt Juni5 tests into Arquillian.
+ * Implements several Junit5 extension API interfaces to adapt Juni5 tests into Arquillian.
  */
 public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback, BeforeTestExecutionCallback, InvocationInterceptor, ParameterResolver {
     public static final String RUNNING_INSIDE_ARQUILLIAN = "insideArquillian";

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
@@ -1,8 +1,6 @@
 package org.jboss.arquillian.junit5;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -10,8 +8,6 @@ class ContextStore {
     private static final String NAMESPACE_KEY = "arquillianNamespace";
 
     private static final String INTERCEPTED_TEMPLATE_NAMESPACE_KEY = "interceptedTestTemplates";
-
-    private static final String RESULT_NAMESPACE_KEY = "results";
 
     private static final String PARAMETER_NAMESPACE_KEY = "methodParameters";
 
@@ -33,10 +29,6 @@ class ContextStore {
         return context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, INTERCEPTED_TEMPLATE_NAMESPACE_KEY));
     }
 
-    private ExtensionContext.Store getResultStore() {
-        return context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, RESULT_NAMESPACE_KEY));
-    }
-
     boolean isRegisteredTemplate(Method method) {
         final ExtensionContext.Store templateStore = getTemplateStore();
 
@@ -45,22 +37,6 @@ class ContextStore {
             templateStore.put(method.toGenericString(), true);
         }
         return isRegistered;
-    }
-
-    void storeResult(String uniqueId, Throwable throwable) {
-        final ExtensionContext.Store resultStore = getResultStore();
-        resultStore.put(uniqueId, throwable);
-        // TODO: find source and unwrap it where it is thrown, not here.
-        if (throwable instanceof InvocationTargetException) {
-            resultStore.put(uniqueId, throwable.getCause());
-        } else {
-            resultStore.put(uniqueId, throwable);
-        }
-    }
-
-    Optional<Throwable> getResult(String uniqueId) {
-        final ExtensionContext.Store resultStore = getResultStore();
-        return Optional.ofNullable(resultStore.getOrDefault(uniqueId, Throwable.class, null));
     }
 
     /**

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/IdentifiedTestException.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/IdentifiedTestException.java
@@ -2,6 +2,9 @@ package org.jboss.arquillian.junit5;
 
 import java.util.Map;
 
+/**
+ * A exception thrown when a test has failed
+ */
 public class IdentifiedTestException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/JUnitJupiterTestClassLifecycleManager.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/JUnitJupiterTestClassLifecycleManager.java
@@ -6,6 +6,23 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static org.jboss.arquillian.junit5.ContextStore.getContextStore;
 
+/**
+ * Manages the lifecycle of JUnit Jupiter test classes within the Arquillian framework.
+ * This class implements both {@link AutoCloseable} and {@link ExtensionContext.Store.CloseableResource}
+ * for junit5 prior to 5.13.0 to ensure proper resource cleanup.
+ *
+ * <p>The manager is responsible for:</p>
+ * <ul>
+ *   <li>Initializing and managing the Arquillian{@link TestRunnerAdaptor}</li>
+ *   <li>Handling test suite lifecycle events (beforeSuite, afterSuite)</li>
+ *   <li>Providing access to the test runner adaptor for test execution</li>
+ *   <li>Managing initialization failures and error handling</li>
+ * </ul>
+ *
+ * <p>This class uses a singleton pattern per test context, ensuring that only one
+ * manager instance exists per test suite execution.</p>
+ */
+
 public class JUnitJupiterTestClassLifecycleManager implements AutoCloseable,
     ExtensionContext.Store.CloseableResource {
     private static final String MANAGER_KEY = "testRunnerManager";
@@ -68,12 +85,23 @@ public class JUnitJupiterTestClassLifecycleManager implements AutoCloseable,
     private boolean hasInitializationException() {
         return caughtInitializationException != null;
     }
-
+    /**
+     * Handles initialization failures that occur during the beforeSuite phase.
+     * This method captures the exception and stores it for later retrieval,
+     * preventing repeated initialization attempts.
+     *
+     * @param e the exception that occurred during initialization
+     */
     private void handleBeforeSuiteFailure(Exception e) throws Exception {
         caughtInitializationException = e;
         throw e;
     }
 
+    /**
+     * Retrieves the TestRunnerAdaptor instance managed by this lifecycle manager.
+     *
+     * @return the TestRunnerAdaptor instance, or null if initialization failed
+     */
     TestRunnerAdaptor getAdaptor() {
         return adaptor;
     }


### PR DESCRIPTION
- Expand the PR by @jamezp to remove use of the ContextStore for the TestResult exception and just return TestResult from interceptInvocation.
- Add tests of a junit5 suite

Fixes #725

With this change the example https://github.com/horstLei/demo-service-junit5.git repo test fails as expected.

```bash
starksm@Scotts-Mac-Studio demo-test-ejb % mvn install -Parq-jboss-managed -Dmaven.surefire.debug -Dtest=at.it4health.test.suite.DemoServiceSuiteAssertOnFirstTest

...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Listening for transport dt_socket at address: 5005
[INFO] Running at.it4health.test.suite.DemoServiceSuiteAssertOnFirstTest
[INFO] Running at.it4health.test.servicea.DemoServiceATest
01:28:11,156 INFO  [org.jboss.modules] (main) JBoss Modules version 1.9.1.Final
...
01:28:40,959 INFO  [org.jboss.as] (MSC service thread 1-1) WFLYSRV0050: WildFly Full 18.0.1.Final (WildFly Core 10.0.3.Final) stopped in 11ms
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.77 s -- in at.it4health.test.suite.DemoServiceSuiteAssertOnFirstTest
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   DemoServiceBTest.functionCTest » IdentifiedTest org.opentest4j.AssertionFailedError: expected: not equal but was: <1>
[INFO] 
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  43.514 s
[INFO] Finished at: 2025-06-21T19:28:41-06:00
[INFO] ------------------------------------------------------------------------

```

## Summary by Sourcery

Adapt the Arquillian JUnit5 extension to eliminate ContextStore-based result handling and directly return and propagate TestResult statuses, while adding support and tests for JUnit5 suite execution with include/exclude tags.

New Features:
- Return TestResult directly from interceptInvocation and propagate failures or skipped status via thrown exceptions instead of using ContextStore
- Add support for executing JUnit5 suites via a new runSuite method and corresponding suite API dependencies

Bug Fixes:
- Resolve issue #725 by ensuring example JUnit5 suite tests fail as expected

Enhancements:
- Remove ContextStore result storage and streamline invocation interceptors to simplify exception handling
- Add comprehensive Javadoc to ArquillianExtension, JUnitJupiterTestClassLifecycleManager, and TestRunner classes

Build:
- Include junit-platform-suite-api and junit-platform-suite-engine as test dependencies in the container POM