### PR TITLE
chore: Fix CI workflows to Maven and improve build coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Maven
 
 on:
   push:
@@ -7,6 +7,16 @@ on:
   pull_request:
     branches:
       - '*'
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   build-and-verify:
@@ -22,6 +32,7 @@ jobs:
           - 17
           - 21
           - 25
+          - 26
     steps:
       - name: Checkout arquillian-core
         uses: actions/checkout@v7
@@ -33,9 +44,16 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --no-transfer-progress clean verify
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: ${{ matrix.java }}-test-reports
+          path: |
+            **/surefire-reports/*
+            **/failsafe-reports/*
 
   # Test JUnit Jupiter module with JUnit 6.x (requires Java 17+)
-  junit6-verify:
+  build-and-verify-junit6:
     name: Verify JUnit Jupiter with JUnit 6.x - JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -44,6 +62,8 @@ jobs:
         java:
           - 17
           - 21
+          - 25
+          - 26
     steps:
       - name: Checkout arquillian-core
         uses: actions/checkout@v7
@@ -55,3 +75,10 @@ jobs:
           cache: maven
       - name: Build with JUnit 6.x
         run: mvn --batch-mode --no-transfer-progress clean verify -Pjunit6 -pl junit5/core,junit5/container -am
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: ${{ matrix.java }}-test-reports-junit6
+          path: |
+            **/surefire-reports/*
+            **/failsafe-reports/*


### PR DESCRIPTION
* Rename .github/workflows/ci.yml to maven.yml and the workflow to "Maven"
* Trigger on merge_group checks_requested to support merge queues and save CI resources if enabled
* Restrict permissions to contents: read
* Cancel in-progress runs of the same workflow and ref
* Add JDK 26 to the build matrices and JDK 25 to the JUnit 6.x matrix
* Rename junit6-verify to build-and-verify-junit6
* Upload surefire/failsafe reports as artifacts on failure

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


Fixes #

## Summary by Sourcery

Update Maven CI workflow configuration to support merge queues, expand Java test coverage, and improve failure diagnostics.

Build:
- Rename the main CI workflow to Maven and adjust triggers to include merge_group checks_requested.
- Restrict workflow permissions to read-only repository contents and enable concurrency with in-progress run cancellation.
- Extend Maven build matrix to include JDK 26 and add JDK 25–26 to the JUnit 6.x verification matrix.
- Rename the JUnit 6 verification job to build-and-verify-junit6 for clearer intent.
- Upload Surefire and Failsafe test reports as artifacts when CI jobs fail to aid debugging.