### PR TITLE
fix: delegate @BeforeEach/@AfterEach interception to lifecycle event observers

### DIFF
--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionWithBeforeAfterEach.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionWithBeforeAfterEach.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.junit5.container;
+
+import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.Cycle;
+import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.wasCalled;
+
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ArquillianExtension.class)
+public class ClassWithArquillianExtensionWithBeforeAfterEach {
+
+    @BeforeEach
+    public void before() throws Exception {
+        wasCalled(Cycle.BEFORE);
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        wasCalled(Cycle.AFTER);
+    }
+
+    @Test
+    public void shouldBeInvoked() throws Exception {
+        wasCalled(Cycle.TEST);
+    }
+}

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitBeforeAfterEachInterceptionTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitBeforeAfterEachInterceptionTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.junit5.container;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import org.jboss.arquillian.junit5.extension.RunModeEvent;
+import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+/**
+ * Verifies that {@code @BeforeEach} and {@code @AfterEach} methods are correctly
+ * invoked or skipped depending on whether the lifecycle event observer invokes the
+ * executor — simulating local-container vs remote-container scenarios.
+ */
+public class JUnitBeforeAfterEachInterceptionTestCase extends JUnitTestBaseClass {
+
+    /**
+     * Simulates a local container where {@code isRunAsClient=false} (testable deployment)
+     * but the adaptor still invokes the executor (because {@code isLocalContainer=true}).
+     * This is the scenario that was broken before the fix — the interceptor's guard
+     * {@code IS_INSIDE_ARQUILLIAN || isRunAsClient} would skip directly without
+     * delegating to the adaptor.
+     */
+    @Test
+    public void shouldRunBeforeAfterEachForLocalContainerWithTestableDeployment() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+        // Make isRunAsClient() return false — simulates a testable deployment
+        // where RunModeEventHandler sets runAsClient=false.
+        doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof RunModeEvent) {
+                ((RunModeEvent) event).setRunAsClient(false);
+            }
+            return null;
+        }).when(adaptor).fireCustomLifecycle(any(TestLifecycleEvent.class));
+
+        TestExecutionSummary result = run(adaptor, ClassWithArquillianExtensionWithBeforeAfterEach.class);
+
+        Assertions.assertEquals(1, result.getTestsSucceededCount());
+        Assertions.assertEquals(0, result.getTestsFailedCount());
+        assertCycle(1, Cycle.BEFORE, Cycle.TEST, Cycle.AFTER);
+    }
+
+    /**
+     * Simulates a remote container where {@code isRunAsClient=false} and the adaptor
+     * does NOT invoke the executor (the container will run the methods itself).
+     * {@code @BeforeEach} and {@code @AfterEach} methods must be skipped on the client side.
+     */
+    @Test
+    public void shouldSkipBeforeAfterEachForRemoteContainerWithTestableDeployment() throws Exception {
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        // Make isRunAsClient() return false
+        doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof RunModeEvent) {
+                ((RunModeEvent) event).setRunAsClient(false);
+            }
+            return null;
+        }).when(adaptor).fireCustomLifecycle(any(TestLifecycleEvent.class));
+        // Only invoke the executor for beforeClass/afterClass and test — NOT for before/after.
+        // This simulates a remote container where ClientBeforeAfterLifecycleEventExecuter
+        // does not invoke the executor because isRunAsClient=false and isLocalContainer=false.
+        doAnswer(new ExecuteLifecycle()).when(adaptor).beforeClass(any(Class.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new ExecuteLifecycle()).when(adaptor).afterClass(any(Class.class), any(LifecycleMethodExecutor.class));
+        doAnswer(new TestExecuteLifecycle(TestResult.passed())).when(adaptor).test(any(TestMethodExecutor.class));
+
+        TestExecutionSummary result = run(adaptor, ClassWithArquillianExtensionWithBeforeAfterEach.class);
+
+        Assertions.assertEquals(1, result.getTestsSucceededCount());
+        Assertions.assertEquals(0, result.getTestsFailedCount());
+        assertCycle(0, Cycle.BEFORE, Cycle.AFTER);
+        assertCycle(1, Cycle.TEST);
+    }
+}

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -182,6 +182,11 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
     /**
      * Intercepts the execution of a @BeforeEach method.
      *
+     * <p>Delegates to {@code adaptor.before()} so that the registered lifecycle event observer
+     * (e.g. {@code ClientBeforeAfterLifecycleEventExecuter}) decides whether to invoke the method.
+     * The observer covers run-as-client, local-container and remote-container scenarios;
+     * the interceptor does not duplicate that decision.</p>
+     *
      * @param invocation the invocation to proceed or skip
      * @param invocationContext the reflective invocation context
      * @param extensionContext the current extension context
@@ -189,38 +194,33 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
      */
     @Override
     public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-            // Since the invocation is going to proceed, the invocation must happen within the context of SPI before()
