### PR TITLE
Add forRemoval=true and since to @deprecated elements; fixes #812 + fix deprecation warnings across the code base post JDK baseline shift to 11

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployController.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployController.java
@@ -113,7 +113,7 @@ public class ContainerDeployController {
         });
     }
 
-    @SuppressWarnings("deprecation") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
+    @SuppressWarnings("removal") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
     public void deploy(@Observes final DeployDeployment event) throws Exception {
         executeOperation(new Callable<Void>() {
             @Inject
@@ -166,7 +166,7 @@ public class ContainerDeployController {
         });
     }
 
-    @SuppressWarnings("deprecation") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
+    @SuppressWarnings("removal") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
     public void undeploy(@Observes final UnDeployDeployment event) throws Exception {
         executeOperation(new Callable<Void>() {
             @Inject

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
@@ -44,7 +44,11 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
 public class ContainerRegistryCreator {
     static final String ARQUILLIAN_LAUNCH_PROPERTY = "arquillian.launch";
     static final String ARQUILLIAN_LAUNCH_DEFAULT = "arquillian.launch_file";
-    @Deprecated
+    /**
+     * @deprecated Use {@link #ARQUILLIAN_LAUNCH_DEFAULT} instead. The {@code .launch} file extension caused warnings
+     * in Eclipse due to conflicts with Eclipse Launch Profile files (ARQ-1607).
+     */
+    @Deprecated(forRemoval = true, since = "1.1.5.Final")
     static final String ARQUILLIAN_LAUNCH_DEFAULT_DEPRECATED = "arquillian.launch";
 
     private Logger log = Logger.getLogger(ContainerRegistryCreator.class.getName());
@@ -169,6 +173,7 @@ public class ContainerRegistryCreator {
         }
     }
 
+    @SuppressWarnings("removal")
     private String getActivatedConfiguration() {
         if (exists(SecurityActions.getProperty(ARQUILLIAN_LAUNCH_PROPERTY))) {
             return SecurityActions.getProperty(ARQUILLIAN_LAUNCH_PROPERTY);

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
@@ -44,7 +44,11 @@ import org.jboss.arquillian.core.spi.ServiceLoader;
 public class ContainerRegistryCreator {
     static final String ARQUILLIAN_LAUNCH_PROPERTY = "arquillian.launch";
     static final String ARQUILLIAN_LAUNCH_DEFAULT = "arquillian.launch_file";
-    @Deprecated
+    /**
+     * @deprecated Use {@link #ARQUILLIAN_LAUNCH_DEFAULT} instead. The {@code .launch} file extension caused warnings
+     * in Eclipse due to conflicts with Eclipse Launch Profile files (ARQ-1607).
+     */
+    @Deprecated(forRemoval = true, since = "1.1.5.Final")
     static final String ARQUILLIAN_LAUNCH_DEFAULT_DEPRECATED = "arquillian.launch";
 
     private Logger log = Logger.getLogger(ContainerRegistryCreator.class.getName());

--- a/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
+++ b/container/impl-base/src/test/java/org/jboss/arquillian/container/impl/client/container/ContainerDeployControllerTestCase.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
  *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  */
-@SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
+@SuppressWarnings({"unchecked", "rawtypes", "removal"})
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerDeployControllerTestCase extends AbstractContainerTestBase {
     private static final String CONTAINER_1_NAME = "container_1";
@@ -156,7 +156,7 @@ public class ContainerDeployControllerTestCase extends AbstractContainerTestBase
         extensions.add(ContainerDeploymentContextHandler.class);
     }
 
-    @SuppressWarnings("deprecation") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
+    @SuppressWarnings("removal") // Suppress DeployableContainer#deploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
     @Test
     public void shouldDeployAllManagedDeployments() throws Exception {
         registry.create(container1, serviceLoader).setState(State.STARTED);
@@ -193,7 +193,7 @@ public class ContainerDeployControllerTestCase extends AbstractContainerTestBase
             scenario.deployment(new DeploymentTargetDescription(DEPLOYMENT_4_NAME)).getDescription().getDescriptor());
     }
 
-    @SuppressWarnings("deprecation") // Suppress DeployableContainer#undeploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
+    @SuppressWarnings("removal") // Suppress DeployableContainer#undeploy(org.jboss.shrinkwrap.descriptor.api.Descriptor)
     @Test
     public void shouldUnDeployAllManagedDeployments() throws Exception {
         registry.create(container1, serviceLoader).setState(State.STARTED);

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/container/DeployableContainer.java
@@ -190,7 +190,7 @@ public interface DeployableContainer<T extends ContainerConfiguration> {
      * @throws DeploymentException if deployment fails
      * @deprecated for removal. This method will be removed in a future version. Use {@link #deploy(Archive)} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.10.1.Final")
     default void deploy(Descriptor descriptor) throws DeploymentException {
         // The default implementation is a no-op.
     }
@@ -217,7 +217,7 @@ public interface DeployableContainer<T extends ContainerConfiguration> {
      * @throws DeploymentException if undeployment fails
      * @deprecated for removal. This method will be removed in a future version. Use {@link #undeploy(Archive)} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.10.1.Final")
     default void undeploy(Descriptor descriptor) throws DeploymentException {
         // The default implementation is a no-op.
     }

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentScenario.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/deployment/DeploymentScenario.java
@@ -86,7 +86,7 @@ public class DeploymentScenario {
         }
         Collections.sort(managedDeployment, new Comparator<Deployment>() {
             public int compare(Deployment o1, Deployment o2) {
-                return new Integer(o1.getDescription().getOrder()).compareTo(o2.getDescription().getOrder());
+                return Integer.valueOf(o1.getDescription().getOrder()).compareTo(o2.getDescription().getOrder());
             }
         });
 
@@ -103,7 +103,7 @@ public class DeploymentScenario {
         }
         Collections.sort(managedDeployment, new Comparator<Deployment>() {
             public int compare(Deployment o1, Deployment o2) {
-                return new Integer(o2.getDescription().getOrder()).compareTo(o1.getDescription().getOrder());
+                return Integer.valueOf(o2.getDescription().getOrder()).compareTo(o1.getDescription().getOrder());
             }
         });
 
@@ -131,7 +131,7 @@ public class DeploymentScenario {
         // sort them by order
         Collections.sort(startupDeployments, new Comparator<Deployment>() {
             public int compare(Deployment o1, Deployment o2) {
-                return new Integer(o1.getDescription().getOrder()).compareTo(o2.getDescription().getOrder());
+                return Integer.valueOf(o1.getDescription().getOrder()).compareTo(o2.getDescription().getOrder());
             }
         });
 

--- a/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
+++ b/container/spi/src/main/java/org/jboss/arquillian/container/spi/client/protocol/metadata/ProtocolMetaData.java
@@ -38,7 +38,13 @@ public class ProtocolMetaData {
         return false;
     }
 
-    @Deprecated
+    /**
+     * Returns the first context of the given type. Note that multiple contexts of the same type may exist;
+     * this method only returns the first match.
+     *
+     * @deprecated Use {@link #getContexts(Class)} instead, which returns all matching contexts.
+     */
+    @Deprecated(forRemoval = true, since = "1.0.0.CR8")
     public <T> T getContext(Class<T> clazz) {
         for (Object obj : contexts) {
             if (clazz.isInstance(obj)) {

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AbstractDeploymentScenarioGenerator.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/deployment/AbstractDeploymentScenarioGenerator.java
@@ -112,7 +112,7 @@ public abstract class AbstractDeploymentScenarioGenerator implements DeploymentS
         // sort them by order
         Collections.sort(deploymentDescriptions, new Comparator<DeploymentDescription>() {
             public int compare(DeploymentDescription d1, DeploymentDescription d2) {
-                return new Integer(d1.getOrder()).compareTo(d2.getOrder());
+                return Integer.valueOf(d1.getOrder()).compareTo(d2.getOrder());
             }
         });
     }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolDefinition.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/domain/ProtocolDefinition.java
@@ -100,7 +100,7 @@ public class ProtocolDefinition {
      */
     public ProtocolConfiguration createProtocolConfiguration(Map<String, String> configuration) throws Exception {
         Validate.notNull(configuration, "ProtocolConfiguration must be specified");
-        ProtocolConfiguration config = protocol.getProtocolConfigurationClass().newInstance();
+        ProtocolConfiguration config = protocol.getProtocolConfigurationClass().getDeclaredConstructor().newInstance();
         MapObject.populate(config, configuration);
         return config;
     }

--- a/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
+++ b/container/test-impl-base/src/test/java/org/jboss/arquillian/container/test/impl/enricher/resource/OperatesOnDeploymentAwareProviderBase.java
@@ -92,7 +92,7 @@ public abstract class OperatesOnDeploymentAwareProviderBase extends AbstractCont
         TestEnricher enricher = new ArquillianResourceTestEnricher();
         injector.get().inject(enricher);
 
-        X test = enrichType.cast(enrichType.newInstance());
+        X test = enrichType.cast(enrichType.getDeclaredConstructor().newInstance());
         enricher.enrich(test);
         return test;
     }
@@ -140,7 +140,7 @@ public abstract class OperatesOnDeploymentAwareProviderBase extends AbstractCont
             TestEnricher enricher = new ArquillianResourceTestEnricher();
             injector.get().inject(enricher);
 
-            X test = enrichType.cast(enrichType.newInstance());
+            X test = enrichType.cast(enrichType.getDeclaredConstructor().newInstance());
             enricher.enrich(test);
 
             return test;

--- a/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestDeployment.java
+++ b/container/test-spi/src/main/java/org/jboss/arquillian/container/test/spi/TestDeployment.java
@@ -53,8 +53,9 @@ public class TestDeployment {
      * @param auxiliaryArchives
      *     All extra library {@link Archive}s defined by extensions / core / frameworks.
      *
-     * @deprecated
+     * @deprecated Use {@link #TestDeployment(DeploymentDescription, Archive, Collection)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.0.0.CR7")
     public TestDeployment(Archive<?> applicationArchive, Collection<Archive<?>> auxiliaryArchives) {
         this(null, applicationArchive, auxiliaryArchives);
     }

--- a/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
+++ b/junit/core/src/main/java/org/jboss/arquillian/junit/State.java
@@ -54,7 +54,7 @@ public class State {
     private static ThreadLocal<Integer> lastCreatedRunner = new ThreadLocal<Integer>() {
         @Override
         protected Integer initialValue() {
-            return new Integer(0);
+            return Integer.valueOf(0);
         }
     };
 

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/JUnitJupiterTestClassLifecycleManager.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/JUnitJupiterTestClassLifecycleManager.java
@@ -23,8 +23,8 @@ import static org.jboss.arquillian.junit5.ContextStore.getContextStore;
  * manager instance exists per test suite execution.</p>
  */
 
-public class JUnitJupiterTestClassLifecycleManager implements AutoCloseable,
-    ExtensionContext.Store.CloseableResource {
+@SuppressWarnings("deprecation") // CloseableResource is deprecated since JUnit 5.13; remove when dropping JUnit 5.13 support
+public class JUnitJupiterTestClassLifecycleManager implements AutoCloseable, ExtensionContext.Store.CloseableResource {
     private static final String MANAGER_KEY = "testRunnerManager";
 
     private TestRunnerAdaptor adaptor;

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameters.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/MethodParameters.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@SuppressWarnings("deprecation") // CloseableResource is deprecated since JUnit 5.13; remove when dropping JUnit 5.13 support
 class MethodParameters implements AutoCloseable, ExtensionContext.Store.CloseableResource {
     private final Map<Integer, Object> parameters;
 

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/AbstractJMXProtocol.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/AbstractJMXProtocol.java
@@ -54,7 +54,7 @@ public abstract class AbstractJMXProtocol<T extends JMXProtocolConfiguration> im
     @Override
     public ContainerMethodExecutor getExecutor(T config, ProtocolMetaData metaData, CommandCallback callback) {
         if (metaData.hasContext(JMXContext.class)) {
-            MBeanServerConnection mbeanServer = metaData.getContext(JMXContext.class).getConnection();
+            MBeanServerConnection mbeanServer = metaData.getContexts(JMXContext.class).iterator().next().getConnection();
 
             Map<String, String> protocolProps = new HashMap<String, String>();
             try {

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
@@ -94,12 +94,14 @@ public class JMXTestRunner extends NotificationBroadcasterSupport implements JMX
     }
 
     @Override
+    @SuppressWarnings("removal")
     public byte[] runTestMethod(String className, String methodName) {
         TestResult result = runTestMethodInternal(className, methodName, new HashMap<String, String>());
         return Serializer.toByteArray(result);
     }
 
     @Override
+    @SuppressWarnings("removal")
     public byte[] runTestMethod(String className, String methodName, Map<String, String> protocolProps) {
         // detect if deprecated method is overridden in sub class, if so call it instead
         try {

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunner.java
@@ -94,6 +94,7 @@ public class JMXTestRunner extends NotificationBroadcasterSupport implements JMX
     }
 
     @Override
+    @SuppressWarnings("removal")
     public byte[] runTestMethod(String className, String methodName) {
         TestResult result = runTestMethodInternal(className, methodName, new HashMap<String, String>());
         return Serializer.toByteArray(result);

--- a/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunnerMBean.java
+++ b/protocols/jmx/src/main/java/org/jboss/arquillian/protocol/jmx/JMXTestRunnerMBean.java
@@ -43,9 +43,9 @@ public interface JMXTestRunnerMBean extends NotificationBroadcaster {
      *
      * @return a serialized {@link TestResult}
      *
-     * @deprecated
+     * @deprecated Use {@link #runTestMethod(String, String, java.util.Map)} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.8.Final")
     byte[] runTestMethod(String className, String methodName);
 
     /**

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestResult.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestResult.java
@@ -39,7 +39,10 @@ public final class TestResult implements Serializable {
     private long start;
     private long end;
 
-    @Deprecated
+    /**
+     * @deprecated Use {@link #passed(String)} or {@link #skipped(String)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status, String description) {
         this(status);
         this.description = description;
@@ -49,8 +52,10 @@ public final class TestResult implements Serializable {
      * Create a empty result.<br/>
      * <br/>
      * Start time is set to Current Milliseconds.
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult() {
         this(null);
     }
@@ -62,8 +67,10 @@ public final class TestResult implements Serializable {
      *
      * @param status
      *     The result status.
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status) {
         this(status, (Throwable) null);
     }
@@ -77,8 +84,10 @@ public final class TestResult implements Serializable {
      *     The result status.
      * @param throwable
      *     thrown exception if any
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped(Throwable)} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status, Throwable throwable) {
         this.status = status;
         setThrowable(throwable);
@@ -86,30 +95,37 @@ public final class TestResult implements Serializable {
         this.start = System.currentTimeMillis();
     }
 
+    @SuppressWarnings("removal")
     public static TestResult passed() {
         return new TestResult(Status.PASSED);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult passed(String description) {
         return new TestResult(Status.PASSED, description);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult skipped(Throwable cause) {
         return new TestResult(Status.SKIPPED, cause);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult skipped(String description) {
         return new TestResult(Status.SKIPPED, description);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult skipped() {
         return new TestResult(Status.SKIPPED);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult failed(Throwable cause) {
         return new TestResult(Status.FAILED, cause);
     }
 
+    @SuppressWarnings("removal")
     public static TestResult flatten(Collection<TestResult> results) {
         final TestResult combinedResult = new TestResult(Status.PASSED);
         final Map<Status, TestResult> resultsPerStatus = new HashMap<Status, TestResult>();
@@ -162,7 +178,6 @@ public final class TestResult implements Serializable {
         return status;
     }
 
-    @Deprecated
     public TestResult setStatus(Status status) {
         this.status = status;
         return this;
@@ -172,7 +187,11 @@ public final class TestResult implements Serializable {
         return description;
     }
 
-    @Deprecated
+    /**
+     * @deprecated Use the static factory methods {@link #passed(String)} or {@link #skipped(String)}
+     * to create a TestResult with a description instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public void setDescription(String description) {
         this.description = description;
     }

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestResult.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/TestResult.java
@@ -39,7 +39,10 @@ public final class TestResult implements Serializable {
     private long start;
     private long end;
 
-    @Deprecated
+    /**
+     * @deprecated Use {@link #passed(String)} or {@link #skipped(String)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status, String description) {
         this(status);
         this.description = description;
@@ -49,8 +52,10 @@ public final class TestResult implements Serializable {
      * Create a empty result.<br/>
      * <br/>
      * Start time is set to Current Milliseconds.
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult() {
         this(null);
     }
@@ -62,8 +67,10 @@ public final class TestResult implements Serializable {
      *
      * @param status
      *     The result status.
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status) {
         this(status, (Throwable) null);
     }
@@ -77,8 +84,10 @@ public final class TestResult implements Serializable {
      *     The result status.
      * @param throwable
      *     thrown exception if any
+     *
+     * @deprecated Use {@link #passed()}, {@link #failed(Throwable)}, or {@link #skipped(Throwable)} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public TestResult(Status status, Throwable throwable) {
         this.status = status;
         setThrowable(throwable);
@@ -162,7 +171,6 @@ public final class TestResult implements Serializable {
         return status;
     }
 
-    @Deprecated
     public TestResult setStatus(Status status) {
         this.status = status;
         return this;
@@ -172,7 +180,11 @@ public final class TestResult implements Serializable {
         return description;
     }
 
-    @Deprecated
+    /**
+     * @deprecated Use the static factory methods {@link #passed(String)} or {@link #skipped(String)}
+     * to create a TestResult with a description instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.1.12.Final")
     public void setDescription(String description) {
         this.description = description;
     }

--- a/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
+++ b/test/spi/src/test/java/org/jboss/arquillian/test/spi/ExceptionProxyTestCase.java
@@ -139,10 +139,10 @@ public class ExceptionProxyTestCase {
         // Create a ClassLoader for the target/serveronly-classes dir
         File serverOnlyClasses = new File("target/serveronly-classes");
         Assert.assertTrue("target/serveronly-classes should exist", serverOnlyClasses.exists());
-        URL[] serveronlyCP = {serverOnlyClasses.toURL()};
+        URL[] serveronlyCP = {serverOnlyClasses.toURI().toURL()};
         URLClassLoader classLoader = new URLClassLoader(serveronlyCP, getClass().getClassLoader());
         Class<IBean> exClass = (Class<IBean>) classLoader.loadClass("org.jboss.arquillian.test.spi.serveronly.SomeBean");
-        IBean bean = exClass.newInstance();
+        IBean bean = exClass.getDeclaredConstructor().newInstance();
         Throwable exception = null;
         try {
             bean.invoke();

--- a/testng/container/src/main/java/org/jboss/arquillian/testng/container/RemoveDependsOnTransformer.java
+++ b/testng/container/src/main/java/org/jboss/arquillian/testng/container/RemoveDependsOnTransformer.java
@@ -32,7 +32,6 @@ public class RemoveDependsOnTransformer implements IAnnotationTransformer {
     /* (non-Javadoc)
      * @see org.testng.IAnnotationTransformer#transform(org.testng.annotations.ITestAnnotation, java.lang.Class, java.lang.reflect.Constructor, java.lang.reflect.Method)
      */
-    @SuppressWarnings("rawtypes")
     @Override
     public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
         annotation.setDependsOnGroups(new String[0]);

--- a/testng/core/src/main/java/org/jboss/arquillian/testng/TestDataProviderTransformer.java
+++ b/testng/core/src/main/java/org/jboss/arquillian/testng/TestDataProviderTransformer.java
@@ -35,7 +35,6 @@ public class TestDataProviderTransformer implements IAnnotationTransformer {
     /* (non-Javadoc)
      * @see org.testng.IAnnotationTransformer#transform(org.testng.annotations.ITestAnnotation, java.lang.Class, java.lang.reflect.Constructor, java.lang.reflect.Method)
      */
-    @SuppressWarnings("rawtypes")
     public void transform(ITestAnnotation testAnnotation, Class clazz, Constructor constructor, Method method) {
         if (testAnnotation.getDataProviderClass() == null) {
             if (testAnnotation instanceof TestAnnotation) {


### PR DESCRIPTION
Quick test, `mvn clean install | grep WARNING | grep deprecated | grep -v AccessibleObject` is now empty result.

## Summary by Sourcery

Clarify and harden deprecation semantics across the codebase for JDK 11, while addressing related warnings and minor modernizations.

Bug Fixes:
- Ensure JMX protocol uses the correct JMX context retrieval API to obtain an MBeanServerConnection.
- Fix reflection usage and URL handling to be compatible with modern JDKs, avoiding deprecated constructors and methods.

Enhancements:
- Mark deprecated APIs with explicit for-removal flags and since versions, and update their Javadoc to point to preferred replacements.
- Adjust deprecation-related suppression annotations to use the JDK 11 "removal" category and add targeted suppressions for JUnit 5 CloseableResource deprecations.
- Improve integer and ThreadLocal initialization patterns by replacing obsolete Integer constructors with Integer.valueOf.
- Simplify TestNG transformers by removing unnecessary rawtype suppression annotations.

Tests:
- Update test code to align with new deprecation and reflection patterns, maintaining compatibility while keeping deprecation warnings controlled.