### PR TITLE
Publish documentation

### DIFF
--- a/.github/actions/build-documentation/action.yml
+++ b/.github/actions/build-documentation/action.yml
@@ -1,0 +1,25 @@
+name: Build documentation
+description: Builds the Arquillian documentation using Asciidoctor
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+
+    - name: Install Asciidoctor
+      run: gem install asciidoctor --version 2.0.26 --no-document
+      shell: bash
+
+    - name: Build documentation
+      run: |
+        mkdir -p target/docs
+        asciidoctor README.adoc \
+          --attribute generated-doc=true \
+          --attribute asciidoctor-source=docs \
+          --out-file target/docs/index.html
+        test -s target/docs/index.html
+        grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' target/docs/index.html
+      shell: bash

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - README.adoc
       - 'docs/**'
+      - .github/actions/build-documentation/action.yml
       - .github/workflows/documentation-build.yml
       - .github/workflows/documentation-publish.yml
 
@@ -23,20 +24,5 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v7
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-
-      - name: Install Asciidoctor
-        run: gem install asciidoctor --version 2.0.26 --no-document
-
       - name: Build documentation
-        run: |
-          mkdir -p target/docs
-          asciidoctor README.adoc \
-            --attribute generated-doc=true \
-            --attribute asciidoctor-source=docs \
-            --out-file target/docs/index.html
-          test -s target/docs/index.html
-          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' target/docs/index.html
+        uses: ./.github/actions/build-documentation

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,0 +1,42 @@
+name: Build documentation
+
+on:
+  pull_request:
+    paths:
+      - README.adoc
+      - 'docs/**'
+      - .github/workflows/documentation-build.yml
+      - .github/workflows/documentation-publish.yml
+
+concurrency:
+  group: documentation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Install Asciidoctor
+        run: gem install asciidoctor --version 2.0.26 --no-document
+
+      - name: Build documentation
+        run: |
+          mkdir -p target/docs
+          asciidoctor README.adoc \
+            --attribute generated-doc=true \
+            --attribute asciidoctor-source=docs \
+            --out-file target/docs/index.html
+          test -s target/docs/index.html
+          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' target/docs/index.html

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - README.adoc
       - 'docs/**'
+      - .github/actions/build-documentation/action.yml
       - .github/workflows/documentation-build.yml
       - .github/workflows/documentation-publish.yml
 
@@ -25,23 +26,8 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v7
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'
-
-      - name: Install Asciidoctor
-        run: gem install asciidoctor --version 2.0.26 --no-document
-
       - name: Build documentation
-        run: |
-          mkdir -p target/docs
-          asciidoctor README.adoc \
-            --attribute generated-doc=true \
-            --attribute asciidoctor-source=docs \
-            --out-file target/docs/index.html
-          test -s target/docs/index.html
-          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' target/docs/index.html
+        uses: ./.github/actions/build-documentation
 
       - name: Upload documentation
         uses: actions/upload-artifact@v7

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -7,13 +7,8 @@ on:
     paths:
       - README.adoc
       - 'docs/**'
-      - .github/workflows/documentation.yml
-  pull_request:
-    paths:
-      - README.adoc
-      - 'docs/**'
-      - .github/workflows/documentation.yml
-  workflow_dispatch:
+      - .github/workflows/documentation-build.yml
+      - .github/workflows/documentation-publish.yml
 
 concurrency:
   group: documentation-${{ github.ref }}
@@ -23,6 +18,7 @@ jobs:
   build:
     name: Build documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -39,54 +35,43 @@ jobs:
 
       - name: Build documentation
         run: |
-          mkdir -p site
+          mkdir -p target/docs
           asciidoctor README.adoc \
             --attribute generated-doc=true \
             --attribute asciidoctor-source=docs \
-            --out-file site/index.html
-          test -s site/index.html
-          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' site/index.html
+            --out-file target/docs/index.html
+          test -s target/docs/index.html
+          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' target/docs/index.html
 
       - name: Upload documentation
         uses: actions/upload-artifact@v7
         with:
           name: documentation
-          path: site/index.html
+          path: target/docs/index.html
           if-no-files-found: error
 
   publish:
     name: Publish documentation
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'arquillian/arquillian-core'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Download documentation
         uses: actions/download-artifact@v8
         with:
           name: documentation
-          path: site
+          path: target/docs
 
       - name: Publish to gh-pages
-        env:
-          GH_PAGES_DIR: ${{ runner.temp }}/gh-pages
-        run: |
-          git fetch origin gh-pages
-          git worktree add "$GH_PAGES_DIR" origin/gh-pages
-          cp site/index.html "$GH_PAGES_DIR/index.html"
-          cd "$GH_PAGES_DIR"
-          git add index.html
-          if git diff --cached --quiet; then
-            echo 'Documentation is already up to date.'
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -m "Publish documentation for ${GITHUB_SHA::7}"
-          git push origin HEAD:gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: target/docs
+          git-config-name: alien-ike
+          git-config-email: arquillian-team@lists.jboss.org

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,92 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.adoc
+      - 'docs/**'
+      - .github/workflows/documentation.yml
+  pull_request:
+    paths:
+      - README.adoc
+      - 'docs/**'
+      - .github/workflows/documentation.yml
+  workflow_dispatch:
+
+concurrency:
+  group: documentation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Install Asciidoctor
+        run: gem install asciidoctor --version 2.0.26 --no-document
+
+      - name: Build documentation
+        run: |
+          mkdir -p site
+          asciidoctor README.adoc \
+            --attribute generated-doc=true \
+            --attribute asciidoctor-source=docs \
+            --out-file site/index.html
+          test -s site/index.html
+          grep -q '<title>Arquillian - So you can rule your code. Not the bugs.</title>' site/index.html
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v7
+        with:
+          name: documentation
+          path: site/index.html
+          if-no-files-found: error
+
+  publish:
+    name: Publish documentation
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Download documentation
+        uses: actions/download-artifact@v8
+        with:
+          name: documentation
+          path: site
+
+      - name: Publish to gh-pages
+        env:
+          GH_PAGES_DIR: ${{ runner.temp }}/gh-pages
+        run: |
+          git fetch origin gh-pages
+          git worktree add "$GH_PAGES_DIR" origin/gh-pages
+          cp site/index.html "$GH_PAGES_DIR/index.html"
+          cd "$GH_PAGES_DIR"
+          git add index.html
+          if git diff --cached --quiet; then
+            echo 'Documentation is already up to date.'
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "Publish documentation for ${GITHUB_SHA::7}"
+          git push origin HEAD:gh-pages


### PR DESCRIPTION
## Summary by Sourcery

Add automation to build and publish Asciidoctor-based project documentation on changes to README or docs.

Build:
- Introduce a GitHub Actions workflow to build documentation from README.adoc using Asciidoctor and store the generated HTML as an artifact.

CI:
- Set up a documentation workflow triggered by pushes and pull requests touching docs files, with concurrency control and artifact upload.

Deployment:
- Automatically deploy the generated documentation to the gh-pages branch on pushes to the main branch in the main repository.