### PR TITLE
[#870] Overhaul out-of-date documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ Arquillian brings the test to the runtime so you don’t have to manage the runt
 * Executing the tests inside (or against) the container
 * Capturing the results and returning them to the test runner for reporting
 
-To avoid introducing unnecessary complexity into the developer’s build environment, Arquillian integrates seamlessly with familiar testing frameworks (e.g., JUnit 4, JUnit 5 and 6, TestNG 5), allowing tests to be launched using existing IDE, Ant and Maven test plugins — without any add-ons.
+To avoid introducing unnecessary complexity into the developer’s build environment, Arquillian integrates seamlessly with familiar testing frameworks (e.g., JUnit 4, JUnit 5 and 6, TestNG 7), allowing tests to be launched using existing IDE, Ant and Maven test plugins — without any add-ons.
 
 ifdef::generated-doc[]
 == Guide

--- a/docs/additional-features.adoc
+++ b/docs/additional-features.adoc
@@ -53,7 +53,7 @@ remotely. In this mode, the test executes in the remote container.
 
 _Arquillian uses this mode by default._
 
-See the Complete Protocol Reference for an overview of the expected
+See <<protocols, Protocols>> for an overview of the expected
 output of the packaging process when you provide a `@Deployment`.
 
 [[client-mode]]
@@ -67,7 +67,33 @@ in your JVM as expected and you're free to test the container from the
 outside, as your clients see it. The only thing Arquillian does is to
 control the lifecycle of your `@Deployment`.
 
-Here is an example calling a Servlet using the `as client` mode.
+Here is an example calling a Servlet using the `as client` mode, on
+JUnit Jupiter (JUnit 5 and 6):
+
+[source,java]
+----
+@ExtendWith(ArquillianExtension.class)
+public class LocalRunServletTestCase {
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+                .addClass(TestServlet.class);
+    }
+
+    @Test
+    public void shouldBeAbleToCallServlet(@ArquillianResource(TestServlet.class) URL baseUrl) throws Exception {
+        String body = readAllAndClose(new URL(baseUrl, "/Test").openStream());
+        Assertions.assertEquals(
+            "hello",
+            body,
+            "Verify that the servlet was deployed and returns the expected result");
+    }
+}
+----
+
+The same test written for JUnit 4 — note that the runner declaration
+differs and that JUnit 4's `Assert` takes the message as the *first*
+argument rather than the last:
 
 [source,java]
 ----
@@ -77,7 +103,7 @@ public class LocalRunServletTestCase {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "test.war")
                 .addClass(TestServlet.class);
-   }
+    }
 
     @Test
     public void shouldBeAbleToCallServlet(@ArquillianResource(TestServlet.class) URL baseUrl) throws Exception {
@@ -86,7 +112,7 @@ public class LocalRunServletTestCase {
             "Verify that the servlet was deployed and returns the expected result",
             "hello",
             body);
-   }
+    }
 }
 ----
 
@@ -165,8 +191,8 @@ this in your test, Arquillian provides something we call
 multiple internal objects.
 
 WARNING: Note that `@ArquillianResource` injection of URLs is only supported
