### PR TITLE
Flaky Test Fixed in test/impl-base Module

### DIFF
--- a/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
+++ b/test/impl-base/src/test/java/org/jboss/arquillian/test/impl/enricher/resource/ArquillianResourceTestEnricherTestCase.java
@@ -38,6 +38,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -232,10 +233,17 @@ public class ArquillianResourceTestEnricherTestCase extends AbstractTestTestBase
     public void shouldBeAbleToInjectBaseContextOnMethodWithQualifier() throws Exception {
         Method resourceMethod = ObjectClass.class.getMethod("testWithQualifier", Object.class);
 
+        Annotation qualifierAnnotation = null;
+        for (Annotation ann : resourceMethod.getParameterAnnotations()[0]) {
+            if (ann.annotationType().equals(ArquillianTestQualifier.class)) {
+                qualifierAnnotation = ann;
+                break;
+            }
+        }
         Mockito.when(
                 resourceProvider.lookup(
                     Mockito.any(ArquillianResource.class),
-                    Mockito.any(resourceMethod.getParameterAnnotations()[0][1].getClass()),
+                    Mockito.any(qualifierAnnotation.getClass()),
                     Mockito.any(ResourceProvider.MethodInjection.class)
                 ))
             .thenReturn(resource);


### PR DESCRIPTION
## Problem
The flakiness/non-determinism in the test`shouldBeAbleToInjectBaseContextOnMethodWithQualifier` in module `test/impl-base` was found with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. Runtime exception `All Providers for type class java.lang.Object returned a null value` was triggered with certain random seeds. This is due to the non-determinism from `Method.getParameterAnnotations()`, which returns annotations on each parameter, but the order of multiple annotations on the SAME parameter is not guaranteed by the Java specification. 

```
resourceMethod.getParameterAnnotations()[0][1].getClass()
```
This original statement falsely assumes that the annotation on index 1 is the target, but different internal states (randomly set by NonDex) may return these annotations in different orders. With some seeds, the `lookup` would end up matching with the wrong class and in turn triggers the exception in `lookup`.

## Solution
Check each annotation iteratively without assuming the index:
```
for (Annotation ann : resourceMethod.getParameterAnnotations()[0]) {
   ...
}
```
This does not weaken the test since it still verifies the correct annotation type (`ArquillianTestQualifier`) is passed to `lookup()`.

## Reproduce
The test error can be reproduced with NonDex with command: 

```
mvn -pl test/impl-base edu.illinois:nondex-maven-plugin:2.1.7:nondex \
Dtest=org.jboss.arquillian.test.impl.enricher.resource.ArquillianResourceTestEnricherTestCase#shouldBeAbleToInjectBaseContextOnMethodWithQualifier`
```

## Summary by Sourcery

Fix flaky test in test/impl-base by dynamically locating the qualifier annotation instead of assuming a fixed annotation index

Bug Fixes:
- Eliminate nondeterminism in shouldBeAbleToInjectBaseContextOnMethodWithQualifier by avoiding hardcoded annotation index

Tests:
- Iterate through parameter annotations to find the ArquillianTestQualifier dynamically in the test