### PR TITLE
[#801] Update project URLs and references especially to the user forum

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = Arquillian - So you can rule your code. Not the bugs.
-:asciidoctor-source: https://raw.githubusercontent.com/arquillian/arquillian-core/master/docs
+:asciidoctor-source: https://raw.githubusercontent.com/arquillian/arquillian-core/main/docs
 :numbered:
 :sectlink:
 :sectanchors:
@@ -31,7 +31,7 @@ Arquillian brings the test to the runtime so you don’t have to manage the runt
 * Executing the tests inside (or against) the container
 * Capturing the results and returning them to the test runner for reporting
 
-To avoid introducing unnecessary complexity into the developer’s build environment, Arquillian integrates seamlessly with familiar testing frameworks (e.g., JUnit 4, JUnit 5, TestNG 5), allowing tests to be launched using existing IDE, Ant and Maven test plugins — without any add-ons.
+To avoid introducing unnecessary complexity into the developer’s build environment, Arquillian integrates seamlessly with familiar testing frameworks (e.g., JUnit 4, JUnit 5 and 6, TestNG 5), allowing tests to be launched using existing IDE, Ant and Maven test plugins — without any add-ons.
 
 ifdef::generated-doc[]
 == Guide
@@ -50,7 +50,8 @@ endif::generated-doc[]
 
 == Useful URLs
 
-* https://arquillian.org[Project Site]
-* https://arquillian.org/guides[Guides]
-* http://discuss.arquillian.org/[Forum]
-* https://issues.redhat.com/browse/ARQ[Issue Tracker]
+* https://github.com/orgs/arquillian/discussions[User Forum – GitHub Discussions]
+* https://github.com/arquillian/arquillian-core/issues[Issue Tracker – GitHub Issues]
+* https://redhat.atlassian.net/browse/ARQ[Issue Tracker – Jira]
+* https://arquillian.org[Project Site] (pending updates)
+* https://arquillian.org/guides[Guides] (pending updates)

--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/container/ContainerRegistryCreator.java
@@ -186,7 +186,7 @@ public class ContainerRegistryCreator {
                         +
                         ". The .launch file extension caused warnings when found in Eclipse due to conflicts with the Eclipse Launch Profile files. "
                         +
-                        "See https://issues.jboss.org/browse/ARQ-1607 for more information.");
+                        "See https://redhat.atlassian.net/browse/ARQ-1607 for more information.");
             }
         }
         return qualifier;

--- a/docs/additional-features.adoc
+++ b/docs/additional-features.adoc
@@ -166,7 +166,7 @@ multiple internal objects.
 
 WARNING: Note that `@ArquillianResource` injection of URLs is only supported
 for in-container tests since Arquillian version 1.1.9.Final
-(see https://issues.jboss.org/browse/ARQ-540[ARQ-540]).
+(see https://redhat.atlassian.net/browse/ARQ-540[ARQ-540]).
 
 When you need to get a hold of the request URI (up through the context
 path) your `Deployment` defined, e.g. "http://localhost:8080/test", you

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.redhat.com/browse/ARQ</url>
+    <url>https://redhat.atlassian.net/browse/ARQ</url>
   </issueManagement>
 
   <licenses>


### PR DESCRIPTION
Update asciidoctor-source from master to main branch, update Jira links from issues.jboss.org and issues.redhat.com to redhat.atlassian.net, update useful links section with GitHub Discussions and current issue trackers, and update testing frameworks mention to include JUnit Jupiter 5 and 6.

## Summary by Sourcery

Update project and issue tracker URLs to current locations and refresh documentation references accordingly.

Enhancements:
- Update hard-coded Jira issue links and issueManagement configuration to point to the new redhat.atlassian.net tracker instead of legacy hosts.

Documentation:
- Refresh README and additional features documentation to reference the current user forum, GitHub Discussions, and updated testing framework versions.