-for in-container tests since Arquillian version 1.1.9.Final
-(see https://redhat.atlassian.net/browse/ARQ-540[ARQ-540]).
+for in-container tests since Arquillian version 1.1.9.Final
+(see https://redhat.atlassian.net/browse/ARQ-540[ARQ-540]).
 
 When you need to get a hold of the request URI (up through the context
 path) your `Deployment` defined, e.g. "http://localhost:8080/test", you
@@ -246,11 +272,13 @@ Arquillian configuration.
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
     <group qualifier="tomcat-cluster" default="true">
         <container qualifier="container-1" default="true">
             <configuration>
-                <property name="tomcatHome">target/tomcat-embedded-6-standby</property>
+                <property name="tomcatHome">target/tomcat-standby</property>
                 <property name="workDir">work</property>
                 <property name="bindHttpPort">8880</property>
                 <property name="unpackArchive">true</property>
@@ -258,7 +286,7 @@ Arquillian configuration.
         </container>
         <container qualifier="container-2">
             <configuration>
-                <property name="tomcatHome">target/tomcat-embedded-6-active-1</property>
+                <property name="tomcatHome">target/tomcat-active-1</property>
                 <property name="workDir">work</property>
                 <property name="bindHttpPort">8881</property>
                 <property name="unpackArchive">true</property>
@@ -331,10 +359,11 @@ packaging requirements hinder how you define your archive, or you simply
 can not communicate with the container using the default protocol due to
 e.g. firewall settings.
 
-Arquillian only supports Servlet 2.5 and Servlet 3.0 at this time. EJB
-3.0 and 3.1 are planned. But you might implement your own Protocol. For
-doing this, please see the Complete Protocol Reference for the better
-knowing what is currently supported.
+Arquillian Core ships the Local, Servlet 2.5 and Servlet 3.0 protocols,
+plus a JMX protocol base that container adapters build on. Container
+adapters may contribute further protocols, and you can implement your
+own. See <<protocols, Protocols>> for what each of the bundled protocols
+does and how it can be configured.
 
 [[enabling-assertions]]
 ==== Enabling Assertions
@@ -349,29 +378,34 @@ container. You may want to consider specifying the package names of your
 test classes to avoid assertions to be enabled throughout the
 container's source code.
 
-[[enabling-assertions-in-jboss-as]]
-===== Enabling Assertions In JBoss AS
+[[enabling-assertions-in-wildfly]]
+===== Enabling Assertions In WildFly
 
-If you are using JBoss AS, the quickest way to setup debug mode is to
-add the following line to the end of $JBOSS_AS_HOME/bin/run.conf
+If you are using WildFly, the quickest way to enable assertions is to
+add the following line to the end of $JBOSS_HOME/bin/standalone.conf
 (Unix/Linux):
 
-[source,java]
+[source,bash]
 ----
 JAVA_OPTS="$JAVA_OPTS -ea"
 ----
 
-or before the line :JAVA_OPTS_SET in $JBOSS_AS_HOME/bin/run.conf.bat
+or before the line :JAVA_OPTS_SET in $JBOSS_HOME/bin/standalone.conf.bat
 (Windows)
 
-[source,java]
+[source,batch]
 ----
 set "JAVA_OPTS=%JAVA_OPTS% -ea"
 ----
 
 Keep in mind your container will always run with assertions enabled
 after making this change. You might want to consider putting some logic
-in the run.conf* file.
+in the standalone.conf* file.
+
+TIP: With a managed container adapter you can usually pass `-ea` through
+the adapter's own configuration instead — for example the `javaVmArguments`
+property of the WildFly managed adapter — which keeps the change scoped
+to the test run.
 
 As an alternative, we recommend using the 'Assert' object that comes
 with your test framework instead to avoid the whole issue. Also keep in

--- a/docs/additional-features.adoc
+++ b/docs/additional-features.adoc
@@ -73,7 +73,7 @@ JUnit Jupiter (JUnit 5 and 6):
 [source,java]
 ----
 @ExtendWith(ArquillianExtension.class)
-public class LocalRunServletTestCase {
+class LocalRunServletTestCase {
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "test.war")
@@ -81,7 +81,7 @@ public class LocalRunServletTestCase {
     }
 
     @Test
-    public void shouldBeAbleToCallServlet(@ArquillianResource(TestServlet.class) URL baseUrl) throws Exception {
+    void shouldBeAbleToCallServlet(@ArquillianResource(TestServlet.class) URL baseUrl) throws Exception {
         String body = readAllAndClose(new URL(baseUrl, "/Test").openStream());
         Assertions.assertEquals(
             "hello",

--- a/docs/advanced-topics.adoc
+++ b/docs/advanced-topics.adoc
@@ -27,6 +27,12 @@ In case you want to add an additional observer that will be applied only to one 
 
 [source,java]
 ----
+// JUnit Jupiter (JUnit 5 and 6)
+@ExtendWith(ArquillianExtension.class)
+@Observer(MyObserver.class)
+public class MyTestCase {
+
+// JUnit 4
 @RunWith(Arquillian.class)
 @Observer(MyObserver.class)
 public class MyTestCase {

--- a/docs/advanced-topics.adoc
+++ b/docs/advanced-topics.adoc
@@ -30,7 +30,7 @@ In case you want to add an additional observer that will be applied only to one 
 // JUnit Jupiter (JUnit 5 and 6)
 @ExtendWith(ArquillianExtension.class)
 @Observer(MyObserver.class)
-public class MyTestCase {
+class MyTestCase {
 
 // JUnit 4
 @RunWith(Arquillian.class)

--- a/docs/build-integration.adoc
+++ b/docs/build-integration.adoc
@@ -155,7 +155,7 @@ and JUnit dependencies below are declared without a version.
 TIP: Use `org.jboss.arquillian.junit:arquillian-junit-container` instead if
 your tests are written against JUnit 4, or
 `org.jboss.arquillian.testng:arquillian-testng-container` for TestNG.
-Testing on a Jakarta EE 9+ container? Import
+If you are testing on a Jakarta EE 9+ container, import
 `org.jboss.arquillian.jakarta:arquillian-jakarta-bom` and use the
 `org.jboss.arquillian.jakarta` artifacts instead.
 

--- a/docs/build-integration.adoc
+++ b/docs/build-integration.adoc
@@ -71,7 +71,7 @@ https://arquillian.org/guides/[Arquillian Guides].
 [[gradle]]
 ==== Gradle
 
-http://gradle.org[Gradle] is a build tool that allows you to create
+https://gradle.org[Gradle] is a build tool that allows you to create
 declarative, maintainable, concise and highly-performing builds. More
 importantly, in this context, Gradle gives you all the freedom you need
 instead of imposing a rigid build lifecycle on you. You'll get a glimpse
@@ -82,7 +82,7 @@ We'll be contrasting two strategies for running Arquillian tests from
 Gradle:
 
 1.  Container-specific test tasks
-2.  Test "profiles" via build fragment imports
+2.  Test "profiles" via a project property
 
 The first strategy is the recommended one since it gives you the benefit
 of being able to run your tests on multiple containers in the same
@@ -91,154 +91,92 @@ familiar to Maven users. Of course, Gradle is so flexible that there are
 likely other solutions for this problem. We invite you to give us
 feedback if you find a better way (or another way worth documenting).
 
+NOTE: The examples below use the Groovy DSL (`build.gradle`) and assume a
+reasonably recent Gradle version. Container adapters are released
+independently of Arquillian Core, so substitute the adapter coordinates
+and versions that match the container you are targeting.
+
 Let's get the common build stuff out of the way, then dive into the two
 strategies listed above.
 
-===== apply from: common
+===== The common build
 
-The simplest Gradle build for a Java project is a sparse one line.
+The simplest Gradle build for a Java project is a sparse few lines.
 
-[source,java]
+[source,groovy]
 ----
-apply plugin: JavaPlugin
-----
-
-Put this line into a file named build.gradle at the root of the project,
-which is the standard location of the Gradle build file. (Perhaps after
-seeing this configuration you'll understand the reference in the section
-title).
-
-Next we'll add the Maven Central and JBoss Community repository
-definitions, so that we can pull down dependent libraries. The latter
-repository hosts the Arquillian artifacts.
-
-[source,java]
-----
-apply plugin: JavaPlugin
+plugins {
+    id 'java'
+}
 
 repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
+    mavenCentral()
 }
 ----
 
-If your SCM (e.g., SVN, Git) is already ignoring the target directory,
-you may want to move the Gradle build output underneath this folder,
-rather than allowing Gradle to use it's default build directory, build.
-Let's add that configuration to the common build logic as well:
+Put this into a file named build.gradle at the root of the project,
+which is the standard location of the Gradle build file. Arquillian and
+the common container adapters are all published to Maven Central, so no
+extra repository declarations are needed.
 
-[source,java]
+We recommend centralizing version numbers at the top of your build to
+make upgrading your dependencies easy. Better still, let the Arquillian
+BOM manage them for you:
+
+[source,groovy]
 ----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
+ext {
+    // substitute the current releases
+    arquillianVersion = '<arquillian.version>'
+    junitVersion = '<junit.version>'
+    jakartaeeVersion = '<jakartaee.version>'
+    weldAdapterVersion = '<weld.adapter.version>'
+    weldVersion = '<weld.version>'
+    wildflyArquillianVersion = '<wildfly.arquillian.version>'
 }
-----
 
-If you are using Gradle alongside Maven, you shouldn't set the buildDir
-to target since Gradle organizes compiled classes different than Maven
-does, possibly leading to conflicts (Though, the behavior of Gradle can
-also be customized).
-
-We also recommend that you centralize version numbers at the top of your
-build to make upgrading your dependency easy. This list will grow as you
-add other containers, but we'll seed the list for the examples below:
-
-[source,java]
-----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-libraryVersions = [
-   junit: '4.8.1', arquillian: '1.0.0.Alpha4', jbossJavaeeSpec: '1.0.0.Beta7', weld: '1.0.1-Final',
-   slf4j: '1.5.8', log4j: '1.2.14', jbossas: '6.0.0.Final', glassfish: '3.0.1-b20', cdi: '1.0-SP1'
-]
-
-...
-----
-
-We also need to add the unit test library (JUnit or TestNG) and the
-corresponding Arquillian integration:
-
-[source,java]
-----
 dependencies {
-   testCompile group: 'junit', name: 'junit', version: libraryVersions.junit
-   testCompile group: 'org.jboss.arquillian', name: 'arquillian-junit', version: libraryVersions.arquillian
+    testImplementation platform("org.jboss.arquillian:arquillian-bom:${arquillianVersion}")
+    testImplementation platform("org.junit:junit-bom:${junitVersion}")
+
+    testImplementation 'org.jboss.arquillian.junit5:arquillian-junit5-container'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+    useJUnitPlatform()
 }
 ----
+
+Both BOMs are imported with `platform(...)`, so the individual Arquillian
+and JUnit dependencies below are declared without a version.
+
+TIP: Use `org.jboss.arquillian.junit:arquillian-junit-container` instead if
+your tests are written against JUnit 4, or
+`org.jboss.arquillian.testng:arquillian-testng-container` for TestNG.
+Testing on a Jakarta EE 9+ container? Import
+`org.jboss.arquillian.jakarta:arquillian-jakarta-bom` and use the
+`org.jboss.arquillian.jakarta` artifacts instead.
 
 In this example, we'll assume the project is compiling against APIs that
-are provided by the target container runtime, so we need to add a
-dependency configuration (aka scope) to include libraries on the compile
-classpath but excluded from the runtime classpath. In the future, Gradle
-will include support for such a scope. Until then, we'll define one
-ourselves in the configurations closure.
+are provided by the target container runtime. Gradle has a built-in
+`compileOnly` configuration for exactly that — libraries on the compile
+classpath but excluded from the runtime classpath:
 
-[source,java]
+[source,groovy]
 ----
-configurations {
-   compileOnly
-}
-----
-
-We also need to add the dependencies associated with that configuration
-to the compile classpaths using the sourceSets closure:
-
-[source,java]
-----
-sourceSets {
-   main {
-      compileClasspath = configurations.compile + configurations.compileOnly
-   }
-   test {
-      compileClasspath = compileClasspath + configurations.compileOnly
-   }
-}
-----
-
-Here's the Gradle build all together now:
-
-[source,java]
-----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-libraryVersions = [
-   junit: '4.8.1', arquillian: '1.0.0.Alpha3', jbossJavaeeSpec: '1.0.0.Beta7', weld: '1.0.1-Final',
-   slf4j: '1.5.8', log4j: '1.2.14', jbossas: '6.0.0.Final', glassfish: '3.0.1-b20', cdi: '1.0-SP1'
-]
-
-repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
-}
-
-configurations {
-   compileOnly
-}
-
-sourceSets {
-   main {
-      compileClasspath = configurations.compile + configurations.compileOnly
-   }
-   test {
-      compileClasspath = compileClasspath + configurations.compileOnly
-   }
+dependencies {
+    compileOnly "jakarta.platform:jakarta.jakartaee-api:${jakartaeeVersion}"
 }
 ----
 
 Now that the foundation of a build is in place (or you've added these
-elements to your existing Gradle build), we are ready to configuring the
+elements to your existing Gradle build), we are ready to configure the
 container-specific test tasks. In the first approach, we'll create a
 unique dependency configuration and task for each container.
 
+[[strategy-container-specific-test-tasks]]
 ===== Strategy #1: Container-Specific Test Tasks
 
 Each project in Gradle is made up of one or more tasks. A task
@@ -250,324 +188,137 @@ Gradle allows you to define any number of test tasks, each having its
 own classpath configuration. We'll use this to configure test executions
 for each container.
 
-Let's assume that we want to run the tests against the following three
-Arquillian-supported containers:
+Let's assume that we want to run the tests against two
+Arquillian-supported containers, a managed WildFly and Weld SE. We'll
+need two components for each container:
 
-* Weld EE Embedded 1.1
-* Remote JBoss AS 6
-* Embedded GlassFish 3
+1.  A dependency configuration extending the test runtime classpath
+2.  A test task using that configuration
 
-We'll need three components for each container:
+We'll start with the Weld SE container. Starting from the Gradle build
+defined in the previous section, we first define a configuration for the
+test runtime dependencies.
 
-1.  Dependency configuration (scope)
-2.  Runtime dependencies
-3.  Custom test task
-
-We'll start with the Weld EE Embedded container. Starting from the
-Gradle build defined in the previous section, we first define a
-configuration for the test runtime dependencies.
-
-[source,java]
+[source,groovy]
 ----
 configurations {
-   compileOnly
-   weldEmbeddedTestRuntime { extendsFrom testRuntime }
+    weldTestRuntime.extendsFrom testRuntimeClasspath
+    wildflyTestRuntime.extendsFrom testRuntimeClasspath
 }
 ----
 
-Next we add the dependencies for compiling against the Java EE API and
-running Arquillian tests in the Weld EE Embedded container:
+Next we add the container adapter and container runtime for each:
 
-[source,java]
+[source,groovy]
 ----
 dependencies {
-   compileOnly group: 'javax.enterprise', name: 'cdi-api', version: libraryVersions.cdi
+    weldTestRuntime "org.jboss.arquillian.container:arquillian-weld-embedded:${weldAdapterVersion}"
+    weldTestRuntime "org.jboss.weld.se:weld-se-core:${weldVersion}"
 
-   testCompile group: 'junit', name: 'junit', version: libraryVersions.junit
-   testCompile group: 'org.jboss.arquillian', name: 'arquillian-junit', version: libraryVersions.arquillian
-
-   // temporarily downgrade the weld-ee-embedded-1.1 container
-   weldEmbeddedTestRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-weld-ee-embedded-1.1', version: '1.0.0.Alpha3'
-   weldEmbeddedTestRuntime group: 'org.jboss.spec', name: 'jboss-javaee-6.0', version: libraryVersions.jbossJavaeeSpec
-   weldEmbeddedTestRuntime group: 'org.jboss.weld', name: 'weld-core', version: libraryVersions.weld
-   weldEmbeddedTestRuntime group: 'org.slf4j', name: 'slf4j-log4j12', version: libraryVersions.slf4j
-   weldEmbeddedTestRuntime group: 'log4j', name: 'log4j', version: libraryVersions.log4j
+    wildflyTestRuntime "org.wildfly.arquillian:wildfly-arquillian-container-managed:${wildflyArquillianVersion}"
 }
 ----
 
-Finally, we define the test task:
+Finally, we define a test task per container:
 
-[source,java]
+[source,groovy]
 ----
-task weldEmbeddedTest(type: Test) {
-   testClassesDir = sourceSets.test.classesDir
-   classpath = sourceSets.test.classes + sourceSets.main.classes + configurations.weldEmbeddedTestRuntime
+tasks.register('weldTest', Test) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.output + sourceSets.main.output + configurations.weldTestRuntime
+    useJUnitPlatform()
+}
+
+tasks.register('wildflyTest', Test) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.output + sourceSets.main.output + configurations.wildflyTestRuntime
+    useJUnitPlatform()
+    systemProperty 'jboss.home', "${buildDir}/wildfly"
 }
 ----
 
-This task will execute in the lifecycle setup by the Java plugin in
-place of the normal test task. You run it as follows:
+You run a task as follows:
 
-[source,java]
+[source,console]
 ----
-gradle weldEmbeddedTest
-----
-
-Or, more simply:
-
-[source,java]
-----
-gradle wET
+gradle weldTest
 ----
 
-Now we just repeat this setup for the other containers.
+Or, using Gradle's abbreviated task names:
+
+[source,console]
+----
+gradle wT
+----
 
 Since you are creating custom test tasks, you likely want to configure
-the default test task to either exclude Arquillian tests are to use a
-default container, perhaps Weld EE Embedded in this case.
+the default `test` task to either exclude Arquillian tests or to use a
+default container.
 
-Here's the full build file with the tasks for our three target
-containers:
+It's now possible to run the Arquillian tests against both containers in
+sequence using a single Gradle command:
 
-[source,java]
+[source,console]
 ----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-libraryVersions = [
-   junit: '4.8.1', arquillian: '1.0.0.Alpha4', jbossJavaeeSpec: '1.0.0.Beta7', weld: '1.0.1-Final',
-   slf4j: '1.5.8', log4j: '1.2.14', jbossas: '6.0.0.Final', glassfish: '3.0.1-b20', cdi: '1.0-SP1'
-]
-
-repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/repositories/deprecated'
-}
-
-configurations {
-   compileOnly
-   weldEmbeddedTestRuntime { extendsFrom testRuntime }
-   jbossasRemoteTestRuntime { extendsFrom testRuntime, compileOnly }
-   glassfishEmbeddedTestRuntime { extendsFrom testRuntime }
-}
-
-dependencies {
-   compileOnly group: 'javax.enterprise', name: 'cdi-api', version: libraryVersions.cdi
-
-   testCompile group: 'junit', name: 'junit', version: libraryVersions.junit
-   testCompile group: 'org.jboss.arquillian', name: 'arquillian-junit', version: libraryVersions.arquillian
-
-   // temporarily downgrade the weld-ee-embedded-1.1 container
-   weldEmbeddedTestRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-weld-ee-embedded-1.1', version: '1.0.0.Alpha3'
-   weldEmbeddedTestRuntime group: 'org.jboss.spec', name: 'jboss-javaee-6.0', version: libraryVersions.jbossJavaeeSpec
-   weldEmbeddedTestRuntime group: 'org.jboss.weld', name: 'weld-core', version: libraryVersions.weld
-   weldEmbeddedTestRuntime group: 'org.slf4j', name: 'slf4j-log4j12', version: libraryVersions.slf4j
-   weldEmbeddedTestRuntime group: 'log4j', name: 'log4j', version: libraryVersions.log4j
-
-   jbossasRemoteTestRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-jbossas-remote-6', version: libraryVersions.arquillian
-   jbossasRemoteTestRuntime group: 'org.jboss.jbossas', name: 'jboss-as-server', classifier: 'client', version: libraryVersions.jbossas, transitive: false
-   jbossasRemoteTestRuntime group: 'org.jboss.jbossas', name: 'jboss-as-profileservice', classifier: 'client', version: libraryVersions.jbossas
-
-   glassfishEmbeddedTestRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-glassfish-embedded-3', version: libraryVersions.arquillian
-   glassfishEmbeddedTestRuntime group: 'org.glassfish.extras', name: 'glassfish-embedded-all', version: libraryVersions.glassfish
-}
-
-sourceSets {
-   main {
-      compileClasspath = configurations.compile + configurations.compileOnly
-   }
-   test {
-      compileClasspath = compileClasspath + configurations.compileOnly
-   }
-}
-
-task weldEmbeddedTest(type: Test) {
-   testClassesDir = sourceSets.test.classesDir
-   classpath = sourceSets.test.classes + sourceSets.main.classes + configurations.weldEmbeddedTestRuntime
-}
-
-task jbossasRemoteTest(type: Test) {
-   testClassesDir = sourceSets.test.classesDir
-   classpath = sourceSets.test.classes + sourceSets.main.classes + files('src/test/resources-jbossas') + configurations.jbossasRemoteTestRuntime
-}
-
-task glassfishEmbeddedTest(type: Test) {
-   testClassesDir = sourceSets.test.classesDir
-   classpath = sourceSets.test.classes + sourceSets.main.classes + configurations.glassfishEmbeddedTestRuntime
-}
-----
-
-Notice we've added an extra resources directory for remote JBoss AS 6 to
-include the required jndi.properties file. That's a special
-configuration for the remote JBoss AS containers, though won't be
-required after Arquillian 1.0.0.Alpha4.
-
-It's now possible to run the Arquillian tests against each of the three
-containers in sequence using this Gradle command (make sure a JBoss AS
-is started in the background):
-
-[source,java]
-----
-gradle weldEmbeddedTest jbossasRemoteTest glassfishEmbeddedTest
+gradle weldTest wildflyTest
 ----
 
 Pretty cool, huh?
 
 Now let's look at another way to solve this problem.
 
+[[strategy-test-profiles]]
 ===== Strategy #2: Test Profiles
 
 Another way to approach integrating Arquillian into a Gradle build is to
 emulate the behavior of Maven profiles. In this case, we won't be adding
-any extra tasks, rather overriding the Java plugin configuration and
-provided tasks.
+any extra tasks, rather overriding the configuration of the test task
+provided by the Java plugin.
 
 A Maven profile effectively overrides portions of the build
 configuration and is activated using a command option (or some other
-profile activation setting).
+profile activation setting). In Gradle, a project property passed with
+`-P` serves the same purpose.
 
-Once again, let's assume that we want to run the tests against the
-following three Arquillian-supported containers:
+We then create a partial Gradle build file for each container that
+contains the container-specific dependencies and configuration. Create a
+file named weld-profile.gradle:
 
-* Weld EE Embedded 1.1
-* Remote JBoss AS 6
-* Embedded GlassFish 3
-
-All we need to do is customize the test runtime classpath for each
-container. First, let's setup the common compile-time dependencies in
-the main build file:
-
-[source,java]
-----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-libraryVersions = [
-   junit: '4.8.1', arquillian: '1.0.0.Alpha3', jbossJavaeeSpec: '1.0.0.Beta7', weld: '1.0.1-Final',
-   slf4j: '1.5.8', log4j: '1.2.14', jbossas: '6.0.0.Final', glassfish: '3.0.1-b20', cdi: '1.0-SP1'
-]
-
-repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
-}
-
-configurations {
-   compileOnly
-}
-
-dependencies {
-   group: 'org.jboss.spec', name: 'jboss-javaee-6.0', version: libraryVersions.jbossJavaeeSpec
-}
-
-sourceSets {
-   main {
-      compileClasspath = configurations.compile + configurations.compileOnly
-   }
-   test {
-      compileClasspath = compileClasspath + configurations.compileOnly
-   }
-}
-----
-
-We then need to create a partial Gradle build file for each container
-that contains the container-specific dependencies and configuration.
-Let's start with Weld EE Embedded.
-
-Create a file named weld-ee-embedded-profile.gradle and populate it with
-the following contents:
-
-[source,java]
+[source,groovy]
 ----
 dependencies {
-   // temporarily downgrade the weld-ee-embedded-1.1 container
-   testRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-weld-ee-embedded-1.1', version: '1.0.0.Alpha3'
-   testRuntime group: 'org.jboss.spec', name: 'jboss-javaee-6.0', version: libraryVersions.jbossJavaeeSpec
-   testRuntime group: 'org.jboss.weld', name: 'weld-core', version: libraryVersions.weld
-   testRuntime group: 'org.slf4j', name: 'slf4j-log4j12', version: libraryVersions.slf4j
-   testRuntime group: 'log4j', name: 'log4j', version: libraryVersions.log4j
+    testRuntimeOnly "org.jboss.arquillian.container:arquillian-weld-embedded:${weldAdapterVersion}"
+    testRuntimeOnly "org.jboss.weld.se:weld-se-core:${weldVersion}"
 }
 ----
 
-Here's the partial build file for Remote JBoss AS, named
-jbossas-remote-profile.gradle:
+And one for WildFly, named wildfly-profile.gradle:
 
-[source,java]
+[source,groovy]
 ----
 dependencies {
-   testRuntime group: 'javax.enterprise', name: 'cdi-api', version: libraryVersions.cdi
-   testRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-jbossas-remote-6', version: libraryVersions.arquillian
-   testRuntime group: 'org.jboss.jbossas', name: 'jboss-as-server', classifier: 'client', version: libraryVersions.jbossas, transitive: false
-   testRuntime group: 'org.jboss.jbossas', name: 'jboss-as-profileservice', classifier: 'client', version: libraryVersions.jbossas
+    testRuntimeOnly "org.wildfly.arquillian:wildfly-arquillian-container-managed:${wildflyArquillianVersion}"
 }
 
 test {
-   classpath = sourceSets.test.classes + sourceSets.main.classes + files('src/test/resources-jbossas') + configurations.testRuntime
+    systemProperty 'jboss.home', "${buildDir}/wildfly"
 }
 ----
 
-And finally the one for Embedded GlassFish, named
-glassfish-embedded-profile.gradle:
+Now we import the appropriate partial Gradle build into the main build.
+The file is selected based on the value of the project property named
+`profile`:
 
-[source,java]
+[source,groovy]
 ----
-dependencies {
-   testRuntime group: 'org.jboss.arquillian.container', name: 'arquillian-glassfish-embedded-3', version: libraryVersions.arquillian
-   testRuntime group: 'org.glassfish.extras', name: 'glassfish-embedded-all', version: libraryVersions.glassfish
-}
+apply from: "${profile}-profile.gradle"
 ----
 
-Now we need to import the appropriate partial Gradle build into the main
-build. The file will be selected based on the value of the project
-property named profile.
+Tests are run in the Weld SE runtime using this command:
 
-[source,java]
+[source,console]
 ----
-apply plugin: JavaPlugin
-
-buildDir = 'target/gradle-build'
-
-libraryVersions = [
-   junit: '4.8.1', arquillian: '1.0.0.Alpha4', jbossJavaeeSpec: '1.0.0.Beta7', weld: '1.0.1-Final',
-   slf4j: '1.5.8', log4j: '1.2.14', jbossas: '6.0.0.Final', glassfish: '3.0.1-b20', cdi: '1.0-SP1'
-]
-
-apply from: profile + '-profile.gradle'
-
-repositories {
-   mavenCentral()
-   mavenRepo urls: 'http://repository.jboss.org/nexus/content/groups/public'
-}
-
-configurations {
-   compileOnly
-}
-
-dependencies {
-   compileOnly group: 'javax.enterprise', name: 'cdi-api', version: libraryVersions.cdi
-
-   testCompile group: 'junit', name: 'junit', version: libraryVersions.junit
-   testCompile group: 'org.jboss.arquillian', name: 'arquillian-junit', version: libraryVersions.arquillian
-}
-
-sourceSets {
-   main {
-      compileClasspath = configurations.compile + configurations.compileOnly
-   }
-   test {
-      compileClasspath = compileClasspath + configurations.compileOnly
-   }
-}
-----
-
-Tests are run in the Weld EE Embedded runtime using this command:
-
-[source,java]
-----
-gradle test -Pprofile=weld-ee-embedded
+gradle test -Pprofile=weld
 ----
 
 That's pretty much the same experience you get when you use Maven (and a
@@ -582,23 +333,44 @@ execution
 
 If you have a better idea of how to integrate an Arquillian test suite
 into a Gradle build, we'd love to hear it on the
-http://community.jboss.org/en/arquillian[Arquillian discussion forums].
-
-[[ant-ivy]]
-==== Ant + Ivy
-
-WRITE ME
+https://github.com/orgs/arquillian/discussions[Arquillian discussion forums].
 
 [[ant]]
 ==== Ant
 
-This guide will detail how to use Arquillian using ant. We will use
-maven to download all the required jars.
+Arquillian has no Ant-specific integration, and needs none: the
+`<junit>`, `<junitlauncher>` and `<testng>` tasks all accept an
+arbitrary classpath, which is the only thing Arquillian requires.
 
-Overview of Steps
+The approach is the same as for any other build tool — resolve the
+Arquillian container integration, the container runtime or deployment
+client and your test framework onto a path, then hand that path to the
+test task. Since Arquillian is distributed via Maven Central, the
+simplest way to resolve those artifacts is with
+https://ant.apache.org/ivy/[Apache Ivy] or the
+https://maven.apache.org/resolver-ant-tasks/[Maven Artifact Resolver Ant
+Tasks], rather than by managing jars by hand.
 
-1.  Setup Example Maven project
-2.  Get All Arquillian dependency jars
-3.  configure ant scripts
+Sketching the JUnit Jupiter case:
 
-Work in progress. Please return.
+[source,xml]
+----
+<path id="arquillian.test.path">
+    <fileset dir="lib/test" includes="**/*.jar"/>
+    <pathelement location="${build.classes.dir}"/>
+    <pathelement location="${build.test.classes.dir}"/>
+    <!-- arquillian.xml and other test resources -->
+    <pathelement location="${test.resources.dir}"/>
+</path>
+
+<junitlauncher haltOnFailure="true">
+    <classpath refid="arquillian.test.path"/>
+    <testclasses outputdir="${build.test.reports.dir}">
+        <fileset dir="${build.test.classes.dir}" includes="**/*TestCase.class"/>
+    </testclasses>
+</junitlauncher>
+----
+
+Swapping the target container is a matter of pointing `lib/test` (or the
+resolved Ivy configuration) at a different container adapter, exactly as
+a Maven profile or a Gradle configuration would.

--- a/docs/containers.adoc
+++ b/docs/containers.adoc
@@ -26,11 +26,11 @@ tests count, you want to execute them in the target environment, or
 container.
 
 _So what is the container that Arquillian uses? Is it some proprietary testing
-container that emulates the behavior of the technology (Java EE)?_
+container that emulates the behavior of the technology (Jakarta EE)?_
 
-Nope! It's pluggable. It can be your target runtime, such as JBoss AS,
+Nope! It's pluggable. It can be your target runtime, such as WildFly,
 GlassFish or Tomcat. Or it can even been an embedded container such as
-OpenEJB, GlassFish Embedded or Weld SE. You can even use one container
+GlassFish Embedded or Weld SE. You can even use one container
 for development and another for continuous integration.
 
 This portability is made possible by a RPC-style (or local, if
@@ -53,10 +53,9 @@ plugins!
 
 A container is further classified by its capabilities:
 
-* Java EE application server (e.g., JBoss AS, GlassFish, WebLogic)
+* Jakarta EE application server (e.g., WildFly, GlassFish, Open Liberty)
 * Servlet container (e.g., Tomcat, Jetty)
-* standalone bean container (e.g., OpenEJB, Weld SE)
-* OSGi container
+* standalone bean container (e.g., Weld SE)
 
 Arquillian can control a variety of containers out of the box. If the
 container you are using isn't supported, Arquillian provides an SPI that
@@ -107,7 +106,7 @@ the tests, you activate one of those groups, which in turn selects a
 target container. The profile is activated either using either a
 commandline flag (-P) or a preference in the IDE.
 
-The https://arquillian.org/getting_started/[Getting Started Guide]
+The https://arquillian.org/guides/getting_started[Getting Started Guide]
 explains how to setup and use Maven profiles for this purpose in more
 detail.
 
@@ -132,12 +131,12 @@ requirement.
 
 Let's imagine that we're working for the company `example.com` and in
 our environment we have two servers; `test.example.com` and
-`hudson.example.com`. `test.example.com` is the JBoss instance we use
-for our integration tests and `hudson.example.com` is our continuous
+`ci.example.com`. `test.example.com` is the WildFly instance we use
+for our integration tests and `ci.example.com` is our continuous
 integration server that we want to run our integration suite from. By
 default, Arquillian will use localhost, so we need to tell it to use
-`test.example.com` to run the tests. The JBoss AS container by default
-use the Servlet protocol, so we have to override the default
+`test.example.com` to run the tests. The WildFly container by default
+uses the Servlet protocol, so we have to override the default
 configuration.
 
 [source,xml]
@@ -147,9 +146,10 @@ configuration.
     xmlns="http://jboss.org/schema/arquillian"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://www.jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="jbossas" default="true">
+    <container qualifier="wildfly" default="true">
         <configuration>
-            <property name="providerUrl">jnp://test.example.com:1099</property>
+            <property name="managementAddress">test.example.com</property>
+            <property name="managementPort">9990</property>
         </configuration>
         <protocol type="Servlet 3.0">
             <property name="host">test.example.com</property>
@@ -160,29 +160,30 @@ configuration.
 </arquillian>
 ----
 
-That should do it! Here we use the JBoss AS 6.0 Remote container which
-default use the Servlet 3.0 protocol implementation. We override the
+That should do it! Here we use the WildFly Remote container which by
+default uses the Servlet 3.0 protocol implementation. We override the
 default Servlet configuration to say that the http requests for this
 container can be executed over `test.example.com:8181`, but we also need
 to configure the container so it knows where to deploy our archives. We
 could for example have configured the Servlet protocol to communicate
-with a Apache server in front of the JBoss AS Server if we wanted to.
+with a reverse proxy in front of the WildFly server if we wanted to.
 Each container has different configuration options.
 
-// TODO Fix the Link
-For a complete overview of all the containers and their configuration
-options, see the
-https://docs.jboss.org/author/display/ARQ/Container+adapters[container
-adapters] appendix.
+For a complete overview of a given container's configuration options,
+consult the documentation of that container adapter. The adapters are
+maintained outside of Arquillian Core; the WildFly adapters, for
+example, live in the
+https://github.com/wildfly/wildfly-arquillian[wildfly-arquillian]
+project.
 
 [[supported-containers]]
 ==== Supported Containers
 
-// TODO Fix the Link
-Please see the
-https://docs.jboss.org/author/display/ARQ/Container+adapters[container
-adapters] appendix for a list of supported containers, including details
-for how to use and configure them.
+Container adapters are released independently of Arquillian Core, so
+the list of supported containers is not fixed by this documentation. See
+the https://arquillian.org/modules/[Arquillian modules] listing for
+adapters and the documentation of each adapter for details on how to use
+and configure it.
 
 [[container-config-runtime-selection]]
 ==== Container Config Runtime Selection
@@ -201,32 +202,32 @@ using Java system properties.
 ----
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xmlns="http://jboss.org/schema/arquillian"
-   xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+   xmlns="http://jboss.org/schema/arquillian"
+   xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-   <container qualifier="jbossas_managed" default="true">
-      <protocol type="Servlet 3.0">
-         <property name="executionType">MANAGED</property>
-      </protocol>
-      <configuration>
-         <property name="jbossHome">${project.baseDir}/target/jboss-as-7.1.1.Final/</property>
-         <property name="allowConnectingToRunningServer">true</property>
-      </configuration>
-   </container>
-   
-   <container qualifier="jetty">
-      <configuration>
-          <more configuration>...</more configuration>
-      </configuration>
-   </container>
+   <container qualifier="wildfly_managed" default="true">
+      <protocol type="Servlet 3.0">
+         <property name="executionType">MANAGED</property>
+      </protocol>
+      <configuration>
+         <property name="jbossHome">${project.baseDir}/target/wildfly/</property>
+         <property name="allowConnectingToRunningServer">true</property>
+      </configuration>
+   </container>
+
+   <container qualifier="jetty">
+      <configuration>
+         <!-- container specific configuration properties -->
+      </configuration>
+   </container>
 </arquillian>
 ----
 
 ===== Activating a configuration via the command line
 
 The -Darquillian.launch system property is what controls arquillian.xml
-configuration selection. If you are running tests from Eclipse or
-directly from the command like, you should add the -D system property to
+configuration selection. If you are running tests from your IDE or
+directly from the command line, you should add the -D system property to
 your launch configuration or command.
 
 ===== Activating a configuration via Maven
@@ -238,17 +239,17 @@ the 'arquillian.launch' system property for test execution, as follows:
 [source,xml]
 ----
 <profile>
-         <id>JBOSS_AS_MANAGED_7.X</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <configuration>
-                     <systemPropertyVariables>
-                        <arquillian.launch>jbossas_managed</arquillian.launch>
-                     </systemPropertyVariables>
-                  </configuration>
-               </plugin>
-  ...
+   <id>wildfly-managed</id>
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <systemPropertyVariables>
+                  <arquillian.launch>wildfly_managed</arquillian.launch>
+               </systemPropertyVariables>
+            </configuration>
+         </plugin>
+         ...
 ----

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -3,9 +3,9 @@
 
 We promised that integration and functional testing with Arquillian is
 no more complex than writing a unit test. Now it's time to prove it to
-you. We've prepared a series of guides designed exclusively to teach you
-how to use Arquillian. You'll have the tests running from both Maven and
-Eclipse by the end of the first guide.
+you. We've prepared a series of guides designed exclusively to teach you
+how to use Arquillian. You'll have the tests running from both Maven and
+your IDE by the end of the first guide.
 
 Head over to the https://arquillian.org/guides/getting_started[Getting
 Started Guide] and start writing real tests!

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -72,7 +72,7 @@ side by side:
 ----
 // JUnit Jupiter (JUnit 5 and 6)
 @ExtendWith(ArquillianExtension.class)
-public class GreeterTestCase {
+class GreeterTestCase {
 
 // JUnit 4
 @RunWith(Arquillian.class)

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 * <<core-principles, Core Principles>>
 * <<how-it-works, How It Works>>
-* <<integration-testing-in java-ee, Integration Testing In Java EE>>
+* <<integration-testing-in-jakarta-ee, Integration Testing In Jakarta EE>>
 
 We believe that integration and functional testing should be no more
 complex or daunting than unit testing. We created Arquillian to make
@@ -20,14 +20,16 @@ that vision a reality.
 
 *Arquillian is a revolutionary testing platform for Java and the JVM
 that enables developers to easily write and execute integration and
-functional tests for Java middleware, ranging from Java EE and beyond.*
+functional tests for Java middleware, ranging from Jakarta EE and
+beyond.*
 
 Arquillian picks up where unit tests leave off, focusing on the
 integration of application code inside a real runtime environment. Much
-the same way Java EE 5 simplified the server programming model by
-providing declarative services for POJOs, Arquillian equips tests with
-container lifecycle management and test case enrichment. Using
-Arquillian, you can focus on the test, not the plumbing.
+the same way the enterprise Java platform simplified the server
+programming model by providing declarative services for POJOs,
+Arquillian equips tests with container lifecycle management and test
+case enrichment. Using Arquillian, you can focus on the test, not the
+plumbing.
 
 In short, Arquillian aims to make integration and functional testing a
 breeze.
@@ -60,17 +62,41 @@ or executing the "test" goal from the build tool.
 [[how-it-works]]
 ==== How It Works
 
-Using Arquillian, you write a basic test case and annotate it with
-declarative behavior that says, "`@RunWith` Arquillian". This
-declaration tells Arquillian to take over execution of the test when
-it's launched.
+Using Arquillian, you write a basic test case and declare that
+Arquillian should run it. This declaration tells Arquillian to take over
+execution of the test when it's launched. How you write it depends on
+the test framework you use, and Arquillian supports all of them
+side by side:
+
+[source,java]
+----
+// JUnit Jupiter (JUnit 5 and 6)
+@ExtendWith(ArquillianExtension.class)
+public class GreeterTestCase {
+
+// JUnit 4
+@RunWith(Arquillian.class)
+public class GreeterTestCase {
+
+// TestNG
+public class GreeterTestCase extends Arquillian {
+----
+
+[NOTE]
+====
+Examples throughout this guide are written for JUnit Jupiter. Unless a
+section says otherwise, the same example works on JUnit 4 by swapping
+`@ExtendWith(ArquillianExtension.class)` for `@RunWith(Arquillian.class)`
+and using the JUnit 4 `Assert` methods, and on TestNG by extending
+`Arquillian`.
+====
 
 __That's when the real magic happens__.
 
 Launching an Arquillian test is as simple as right-clicking the test
-class in the IDE and selecting _Run As > Test (e.g., JUnit, TestNG,
-Spock, etc)_. Based on the classpath configuration, Arquillian starts or
-binds to the target container (JBoss AS, GlassFish, OpenEJB, etc) and
+class in the IDE and selecting _Run As > Test (e.g., JUnit, TestNG)_.
+Based on the classpath configuration, Arquillian starts or
+binds to the target container (WildFly, GlassFish, Open Liberty, etc) and
 deploys the test archive defined in the `@Deployment` method. The
 archive includes the test case along with the specified classes,
 resources and libraries. Your test then executes inside the container
@@ -83,14 +109,14 @@ transports them back to the test runner for reporting.
 NOTE: Arquillian also has a client run mode, which only deploys the test archive, not the test case.
 
 
-Aside from a few extra declarations (i.e., `@RunWith` and
-`@Deployment`), an Arquillian test looks like any other unit test and
-launched like any other unit test.
+Aside from a few extra declarations (i.e., the Arquillian runner
+declaration and `@Deployment`), an Arquillian test looks like any other
+unit test and launched like any other unit test.
 
-[[integration-testing-in-java-ee]]
-==== Integration Testing In Java EE
+[[integration-testing-in-jakarta-ee]]
+==== Integration Testing In Jakarta EE
 
-Integration testing is very important in Java EE. The reason is
+Integration testing is very important in Jakarta EE. The reason is
 two-fold:
 
 * Business components often interact with resources or sub-system
@@ -107,15 +133,15 @@ injection, etc) is a non-starter because the developer has no idea what
 to even use. Clearly there is a need for a simple solution, and
 Arquillian fills that void.
 
-Some might argue that, as of Java EE 5, the business logic performed by
-most Java EE components can now be tested outside of the container
-because they are POJOs. But let's not forget that in order to isolate
-the business logic in Java EE components from infrastructure services
-(transactions, security, etc), many of those services were pushed into
-declarative programming constructs. At some point you want to make sure
-that the infrastructure services are applied correctly and that the
-business logic functions properly within that context, justifying the
-second reason that integration testing is important in Java EE.
+Some might argue that the business logic performed by most Jakarta EE
+components can be tested outside of the container because they are
+POJOs. But let's not forget that in order to isolate the business logic
+in Jakarta EE components from infrastructure services (transactions,
+security, etc), many of those services were pushed into declarative
+programming constructs. At some point you want to make sure that the
+infrastructure services are applied correctly and that the business
+logic functions properly within that context, justifying the second
+reason that integration testing is important in Jakarta EE.
 
 [[testing-the-real-component]]
 ===== Testing The Real Component
@@ -181,6 +207,6 @@ the classpath hell that typically haunts test runners (Eclipse, Maven),
 it also gives you the option to focus on the interaction between an
 subset of production classes, or to easily swap in alternative classes.
 Within that grouping you get the self-assembly of services provided by
-Java EE---the very integration which is being tested.
+Jakarta EE---the very integration which is being tested.
 
 Let's move on and consider some typical usage scenarios for Arquillian.

--- a/docs/protocols.adoc
+++ b/docs/protocols.adoc
@@ -7,6 +7,7 @@ ifdef::env-github,env-browser[]
 :outfilesuffix: .adoc
 endif::[]
 
+[[protocols]]
 === Protocols
 :icons: font
 
@@ -19,13 +20,16 @@ be configured.
 * <<local, Local>>
 * <<servlet-2.5, Servlet 2.5>>
 * <<servlet-3.0, Servlet 3.0>>
+* <<jmx, JMX>>
 
 [[local]]
 ==== Local
 
-The Local Protocol implementation is used by most EE5 compliant
-containers. It does nothing to the deployment. The Local Protocol is also
-used when executing in run mode `as client`.
+The Local Protocol does nothing to the deployment and invokes the test
+method directly in the test runner's JVM. It is the default for
+containers that have no web component to talk to, such as embedded CDI
+containers. Tests running in `as client` mode are invoked the same way,
+whatever protocol the container declares.
 
 *Packaging rules*
 
@@ -58,8 +62,9 @@ used when executing in run mode `as client`.
 [[servlet-2.5]]
 ==== Servlet 2.5
 
-The Servlet 2.5 Protocol implementation is used by most EE5 compliant
-containers. It will attempt to add a war to the deployment.
+The Servlet 2.5 Protocol implementation targets containers that only
+provide the Servlet 2.5 programming model (no web fragments). It will
+attempt to add a war to the deployment.
 
 *Packaging rules*
 
@@ -93,6 +98,11 @@ containers. It will attempt to add a war to the deployment.
 |===
 |Name |Type |Default |Description
 
+|scheme
+|String
+|none
+|Used to override the Deployments default scheme (e.g. `https`).
+
 |host
 |String
 |none
@@ -107,13 +117,21 @@ containers. It will attempt to add a war to the deployment.
 |String
 |none
 |Used to override the Deployments default contextRoot.
+
+|pullInMilliSeconds
+|int
+|100
+|Interval at which the protocol's command service polls the container for
+ remote events. Used by extensions that exchange data between the
+ container and the client.
 |===
 
 [[servlet-3.0]]
 ==== Servlet 3.0
 
-The Servlet 3.0 Protocol implementation is used by most EE6 compliant
-containers. It will attempt to add a web-fragment to the deployment.
+The Servlet 3.0 Protocol implementation is the default for most modern
+containers, including all Jakarta EE ones. It will attempt to add a
+web-fragment to the deployment.
 
 *Packaging rules*
 
@@ -146,6 +164,11 @@ containers. It will attempt to add a web-fragment to the deployment.
 |===
 |Name |Type |Default |Description
 
+|scheme
+|String
+|none
+|Used to override the Deployments default scheme (e.g. `https`).
+
 |host
 |String
 |none
@@ -160,4 +183,28 @@ containers. It will attempt to add a web-fragment to the deployment.
 |String
 |none
 |Used to override the Deployments default contextRoot.
+
+|pullInMilliSeconds
+|int
+|100
+|Interval at which the protocol's command service polls the container for
+ remote events. Used by extensions that exchange data between the
+ container and the client.
 |===
+
+[[jmx]]
+==== JMX
+
+Arquillian Core ships the base of a JMX protocol
+(`org.jboss.arquillian.protocol.jmx.AbstractJMXProtocol`) rather than a
+ready-to-use protocol. It communicates with the container over a JMX
+`MBeanServerConnection` instead of over HTTP, which makes it a fit for
+containers that have no web component (an OSGi framework, for instance).
+
+Because the way an MBean server is located is entirely container
+specific, container adapters subclass `AbstractJMXProtocol`, supply the
+protocol name via `getProtocolName()` and provide the
+`MBeanServerConnection`. Consult the documentation of your container
+adapter to find out whether it offers a JMX protocol and what its name
+is, as that name is what you pass to `@OverProtocol` or to the
+`<protocol type="...">` element in `arquillian.xml`.

--- a/docs/rules.adoc
+++ b/docs/rules.adoc
@@ -12,12 +12,19 @@ endif::[]
 
 If you want to use Arquillian Testing Platform with other JUnit Runner, you can now use JUnit Rules - `ArquillianTestClass` and `ArquillianTest` - and happily let Arquillian do the heavy lifting for your tests.
 
+NOTE: Rules are a JUnit 4 concept. On JUnit Jupiter (JUnit 5 and 6) there is
+no such restriction — `ArquillianExtension` is a JUnit extension and composes
+with other extensions directly, so use
+`@ExtendWith(ArquillianExtension.class)` (or the `@ArquillianTest`
+shorthand) instead.
+
 To get the similar functionality what the `@RunWith(Arquillian.class)` is offering you should require both rules i.e. `ArquillianTestClass` and `ArquillianTest`.
 If you are trying to run tests with one rule, it won't work as per expectations. We are not enforcing user to define both rules as implementations of `MethodRuleChain`
 is different for different users. JUnit doesn't provide `MethodRuleChain` similar to the `RuleChain`, as we don't know your implementation of `MethodRuleChain`,
 we can't check if your MethodRuleChain has `ArquillianTest` Rule defined.
 
-IMPORTANT: In order to use this feature, your project needs JUnit `4.12` version.
+IMPORTANT: In order to use this feature, your project needs JUnit `4.12` or later
+(Arquillian builds and tests against `4.13.2`).
 
 ==== How to use it?
 
@@ -53,10 +60,13 @@ public class GreeterManagedBeanWithJUnitRulesTestCase {
 IMPORTANT: However while using above Junit Rules you can't inject method scoped Arquillian resources.
 Unfortunately it is not possible to have one rule acting as both test class and test method rule. For more info
  see this https://github.com/junit-team/junit4/issues/351#issuecomment-102084524[comment].
-In order to use any other JUnit Method Rule with `ArquillianTest` Rule, you have to use it with `RuleChain`
-having `ArquillianTest` as outer Rule.
+In order to use any other JUnit Method Rule with `ArquillianTest` Rule, you have to use it with
+`org.jboss.arquillian.junit.MethodRuleChain` having `ArquillianTest` as the outer Rule.
 e.g.
-```java
-   @Rule
-   public MethodRule testWatchman = MethodRuleChain.outer(new ArquillianTest().around(new TestWatchman());
-```
+
+[source,java]
+----
+@Rule
+public MethodRuleChain chain = MethodRuleChain.outer(new ArquillianTest())
+                                              .around(new MyOtherMethodRule());
+----

--- a/docs/test-enrichers.adoc
+++ b/docs/test-enrichers.adoc
@@ -61,7 +61,7 @@ Here's an example of a field injection in a test class, on JUnit Jupiter
 [source,java]
 ----
 @ExtendWith(ArquillianExtension.class)
-public class GreeterTestCase {
+class GreeterTestCase {
     @Inject
     private Greeter greeter;
 
@@ -87,7 +87,7 @@ Here's an example of a method argument injection in a test method:
 [source,java]
 ----
 @Test
-public void testGreeting(Greeter greeter) {
+void testGreeting(Greeter greeter) {
   ...
 }
 ----

--- a/docs/test-enrichers.adoc
+++ b/docs/test-enrichers.adoc
@@ -55,7 +55,21 @@ Injection points are recognized in the following two locations:
 1.  Field (any visibility)
 2.  `@Test` method argument
 
-Here's an example of a field injection in a test class:
+Here's an example of a field injection in a test class, on JUnit Jupiter
+(JUnit 5 and 6):
+
+[source,java]
+----
+@ExtendWith(ArquillianExtension.class)
+public class GreeterTestCase {
+    @Inject
+    private Greeter greeter;
+
+    ...
+}
+----
+
+and the same test on JUnit 4:
 
 [source,java]
 ----
@@ -87,28 +101,44 @@ method argument.
 There are three injection-based enrichers provided by Arquillian out of
 the box:
 
-* `@Resource` - Java EE resource injections
-* `@EJB` - EJB session bean reference injections
+* `@Resource` - Jakarta EE resource injections
+* `@EJB` - Enterprise bean reference injections
 * `@Inject`, `@Resource`, `@EJB`, `@PersistenceContext` and
 `@PersistenceUnit` - CDI-supported injections
 
 The first two enrichers use JNDI to lookup the instance to inject. The
 CDI injections are handled by treating the test class as a bean capable
 of receiving standard CDI injections (non-contextual injection). Since
-CDI requires containers to satisfy all Java EE injection points on a CDI
-bean, the `@Resource`, `@EJB`, `@PersistenceContext` and
+CDI requires containers to satisfy all Jakarta EE injection points on a
+CDI bean, the `@Resource`, `@EJB`, `@PersistenceContext` and
 `@PersistenceUnit` injections are supported transitively by the CDI
 enricher. In fact, because of CDI's tight integration with the
 container, `@EJB` injections in the test class are satisfied according
 to specification when the CDI enricher is available.
+
+Arquillian also ships an enricher that makes a JNDI `Context` available
+via `@ArquillianResource`, for cases where you want to perform lookups
+by hand:
+
+[source,java]
+----
+@ArquillianResource
+private Context context;
+----
+
+NOTE: Arquillian Core itself is built against the `javax.*` packages.
+Artifacts transformed to the `jakarta.*` namespace are published
+separately under the `org.jboss.arquillian.jakarta` group id, with their
+own versioning and BOM (`arquillian-jakarta-bom`). Use those when
+testing on a Jakarta EE 9 or newer container.
 
 [[resource-injection]]
 ====== Resource Injection
 
 The `@Resource` annotation gives you access to any object which is
 available via JNDI. It follows the standard rules for `@Resource` (as
-defined in the Section 2.3 of the Common Annotations for the Java
-Platform specification).
+defined in the Jakarta Annotations specification, formerly known as
+Common Annotations for the Java Platform).
 
 [[ejb-injection]]
 ====== EJB Injection (without CDI support)
@@ -134,9 +164,10 @@ unqualified interface name + "/no-interface"
 If no matching beans were found in those locations the injection will
 fail.
 
-At the moment, the lookup for an EJB session reference relies on some
-common naming convention of EJB beans. In the future the lookup will
-rely on the standard JNDI naming conventions established in Java EE 6.
+Note that this lookup relies on common naming conventions for enterprise
+beans rather than purely on the portable `java:global` JNDI names. Where
+possible, prefer the CDI enricher, which resolves `@EJB` injection points
+through the container itself.
 
 [[cdi-injection]]
 ====== CDI Injection
@@ -152,7 +183,8 @@ add a beans.xml to the archive:
 public static JavaArchive createTestArchive() {
    return ShrinkWrap.create(JavaArchive.class, "test.jar")
       .addClass(NameOfClassUnderTest.class)
-      .addAsManifestResource(EmptyAsset.INSTANCE, Paths.create("beans.xml"))
+      .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+}
 ----
 
 In an application that takes full advantage of CDI, you can likely get
@@ -163,8 +195,8 @@ time-to-time.
 [[active-scopes]]
 ==== Active Scopes
 
-When running your tests the embedded Weld EE container, Arquillian
-activates scopes as follows:
+When running your tests in an embedded CDI container such as Weld SE,
+Arquillian activates scopes as follows:
 
 * Application scope - Active for all methods in a test class
 * Session scope - Active for all methods in a test class


### PR DESCRIPTION
Initial overhaul before I jet off to PTO for the rest of the week.


Terminology:
* JBoss AS -> WildFly across container lists, arquillian.xml samples, the assertions section ($JBOSS_AS_HOME/bin/run.conf -> $JBOSS_HOME/bin/standalone.conf) and the Maven profile example
* Java EE -> Jakarta EE, "EJB session bean" -> "enterprise bean", "Common Annotations for the Java Platform" -> "Jakarta Annotations"
* Drop OpenEJB from container examples, add Open Liberty

Fixes:
* introduction.adoc: broken xref "integration-testing-in java-ee" (space instead of hyphen) never resolved
* containers.adoc: 68 non-breaking spaces (U+00A0) used as XML indentation, making the samples uncopyable; also strip trailing whitespace across docs/
* test-enrichers.adoc: unterminated CDI snippet and nonexistent Paths.create("beans.xml")
* rules.adoc: MethodRuleChain example had mismatched parens and the wrong type
* Remove two dead docs.jboss.org/author/display/ARQ links carrying "// TODO Fix the Link" markers, and a dead community.jboss.org link

Stale claims corrected against the code:
* Replace "only supports Servlet 2.5 and Servlet 3.0, EJB 3.0/3.1 are planned" with what actually ships, and document the JMX protocol
* Add missing scheme and pullInMilliSeconds protocol config options
* Drop the "in the future ... Java EE 6" JNDI naming claim
* README: TestNG 5 -> TestNG 7 to match build/pom.xml

Test framework coverage: samples previously showed only @RunWith(Arquillian.class). They now cover both supported styles.
introduction.adoc gives the Jupiter, JUnit 4 and TestNG declarations up front and establishes that examples default to Jupiter. The enricher, client-mode and @Observer samples are shown for both JUnit Jupiter and JUnit 4. The client-mode sample calls out that JUnit 4's Assert takes the message as the first argument rather than the last. rules.adoc stays on JUnit 4, since rules are a JUnit 4 concept, and says why.

build-integration.adoc: the Gradle chapter was Gradle 0.9-era (apply plugin: JavaPlugin, mavenRepo urls:, testCompile, sourceSets.test.classesDir) against Arquillian 1.0.0.Alpha4, JUnit 4.8.1, JBoss AS 6 and GlassFish 3, resolved from repositories that no longer serve. Rewritten for current Gradle (plugins {}, platform() BOM imports, testImplementation, tasks.register); the built-in compileOnly configuration removes an obsolete section on hand-rolling one. Container adapter versions are placeholders since adapters release independently of Core. The Ant "WRITE ME" / "Work in progress" placeholders are now a real section.

## Summary by Sourcery

Refresh and correct documentation to reflect current Arquillian ecosystem, supported containers, and modern build and testing practices.

Documentation:
- Update terminology and examples across docs to use current Jakarta EE, WildFly, and container naming, removing obsolete references like JBoss AS and OpenEJB.
- Fix multiple broken or outdated documentation samples, including invalid code snippets, incorrect JUnit rule examples, and dead external links.
- Revise testing documentation to cover both JUnit Jupiter, JUnit 4, and TestNG usage, clarifying supported styles and differences in assertions and rules.
- Modernize the Gradle and Ant build integration guides to match current Arquillian versions and contemporary build configurations, replacing obsolete instructions and repositories.
- Align protocol and feature documentation with current implementation, including supported servlet/EE levels, JMX protocol details, and up-to-date configuration options.
- Update README testing framework references and other stale claims to match the current build configuration and actual shipped capabilities.