### PR TITLE
Remove build status image from README with old broken link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,8 +10,6 @@
 :icons: font
 :toc: left
 
-image:https://travis-ci.org/arquillian/arquillian-core.svg?branch=master["Build Status", link="https://travis-ci.org/arquillian/arquillian-core"]
-
 ifndef::generated-doc[]
 To read complete documentation visit https://arquillian.org/arquillian-core/
 endif::generated-doc[]


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


Fixes #

## Summary by Sourcery

Documentation:
- Clean up the README by removing the obsolete build status image with a broken link.