### PR TITLE
[848] Ensure the deployment context gets destroyed after the undeploy…

### DIFF
--- a/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/ContainerDeploymentContextHandler.java
+++ b/container/impl-base/src/main/java/org/jboss/arquillian/container/impl/client/ContainerDeploymentContextHandler.java
@@ -17,10 +17,12 @@
  */
 package org.jboss.arquillian.container.impl.client;
 
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
 import org.jboss.arquillian.container.spi.context.ContainerContext;
 import org.jboss.arquillian.container.spi.context.DeploymentContext;
 import org.jboss.arquillian.container.spi.event.ContainerControlEvent;
 import org.jboss.arquillian.container.spi.event.DeploymentEvent;
+import org.jboss.arquillian.container.spi.event.UnDeployDeployment;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
@@ -70,6 +72,24 @@ public class ContainerDeploymentContextHandler {
             context.proceed();
         } finally {
             deploymentContext.deactivate();
+        }
+    }
+
+    /**
+     * Destroy the {@link DeploymentContext} after undeploy.
+     *
+     * @param context the events context
+     */
+    public void destroyDeploymentContext(@Observes EventContext<UnDeployDeployment> context) {
+        final DeploymentContext deploymentContext = this.deploymentContext.get();
+        try {
+            // Let undeploy happen first
+            context.proceed();
+        } finally {
+            // After undeploy completes, destroy the context
+            final UnDeployDeployment event = context.getEvent();
+            final Deployment deployment = event.getDeployment();
+            deploymentContext.destroy(deployment);
         }
     }
 }


### PR DESCRIPTION
…ing the deployment.


Fixes #848 
Upstream: #847

## Summary by Sourcery

Bug Fixes:
- Destroy the deployment context after undeploy events to prevent stale deployment state from persisting across operations.