### PR TITLE
[#875] Remove takari-smart-builder extension which provides no measur…

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-  <extension>
-    <groupId>io.takari.maven</groupId>
-    <artifactId>takari-smart-builder</artifactId>
-    <version>1.1.1</version>
-  </extension>
-</extensions>


### PR DESCRIPTION
…able benefit over Maven's built-in parallel builder for this project

## Summary by Sourcery

Build:
- Remove Takari Smart Builder extension from Maven build configuration, relying solely on Maven's built-in parallel builder