### PR TITLE
CI: Add JDK 25 LTS to the testing mix, remove unnecessary job definit…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: CI
 
 on:
   push:
@@ -9,79 +9,27 @@ on:
       - '*'
 
 jobs:
-
-  arquillian-build-jdk8:
-    name: Integration - JDK 8
+  build-and-verify:
+    name: Build and verify with Maven - JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    outputs:
-      SNAPSHOT_VERSION: ${{ steps.arq-version.outputs.SNAPSHOT_VERSION }}
+    strategy:
+      matrix:
+        # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).
+        # Reference: https://adoptium.net/support/
+        java:
+          - 8
+          - 11
+          - 17
+          - 21
+          - 25
     steps:
       - name: Checkout arquillian-core
         uses: actions/checkout@v4
-      - name: Setup JDK 8
+      - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          java-version: 8
-          distribution: temurin
-          cache: maven
-      - name: Build with Maven
-        run: mvn --batch-mode --no-transfer-progress clean verify
-      - name: Version save
-        id: arq-version
-        run: |
-          VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-          echo "SNAPSHOT_VERSION=$VERSION" >> $GITHUB_OUTPUT        
-          echo "Arquillian version: $VERSION"
-      - name: Artifact upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: arquillian
-          path: ~/.m2/repository/org/jboss/
-
-  arquillian-build-jdk11:
-    name: Integration - JDK 11
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Build with Maven
-        uses: actions/checkout@v4
-      - name: Setup JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: 11
-          distribution: temurin
-          cache: maven
-      - name: Build with Maven
-        run: mvn --batch-mode --no-transfer-progress clean verify
-
-  arquillian-build-jdk17:
-    name: Integration - JDK 17
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Build with Maven
-        uses: actions/checkout@v4
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
-          cache: maven
-      - name: Build with Maven
-        run: mvn --batch-mode --no-transfer-progress clean verify
-
-  arquillian-build-jdk21:
-    name: Integration - JDK 21
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Build with Maven
-        uses: actions/checkout@v4
-      - name: Setup JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
+          java-version: ${{ matrix.java }}
           distribution: temurin
           cache: maven
       - name: Build with Maven


### PR DESCRIPTION
…ion, remove non-sensical upload step (archive is uploaded but the project is never installed...)

## Summary by Sourcery

Run Maven CI builds across a matrix of LTS and latest JDK versions while simplifying the workflow configuration.

CI:
- Consolidate multiple JDK-specific GitHub Actions jobs into a single matrix-driven job covering JDK 8, 11, 17, 21, and 25.
- Remove unused workflow outputs and the redundant artifact upload step from the CI configuration.
- Rename the workflow to a more generic CI name.