### PR TITLE
Add integration test case for JUnit Jupiter @RepeatedTest class - #771

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/RepeatedTestTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/RepeatedTestTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2026 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.integration.test.lifecycle;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.TMP_FILE_ASSET_NAME;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.appendToFile;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.checkRunsWhere;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.getTmpFilePath;
+import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
+
+@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
+@ExtendWith(FileWriterExtension.class)
+@ArquillianTest
+@ExpectedTrace("repeated_test,repeated_test,repeated_test")
+class RepeatedTestTest {
+
+    @Deployment
+    static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(FileWriterExtension.class, ExpectedTrace.class)
+                .addAsResource(new StringAsset(getTmpFilePath().toString()), TMP_FILE_ASSET_NAME);
+    }
+
+    @RepeatedTest(3)
+    void repeatedTest() {
+        appendToFile("repeated_test");
+        checkRunsWhere(SERVER);
+    }
+}


### PR DESCRIPTION
Integration test case and reproducer for #771

Can be tested (after removing the `@Disabled` annotation) via:
```sh
./mvnw verify --file integration-tests/junit5-tests/pom.xml -Pwildfly -Dtest=RepeatedTestTest
# or
./mvnw verify --file integration-tests/junit5-tests/pom.xml -Ppayara -Dtest=RepeatedTestTest
```

The test is indeed executed 9 times (3^2) instead of 3 times.

## Summary by Sourcery

Tests:
- Introduce a disabled Arquillian JUnit Jupiter integration test class using @RepeatedTest to reproduce issue #771 regarding tests running more times than expected.