### PR TITLE
[#773] Add support for JUnit Jupiter @nested classes not running in the container

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/FileWriterExtension.java
@@ -15,6 +15,9 @@
  */
 package org.jboss.arquillian.integration.test.lifecycle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -27,20 +30,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * @author lprimak
  */
-public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
-    ExtensionContext.Store.CloseableResource {
+public class FileWriterExtension implements BeforeAllCallback, AutoCloseable {
 
     private static final String ARQUILLIAN_LIFECYCLE_TEST = "arquillianLifecycleTest";
 
     private static Path TMP_FILE_PATH;
+    private Path instanceTmpFilePath;
     private Class<?> testClass;
 
     static final String TMP_FILE_ASSET_NAME = "temporaryFileAsset";
@@ -63,6 +64,7 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
             initTmpFileName(tempDir);
             assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
             createTmpFile();
+            instanceTmpFilePath = TMP_FILE_PATH;
         }
         extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL)
                 .put(this.getClass().getName() + "." + testClass.getName(), this);
@@ -73,8 +75,8 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
         if (isRunningOnServer()) {
             return;
         }
-        String contents = readFromFile();
-        Path tempDir = getTmpFilePath().getParent();
+        String contents = readFromFile(instanceTmpFilePath);
+        Path tempDir = instanceTmpFilePath.getParent();
         Files.walk(tempDir).map(Path::toFile).forEach(File::delete);
         assertTrue(tempDir.toFile().delete(), "Cleanup Failed");
 
@@ -120,8 +122,8 @@ public class FileWriterExtension implements BeforeAllCallback, AutoCloseable,
         }
     }
 
