### PR TITLE
Add test case for JUnit Jupiter @Nested class - #773

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/ExpectedTrace.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/ExpectedTrace.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2026 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface ExpectedTrace {
+    String value();
+}

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
@@ -33,12 +33,16 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
- *
  * @author lprimak
  */
 public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
     ExtensionContext.Store.CloseableResource {
+
+    private static final String ARQUILLIAN_LIFECYCLE_TEST = "arquillianLifecycleTest";
+
     private static Path TMP_FILE_PATH;
+    private Class<?> testClass;
+
     static final String TMP_FILE_ASSET_NAME = "temporaryFileAsset";
 
     enum RunsWhere {
@@ -48,13 +52,20 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        Class<?> clazz = extensionContext.getRequiredTestClass();
+        if (clazz.getAnnotation(ExpectedTrace.class) == null) {
+            // for @Nested classes
+            return;
+        }
+        testClass = clazz;
         if (!isRunningOnServer()) {
-            Path tempDir = Files.createTempDirectory("arquillianLifecycleTest");
+            Path tempDir = Files.createTempDirectory(ARQUILLIAN_LIFECYCLE_TEST);
             initTmpFileName(tempDir);
             assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
             createTmpFile();
         }
-        extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL).put(this.getClass().getName(), this);
+        extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL)
+                .put(this.getClass().getName() + "." + testClass.getName(), this);
     }
 
     @Override
@@ -62,22 +73,23 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
         if (isRunningOnServer()) {
             return;
         }
-        String contents;
-        try (FileReader fileReader = new FileReader(getTmpFilePath().toFile())) {
-            char[] buf = new char[1000];
-            int length = fileReader.read(buf);
-            contents = new String(buf, 0, length - 1);
-        }
+        String contents = readFromFile();
         Path tempDir = getTmpFilePath().getParent();
         Files.walk(tempDir).map(Path::toFile).forEach(File::delete);
         assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
-        assertEquals("before_all,before_each,test_one,after_each,before_each,test_two,after_each,after_all", contents);
+
+        ExpectedTrace annotation = testClass.getAnnotation(ExpectedTrace.class);
+        if (annotation == null) {
+            throw new IllegalStateException("Test class " + testClass.getName() + " must be annotated with @"
+                    + ExpectedTrace.class.getSimpleName());
+        }
+        assertEquals(annotation.value(), contents);
     }
 
     static void initTmpFileName(Path tmpDirBase) {
         TMP_FILE_PATH = tmpDirBase.getParent().resolve(
-                tmpDirBase.getFileName() + "-arquillianLifecycleTest")
-            .resolve("lifecycleOutput");
+                tmpDirBase.getFileName() + "-" + ARQUILLIAN_LIFECYCLE_TEST)
+                .resolve("lifecycleOutput");
     }
 
     void createTmpFile() throws IOException {
@@ -103,6 +115,19 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
     static void appendToFile(String str) {
         try (FileWriter fw = new FileWriter(getTmpFilePath().toFile(), true)) {
             fw.append(str + ",");
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    static String readFromFile() {
+        try (FileReader fileReader = new FileReader(getTmpFilePath().toFile())) {
+            char[] buf = new char[10000];
+            int length = fileReader.read(buf);
+            if (length <= 0) {
+                return "";
+            }
+            return new String(buf, 0, length - 1);
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/LifecycleMethodsTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/LifecycleMethodsTest.java
@@ -17,25 +17,25 @@ package org.jboss.arquillian.integration.test.lifecycle;
 
 import jakarta.inject.Inject;
 import org.jboss.arquillian.container.test.api.Deployment;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.CLIENT;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.TMP_FILE_ASSET_NAME;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.appendToFile;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.checkRunsWhere;
-import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.getTmpFilePath;
-
 import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.TMP_FILE_ASSET_NAME;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.appendToFile;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.checkRunsWhere;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.getTmpFilePath;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.CLIENT;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(FileWriterExtension.class)
 @ArquillianTest
+@ExpectedTrace("before_all,before_each,test_one,after_each,before_each,test_two,after_each,after_all")
 public class LifecycleMethodsTest {
     @Inject
     Greeter greeter;
@@ -88,11 +89,11 @@ public class LifecycleMethodsTest {
         checkRunsWhere(CLIENT);
     }
 
-
     @Deployment
     static JavaArchive createDeployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
                 .addClass(FileWriterExtension.class)
+                .addClass(ExpectedTrace.class)
                 .addClass(Greeter.class)
                 .addAsResource(new StringAsset(getTmpFilePath().toString()), TMP_FILE_ASSET_NAME);
         return jar;

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/NestedClassTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/NestedClassTest.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2026 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.TMP_FILE_ASSET_NAME;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.appendToFile;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.checkRunsWhere;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.getTmpFilePath;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.CLIENT;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
+
+@Disabled("https://github.com/arquillian/arquillian-core/issues/773")
+@ExtendWith(FileWriterExtension.class)
+@ArquillianTest
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExpectedTrace("before_all,"
+        + "outer_before_each,outer_test,outer_after_each,"
+        + "outer_before_each,inner_before_each,nested_test,inner_after_each,outer_after_each,"
+        + "after_all")
+class NestedClassTest {
+
+    @Deployment
+    static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(FileWriterExtension.class, ExpectedTrace.class)
+                .addAsResource(new StringAsset(getTmpFilePath().toString()), TMP_FILE_ASSET_NAME)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        appendToFile("before_all");
+        checkRunsWhere(CLIENT);
+    }
+
+    @BeforeEach
+    void outerBeforeEach() {
+        appendToFile("outer_before_each");
+        // runs on both server and client
+    }
+
+    @AfterEach
+    void outerAfterEach() {
+        appendToFile("outer_after_each");
+        // runs on both server and client
+    }
+
+    @Test
+    @Order(1)
+    void outerTest() {
+        appendToFile("outer_test");
+        checkRunsWhere(SERVER);
+    }
+
+    @Nested
+    @Order(2)
+    class InnerTest {
+
+        @BeforeEach
+        void innerBeforeEach() {
+            appendToFile("inner_before_each");
+            checkRunsWhere(SERVER);
+        }
+
+        @AfterEach
+        void innerAfterEach() {
+            appendToFile("inner_after_each");
+            checkRunsWhere(SERVER);
+        }
+
+        @Test
+        void nestedTest() {
+            appendToFile("nested_test");
+            checkRunsWhere(SERVER);
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        appendToFile("after_all");
+        checkRunsWhere(CLIENT);
+    }
+}


### PR DESCRIPTION
Introduced a new test class for the `@Nested` test. Tried to reuse the `FileWriterExtension` pattern (for the persistent state between client and server/container) but had to make some changes since the `FileWriterExtension`  wasn't very flexible for other test cases.

## Summary by Sourcery

Add support in the lifecycle test infrastructure to assert configurable expected traces and introduce coverage for JUnit Jupiter nested test classes.

Enhancements:
- Make FileWriterExtension reusable across multiple lifecycle tests by parameterizing expected traces via an annotation and scoping its global store key per test class.
- Extract file reading logic in FileWriterExtension and centralize temporary file naming using a shared constant.
- Introduce the ExpectedTrace annotation to declare the expected lifecycle event sequence on a per-test-class basis.

Tests:
- Annotate the existing LifecycleMethodsTest with ExpectedTrace to validate its lifecycle event sequence declaratively.
- Add a new NestedClassTest (currently disabled) to verify lifecycle behavior and event ordering for JUnit Jupiter @Nested test classes.