-            final AtomicBoolean proceedInvoked = new AtomicBoolean(false);
-            try {
-                getManager(extensionContext).getAdaptor().before(
-                    extensionContext.getRequiredTestInstance(),
-                    extensionContext.getRequiredTestMethod(),
-                    () -> {
-                        proceedInvoked.set(true);
-                        invocation.proceed();
-                    });
-            } catch (Throwable t) {
-                // If before() threw before invoking the LifecycleMethodExecutor (e.g. due to a ServerSetupTask
-                // assumption failure), the JUnit 5 invocation was never consumed. Call skip() so JUnit does not
-                // generate "Chain of InvocationInterceptors never called invocation".
-                if (!proceedInvoked.get()) {
-                    invocation.skip();
-                }
-                throw t;
-            }
-            // If before() returned normally without calling the LifecycleMethodExecutor (e.g. DONT_EXECUTE
-            // decision after a failed deployment setup), the invocation must still be consumed.
+        final AtomicBoolean proceedInvoked = new AtomicBoolean(false);
+        try {
+            getManager(extensionContext).getAdaptor().before(
+                extensionContext.getRequiredTestInstance(),
+                extensionContext.getRequiredTestMethod(),
+                () -> {
+                    proceedInvoked.set(true);
+                    invocation.proceed();
+                });
+        } catch (Throwable t) {
             if (!proceedInvoked.get()) {
                 invocation.skip();
             }
-        } else {
+            throw t;
+        }
+        if (!proceedInvoked.get()) {
             invocation.skip();
         }
     }
 
     /**
      * Intercepts the execution of an @AfterEach method.
+     *
+     * <p>Delegates to {@code adaptor.after()} so that the registered lifecycle event observer
+     * (e.g. {@code ClientBeforeAfterLifecycleEventExecuter}) decides whether to invoke the method.
+     * The observer covers run-as-client, local-container and remote-container scenarios;
+     * the interceptor does not duplicate that decision.</p>
      *
      * @param invocation the invocation to proceed or skip
      * @param invocationContext the reflective invocation context
@@ -229,26 +229,22 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
      */
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (IS_INSIDE_ARQUILLIAN.test(extensionContext) || isRunAsClient(extensionContext)) {
-            final AtomicBoolean proceedInvoked = new AtomicBoolean(false);
-            try {
-                getManager(extensionContext).getAdaptor().after(
-                    extensionContext.getRequiredTestInstance(),
-                    extensionContext.getRequiredTestMethod(),
-                    () -> {
-                        proceedInvoked.set(true);
-                        invocation.proceed();
-                    });
-            } catch (Throwable t) {
-                if (!proceedInvoked.get()) {
-                    invocation.skip();
-                }
-                throw t;
-            }
+        final AtomicBoolean proceedInvoked = new AtomicBoolean(false);
+        try {
+            getManager(extensionContext).getAdaptor().after(
+                extensionContext.getRequiredTestInstance(),
+                extensionContext.getRequiredTestMethod(),
+                () -> {
+                    proceedInvoked.set(true);
+                    invocation.proceed();
+                });
+        } catch (Throwable t) {
             if (!proceedInvoked.get()) {
                 invocation.skip();
             }
-        } else {
+            throw t;
+        }
+        if (!proceedInvoked.get()) {
             invocation.skip();
         }
     }


### PR DESCRIPTION
#### Short description of what this resolves:

Hey, I am trying to migrate the Jakarta Validation TCK from TestNG to JUnit, and I've run into an issue with tests executed in the standalone mode ... where the before/after each never got executed... 
At first I was going to try and create a new module for junit-jupiter-standalone to match the junit4 structure .. but then I thought I'd ask AI to see if my thinking is ok and it suggests we don't really need one and that those guards aren't needed and we should just always delegate to the adapter ... 
For extra info: Jakarta TCK has its own standalone-container-adapter 

#### Changes proposed in this pull request:

- removes the guards from intercepting methods and always delegates to the adapter


Fixes #

I'll open it as a draft, and if you think the approach is valid and I didn't miss anything during the migration, I'll also open an issue for it 🤞🏻 🙂 Thanks!

## Summary by Sourcery

Tests:
- Add JUnit 5 container tests to verify @BeforeEach/@AfterEach are executed for local-container testable deployments and skipped for remote-container scenarios based on lifecycle observer behavior.