-    static String readFromFile() {
-        try (FileReader fileReader = new FileReader(getTmpFilePath().toFile())) {
+    private static String readFromFile(Path path) {
+        try (FileReader fileReader = new FileReader(path.toFile())) {
             char[] buf = new char[10000];
             int length = fileReader.read(buf);
             if (length <= 0) {

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/NestedClassTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/NestedClassTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.ClassOrderer;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
@@ -43,7 +42,10 @@ import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtensio
 import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.CLIENT;
 import static org.jboss.arquillian.integration.test.lifecycle.FileWriterExtension.RunsWhere.SERVER;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/773")
+/**
+ * Verifies that JUnit Jupiter {@code @Nested} inner class tests run in the container (SERVER),
+ * sharing the deployment and lifecycle of the enclosing test class.
+ */
 @ExtendWith(FileWriterExtension.class)
 @ArquillianTest
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -1,5 +1,7 @@
 package org.jboss.arquillian.junit5;
 
+import static org.jboss.arquillian.junit5.JUnitJupiterTestClassLifecycleManager.getManager;
+
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Optional;
@@ -11,6 +13,7 @@ import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -24,8 +27,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.opentest4j.TestAbortedException;
 
-import static org.jboss.arquillian.junit5.JUnitJupiterTestClassLifecycleManager.getManager;
-
 /**
  * Implements several JUnit 5 extension API interfaces to adapt JUnit 5 tests for Arquillian.
  */
@@ -38,11 +39,18 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     /**
      * Called before all tests in the test class are executed.
      *
+     * <p>{@code @Nested} inner classes are skipped because the outer test class already fired
+     * {@code BeforeClass}, which generated the deployment and activated the class-scoped context.
+     * Firing it again for the inner class would create a separate, empty deployment scenario.</p>
+     *
      * @param context the current extension context
      * @throws Exception if any error occurs
      */
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
+        if (isNestedTestClass(context)) {
+            return;
+        }
         getManager(context).getAdaptor().beforeClass(
             context.getRequiredTestClass(),
             LifecycleMethodExecutor.NO_OP);
@@ -51,11 +59,17 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     /**
      * Called after all tests in the test class have been executed.
      *
+     * <p>{@code @Nested} inner classes are skipped because the outer test class handles
+     * undeployment and class-scoped context cleanup in its own {@code AfterClass} event.</p>
+     *
      * @param context the current extension context
      * @throws Exception if any error occurs
      */
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
+        if (isNestedTestClass(context)) {
+            return;
+        }
         getManager(context).getAdaptor().afterClass(
             context.getRequiredTestClass(),
             LifecycleMethodExecutor.NO_OP);
@@ -405,6 +419,15 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
         }
         // We should not reach this, but it's a safeguard in case a new status is ever added and missed here
         throw new AssertionError(result.getDescription());
+    }
+
+    /**
+     * Returns {@code true} if the test class in the given context is a JUnit 5 {@code @Nested} inner class.
+     * Nested classes share the deployment and lifecycle of their enclosing test class, so Arquillian
+     * must not fire class-level events ({@code BeforeClass}/{@code AfterClass}) for them independently.
+     */
+    private static boolean isNestedTestClass(ExtensionContext context) {
+        return context.getRequiredTestClass().isAnnotationPresent(Nested.class);
     }
 
     private static Optional<Throwable> failedAssertion(Throwable exception) {

--- a/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestEvent.java
+++ b/test/spi/src/main/java/org/jboss/arquillian/test/spi/event/suite/TestEvent.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.test.spi.event.suite;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * Base for events fired in the Test execution cycle.
@@ -45,12 +46,47 @@ public class TestEvent extends ClassEvent {
         this.testMethod = testMethod;
     }
 
-    // TODO: eeehh..?
+    /**
+     * Validates the test instance and method, and extracts the top-level test class.
+     *
+     * <p>Arquillian's class-scoped context — which holds the {@code DeploymentScenario}, container
+     * references, and other class-level state — is keyed on the class passed to
+     * {@link ClassEvent#ClassEvent(Class)}. For top-level test classes this is simply
+     * {@code testInstance.getClass()}. For JUnit 5 {@code @Nested} inner classes, however, the
+     * runtime class of the test instance is the inner class itself, while the deployment and
+     * class-scoped state belong to the outermost enclosing class (the one that declares the
+     * {@code @Deployment} method). If the inner class were used as the context key, Arquillian
+     * would activate an empty class context, find no deployment, and default to
+     * {@code runAsClient = true} — running the test on the client instead of in the container.</p>
+     *
+     * <p>To fix this, the method walks up the enclosing-class chain while the class is a
+     * non-static member class ({@code isMemberClass() && !isStatic()}). This is safe for all
+     * supported test frameworks:</p>
+     * <ul>
+     *   <li><b>JUnit 5</b> — {@code @Nested} classes are required to be non-static; JUnit 5
+     *       ignores the annotation on static inner classes. So the condition
+     *       {@code isMemberClass() && !isStatic()} matches exactly the set of {@code @Nested}
+     *       classes, without introducing a compile-time dependency on the JUnit 5 API in this
+     *       framework-agnostic SPI module.</li>
+     *   <li><b>JUnit 4 / TestNG</b> — neither framework supports non-static inner classes as
+     *       test classes, so {@code isMemberClass()} is always {@code false} and the loop is
+     *       never entered.</li>
+     * </ul>
+     *
+     * @param testInstance the test instance
+     * @param testMethod   the test method
+     * @return the outermost enclosing class, or the instance's own class if it is not a non-static member class
+     */
     private static Class<?> validateAndExtractClass(Object testInstance, Method testMethod) {
         Validate.notNull(testInstance, "TestInstance must be specified");
         Validate.notNull(testMethod, "TestMethod must be specified");
 
-        return testInstance.getClass();
+        Class<?> clazz = testInstance.getClass();
+        while (clazz.isMemberClass() && !Modifier.isStatic(clazz.getModifiers())) {
+            // This must be a @Nested class - return the enclosing class
+            clazz = clazz.getEnclosingClass();
+        }
+        return clazz;
     }
 
     public Object getTestInstance() {


### PR DESCRIPTION
Fixes https://github.com/arquillian/arquillian-core/issues/773

## Summary by Sourcery

Ensure JUnit 5 @Nested test classes share the outer test class context so they execute in-container instead of as client-side tests.

Bug Fixes:
- Correct class resolution for test events so non-static inner test classes use the outermost enclosing class for Arquillian class-scoped context and deployment lookup.
- Skip firing beforeAll/afterAll class-level lifecycle events for JUnit 5 @Nested inner classes, preventing creation of separate empty deployment scenarios.

Tests:
- Adjust the JUnit 5 lifecycle FileWriterExtension test helper to track per-instance temporary file paths for correct cleanup assertions in nested test scenarios.