### PR TITLE
Upgrade mockito-core to 4.11.0 - last JDK 8 compatible version.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -26,7 +26,7 @@
     <version.javax.inject>1</version.javax.inject>
     <version.junit>4.13.2</version.junit>
     <version.junit5>5.13.3</version.junit5>
-    <version.mockito>4.10.0</version.mockito>
+    <version.mockito>4.11.0</version.mockito>
     <version.testng>7.5</version.testng>
     <version.assertj>3.27.3</version.assertj>
   </properties>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump mockito-core version in build configuration to 4.11.0 (last JDK 8 compatible release)