### PR TITLE
[#808] Add JUnit 6 testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,25 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --no-transfer-progress clean verify
+
+  # Test JUnit Jupiter module with JUnit 6.x (requires Java 17+)
+  junit6-verify:
+    name: Verify JUnit Jupiter with JUnit 6.x - JDK ${{ matrix.java }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        java:
+          - 17
+          - 21
+    steps:
+      - name: Checkout arquillian-core
+        uses: actions/checkout@v7
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: maven
+      - name: Build with JUnit 6.x
+        run: mvn --batch-mode --no-transfer-progress clean verify -Pjunit6 -pl junit5/core,junit5/container -am

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -25,7 +25,7 @@
     <!-- Arquillian Core common Deps, Test related -->
     <version.javax.inject>1</version.javax.inject>
     <version.junit>4.13.2</version.junit>
-    <version.junit5>5.14.4</version.junit5>
+    <version.junit-jupiter>5.14.4</version.junit-jupiter>
     <version.mockito>4.11.0</version.mockito>
     <version.testng>7.5</version.testng>
     <version.assertj>3.27.7</version.assertj>
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
+        <version>${version.junit-jupiter}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -96,4 +96,15 @@
 
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <!-- Profile to test with JUnit 6.x (requires Java 17+) -->
+    <profile>
+      <id>junit6</id>
+      <properties>
+        <version.junit-jupiter>6.1.2</version.junit-jupiter>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Add a Maven profile 'junit6' that overrides the JUnit version to 6.0.3 and a CI job that tests the JUnit Jupiter module with JUnit 6 on Java 17 and 21 to verify compat.

## Summary by Sourcery

Add support for testing the JUnit Jupiter module against JUnit 6 in CI while enforcing Java 8 API compatibility in the build.

New Features:
- Introduce a Maven profile to run the JUnit Jupiter modules against JUnit 6.0.3.

Enhancements:
- Rename the JUnit 5 version property to a more specific junit-jupiter property for clearer version management.

Build:
- Configure the animal-sniffer Maven plugin to verify Java 8 API compatibility during the build.

CI:
- Add a GitHub Actions job to run the JUnit Jupiter modules with the junit6 Maven profile on Java 17 and 21.