### PR TITLE
Remove use of dead extension takari-local-repository which is not part of Maven Core itself, and break build with Maven 3.10.x

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
     <artifactId>takari-smart-builder</artifactId>
     <version>1.1.1</version>
   </extension>
-  <extension>
-    <groupId>io.takari.aether</groupId>
-    <artifactId>takari-local-repository</artifactId>
-    <version>0.11.3</version>
-  </extension>
 </extensions>


### PR DESCRIPTION
Build failing with Maven 3.10-rc1

```
---------------------------------------------------
Exception in thread "main" java.lang.NoSuchMethodError: 'java.lang.String org.eclipse.aether.impl.UpdateCheck.getPolicy()'
	at io.takari.aether.localrepo.TakariUpdateCheckManager.checkMetadata(TakariUpdateCheckManager.java:235)
	at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolve(DefaultMetadataResolver.java:272)
	at org.eclipse.aether.internal.impl.DefaultMetadataResolver.resolveMetadata(DefaultMetadataResolver.java:149)
	at org.apache.maven.repository.internal.DefaultVersionRangeResolver.getVersions(DefaultVersionRangeResolver.java:230)
	at org.apache.maven.repository.internal.DefaultVersionRangeResolver.resolveVersionRange(DefaultVersionRangeResolver.java:180)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveVersionRange(DefaultRepositorySystem.java:197)
	at eu.maveniverse.maven.mimir.extension3.MimirLifecycleParticipant.mayCheckForUpdates(MimirLifecycleParticipant.java:167)
	at eu.maveniverse.maven.mimir.extension3.MimirLifecycleParticipant.mayInitialize(MimirLifecycleParticipant.java:109)
	at eu.maveniverse.maven.mimir.extension3.MimirLifecycleParticipant.afterSessionStart(MimirLifecycleParticipant.java:66)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:194)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:179)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:1017)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:299)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:219)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:362)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
olamy@olamy-laptop:~/dev/sources/jetty/arquillian-core$ mvn -v
```


Fixes #

## Summary by Sourcery

Build:
- Delete takari-local-repository Maven extension from .mvn/extensions.xml to avoid issues with newer Maven versions.