### PR TITLE
Upgrade Payara integration test profile

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
           path: '**/server.log'
 
   payara-integration:
-    name: 'Payara ${{ matrix.payara }} Integration Tests (${{ matrix.os }}, ${{ matrix.java }})'
+    name: 'Payara Integration Tests (${{ matrix.os }}, ${{ matrix.java }})'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -60,18 +60,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         java:
-          - 11
-          - 17
+          # Payara 7 requires JDK 21+ (Jakarta EE 11)
           - 21
-        payara:
-          - 6
-          - 7
-        exclude:
-          # Payara 7 requires JDK 21+ (compiled with class file version 65)
-          - java: 11
-            payara: 7
-          - java: 17
-            payara: 7
 
     steps:
       - uses: actions/checkout@v6
@@ -81,16 +71,16 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
           cache: maven
-      - name: Build with Maven Java ${{ matrix.java }} - Payara ${{ matrix.payara }} - ${{ matrix.os }}
+      - name: Build with Maven Java ${{ matrix.java }} - ${{ matrix.os }}
         run:  |
-          ./mvnw -V clean install -U -B -fae '-Dpayara.version=${{ matrix.payara }}' '-T1' '-Pintegration-tests'
+          ./mvnw -V clean install -U -B -fae '-Ppayara' '-T1' '-Pintegration-tests'
       - uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ matrix.java }}-payara-${{ matrix.payara }}-surefire-reports
+          name: ${{ matrix.os }}-${{ matrix.java }}-payara-surefire-reports
           path: '**/surefire-reports/*'
       - uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ matrix.java }}-payara-${{ matrix.payara }}-server-logs
+          name: ${{ matrix.os }}-${{ matrix.java }}-payara-server-logs
           path: '**/server.log'

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -259,46 +259,13 @@
     </profile>
 
     <profile>
-      <!-- Payara 6 (Jakarta EE 10) - supports JDK 11+. Activate with -Dpayara.version=6 -->
-      <id>payara6</id>
-      <activation>
-        <property>
-          <name>payara.version</name>
-          <value>6</value>
-        </property>
-      </activation>
-      <properties>
-        <version.fish.payara>6.2025.10</version.fish.payara>
-        <payara.home>${project.build.directory}${file.separator}payara6</payara.home>
-      </properties>
-    </profile>
-
-    <profile>
-      <!-- Payara 7 (Jakarta EE 11) - requires JDK 21+. Activate with -Dpayara.version=7 -->
-      <id>payara7</id>
-      <activation>
-        <property>
-          <name>payara.version</name>
-          <value>7</value>
-        </property>
-      </activation>
-      <properties>
-        <version.fish.payara>7.2026.1</version.fish.payara>
-        <payara.home>${project.build.directory}${file.separator}payara7</payara.home>
-      </properties>
-    </profile>
-
-    <profile>
-      <!-- Common Payara configuration - activates automatically when payara.version is set -->
-      <id>payara-common</id>
-      <activation>
-        <property>
-          <name>payara.version</name>
-        </property>
-      </activation>
+      <!-- Payara 7 (Jakarta EE 11) - requires JDK 21+ -->
+      <id>payara</id>
       <properties>
         <skip.provision.server>${skipTests}</skip.provision.server>
+        <version.fish.payara>7.2026.1</version.fish.payara>
         <version.fish.payara.arquillian>3.1</version.fish.payara.arquillian>
+        <payara.home>${project.build.directory}${file.separator}payara7</payara.home>
       </properties>
 
       <dependencies>


### PR DESCRIPTION
Profiles activate automatically via -Dpayara.version=6 or 7 Payara 7 requires JDK 21+ (Jakarta EE 11)

Fix archive names
Remove unnecesary cron - nothing is dynamic here, no need to retest
Fix typos

## Summary by Sourcery

Add Payara 6 and 7-specific integration test profiles and update CI integration workflows accordingly.

New Features:
- Introduce separate Maven profiles for Payara 6 and Payara 7 integration tests, activated via the payara.version property.

Enhancements:
- Refine the shared Payara Maven profile to hold common configuration that activates automatically when payara.version is set.
- Tighten CI matrix configuration for Payara integration tests, including explicit Payara version dimension and JDK compatibility exclusions.
- Simplify and normalize artifact names produced by CI for WildFly and Payara integration test runs.

CI:
- Remove the scheduled daily integration test run and keep the workflow triggered only on pushes and pull requests.
- Reformat and clarify GitHub Actions matrices and job names for integration tests to better reflect OS, JDK, and Payara versions.