### PR TITLE
[#884] Add Javadoc to ContainerController and clarify config override…

### DIFF
--- a/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
+++ b/container/test-api/src/main/java/org/jboss/arquillian/container/test/api/ContainerController.java
@@ -56,13 +56,46 @@ import java.util.Map;
  * @author <a href="mailto:mgencur@redhat.com">Martin Gencur</a>
  */
 public interface ContainerController {
+
+    /**
+     * Starts the container with the given qualifier using its existing configuration.
+     *
+     * @param containerQualifier the qualifier of the container to start
+     */
     void start(String containerQualifier);
 
-    void start(String containerQualifier, Map<String, String> config);
+    /**
+     * Starts the container with the given qualifier, applying the provided configuration overrides
+     * on top of the existing container configuration (e.g. from {@code arquillian.xml}).
+     * <p>
+     * Note: this method re-fires the {@code SetupContainer} event so the container adapter picks up
+     * the overridden configuration. This means {@code setup()} is called twice for the container –
+     * once during suite setup with the original configuration, and again here with the merged configuration.
+     *
+     * @param containerQualifier the qualifier of the container to start
+     * @param configurationOverride configuration properties to override before starting the container
+     */
+    void start(String containerQualifier, Map<String, String> configurationOverride);
 
+    /**
+     * Stops the container with the given qualifier.
+     *
+     * @param containerQualifier the qualifier of the container to stop
+     */
     void stop(String containerQualifier);
 
+    /**
+     * Kills the container with the given qualifier.
+     *
+     * @param containerQualifier the qualifier of the container to kill
+     */
     void kill(String containerQualifier);
 
+    /**
+     * Returns whether the container with the given qualifier is started.
+     *
+     * @param containerQualifier the qualifier of the container to check
+     * @return {@code true} if the container is started, {@code false} otherwise
+     */
     boolean isStarted(String containerQualifier);
 }

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerController.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ClientContainerController.java
@@ -101,7 +101,7 @@ public class ClientContainerController implements ContainerController {
     }
 
     @Override
-    public void start(String containerQualifier, Map<String, String> config) {
+    public void start(String containerQualifier, Map<String, String> configurationOverride) {
         DeploymentScenario scenario = deploymentScenario.get();
         if (scenario == null) {
             throw new IllegalArgumentException("No deployment scenario in context");
@@ -126,8 +126,8 @@ public class ClientContainerController implements ContainerController {
 
         Container container = registry.getContainer(new TargetDescription(containerQualifier));
 
-        for (String name : config.keySet()) {
-            container.getContainerConfiguration().overrideProperty(name, config.get(name));
+        for (String name : configurationOverride.keySet()) {
+            container.getContainerConfiguration().overrideProperty(name, configurationOverride.get(name));
         }
 
         log.info("Manual starting of a server instance with overridden configuration. New configuration: " +

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerController.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/ContainerContainerController.java
@@ -43,8 +43,8 @@ public class ContainerContainerController implements ContainerController {
     }
 
     @Override
-    public void start(String containerQualifier, Map<String, String> config) {
-        getCommandService().execute(new StartContainerCommand(containerQualifier, config));
+    public void start(String containerQualifier, Map<String, String> configurationOverride) {
+        getCommandService().execute(new StartContainerCommand(containerQualifier, configurationOverride));
     }
 
     @Override

--- a/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StartContainerCommand.java
+++ b/container/test-impl-base/src/main/java/org/jboss/arquillian/container/test/impl/client/container/command/StartContainerCommand.java
@@ -30,26 +30,23 @@ public class StartContainerCommand extends AbstractCommand<String> {
 
     private String containerQualifier;
 
-    private Map<String, String> configuration;
+    private Map<String, String> configurationOverride;
 
     public StartContainerCommand(String containerQualifier) {
         this.containerQualifier = containerQualifier;
-        this.configuration = null;
+        this.configurationOverride = null;
     }
 
-    public StartContainerCommand(String containerQualifier, Map<String, String> config) {
+    public StartContainerCommand(String containerQualifier, Map<String, String> configurationOverride) {
         this.containerQualifier = containerQualifier;
-        this.configuration = config;
+        this.configurationOverride = configurationOverride;
     }
 
-    /**
-     * @return the containerQualifier
-     */
     public String getContainerQualifier() {
         return containerQualifier;
     }
 
     public Map<String, String> getConfiguration() {
-        return configuration;
+        return configurationOverride;
     }
 }


### PR DESCRIPTION
… semantics

Also document SetupContainer double-fire behavior on start with overrides

## Summary by Sourcery

Clarify container start configuration override behavior and document the ContainerController lifecycle API.

Enhancements:
- Document container lifecycle operations and clarify that configuration passed to manual starts overrides existing settings while re-firing setup with the merged configuration.
- Align container start command and controller naming with configuration-override semantics.