### PR TITLE
Drop JDK 8 support and baseline on JDK 11 since 1.11.x and align with…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and optionally the latest EA JDK (if available).
         # Reference: https://adoptium.net/support/
         java:
-          - 8
           - 11
           - 17
           - 21

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -96,29 +96,4 @@
 
     </dependencies>
   </dependencyManagement>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.27</version>
-        <executions>
-          <execution>
-            <id>signature-check</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java18</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -41,8 +41,6 @@
   </modules>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
-
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <skipItTests>false</skipItTests>
     <skipTests>${skipItTests}</skipTests>

--- a/junit5/container/pom.xml
+++ b/junit5/container/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Arquillian TestRunner JUnit 5 Container</name>
 
-  <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
-  </properties>
-
   <dependencies>
     <!-- org.jboss.arquillian -->
     <dependency>

--- a/junit5/core/pom.xml
+++ b/junit5/core/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Arquillian TestRunner JUnit 5 Core</name>
 
-  <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
-  </properties>
-
   <dependencies>
     <!-- org.jboss.arquillian -->
     <dependency>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -18,12 +18,6 @@
   <name>Arquillian TestRunner JUnit Jupiter Aggregator</name>
   <description>Arquillian JUnit Jupiter Aggregator</description>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
-
   <modules>
     <module>core</module>
     <module>container</module>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- jboss-parent overrides -->
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
     <jdk.min.version>${maven.compiler.release}</jdk.min.version>
 
     <!-- Central Publishing Plugin -->

--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -27,7 +27,7 @@
     <version.javax-el>2.2</version.javax-el>
     <version.slf4j>2.0.17</version.slf4j>
 
-    <java11.opensargs />
+    <java11.opensargs>--add-opens java.base/java.lang=ALL-UNNAMED</java11.opensargs>
   </properties>
 
   <!-- Dependencies -->
@@ -135,15 +135,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>not-java8</id>
-      <activation>
-        <jdk>[11,]</jdk>
-      </activation>
-      <properties>
-        <java11.opensargs>--add-opens java.base/java.lang=ALL-UNNAMED</java11.opensargs>
-      </properties>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
…Jakarta EE 10 baseline; fixes #662

## Summary by Sourcery

Raise the project’s baseline to JDK 11 and remove JDK 8–specific configuration and checks.

Build:
- Update Mockito dependency to version 5.15.2.
- Remove the animal-sniffer JDK 8 signature check from the build configuration.
- Simplify module compiler settings to rely on the parent JDK 11 configuration and always set the Java 11 add-opens arguments for CDI tests.

CI:
- Drop JDK 8 from the CI test matrix so builds run on JDK 11 and newer only.