### PR TITLE
[#771] Fix JUnit Jupiter template tests in container mode (`@RepeatedTest` and `@ParametrizedTest`)

### DIFF
--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/mixed/MixedRunModeParameterizedTestTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/mixed/MixedRunModeParameterizedTestTest.java
@@ -28,14 +28,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
 @ArquillianIntegrationTest({
         @TraceStep(name = "before_all", runsWhere = CLIENT, order = 0),
         @TraceStep(name = "before_each", runsWhere = SERVER, order = 1),

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/mixed/MixedRunModeRepeatedTestTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/mixed/MixedRunModeRepeatedTestTest.java
@@ -28,13 +28,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
 @ArquillianIntegrationTest({
         @TraceStep(name = "before_all", runsWhere = CLIENT, order = 0),
         @TraceStep(name = "before_each", runsWhere = SERVER, order = 1),

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/server/ServerSideParameterizedTestTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/server/ServerSideParameterizedTestTest.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
 @ArquillianIntegrationTest({
         @TraceStep(name = "before_all", runsWhere = CLIENT, order = 0),
         @TraceStep(name = "before_each", runsWhere = SERVER, order = 1),

--- a/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/server/ServerSideRepeatedTestTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/jboss/arquillian/integration/test/lifecycle/server/ServerSideRepeatedTestTest.java
@@ -27,13 +27,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
 @ArquillianIntegrationTest({
         @TraceStep(name = "before_all", runsWhere = CLIENT, order = 0),
         @TraceStep(name = "before_each", runsWhere = SERVER, order = 1),

--- a/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitIntegrationTestCase.java
+++ b/junit/container/src/test/java/org/jboss/arquillian/junit/container/JUnitIntegrationTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.arquillian.junit.container;
 
+import org.jboss.arquillian.junit.container.fixtures.ClassWithArquillianRunnerWithRules;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
 import org.junit.Assert;
 import org.junit.Test;

--- a/junit/container/src/test/java/org/jboss/arquillian/junit/container/fixtures/ClassWithArquillianRunnerWithRules.java
+++ b/junit/container/src/test/java/org/jboss/arquillian/junit/container/fixtures/ClassWithArquillianRunnerWithRules.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.junit.container;
+package org.jboss.arquillian.junit.container.fixtures;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.After;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionAndParameterizedTest.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionAndParameterizedTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2021 Red Hat Inc. and/or its affiliates and other contributors
+ * Copyright 2026 Red Hat Inc. and/or its affiliates and other contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -17,51 +17,15 @@
 package org.jboss.arquillian.junit5.container;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.Cycle;
-import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.wasCalled;
-
 @ExtendWith(ArquillianExtension.class)
 public class ClassWithArquillianExtensionAndParameterizedTest {
 
-  @BeforeAll
-  public static void beforeClass() throws Throwable {
-    wasCalled(Cycle.BEFORE_CLASS);
-  }
-
-  @AfterAll
-  public static void afterClass() throws Throwable {
-    wasCalled(Cycle.AFTER_CLASS);
-  }
-
-  @BeforeEach
-  public void before() throws Throwable {
-    wasCalled(Cycle.BEFORE);
-  }
-
-  @AfterEach
-  public void after() throws Throwable {
-    wasCalled(Cycle.AFTER);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"one", "two"})
-  public void failingTest() throws Throwable {
-    wasCalled(Cycle.TEST);
-    Assertions.fail("Intentionally failing the test.");
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"one", "two"})
-  public void succeedingTest() throws Throwable {
-    wasCalled(Cycle.TEST);
-  }
+    @ParameterizedTest
+    @ValueSource(strings = {"one", "two", "three"})
+    public void parameterizedTest(String param) {
+    }
 }

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionAndRepeatedTest.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/ClassWithArquillianExtensionAndRepeatedTest.java
@@ -16,14 +16,7 @@
  */
 package org.jboss.arquillian.junit5.container;
 
-import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.Cycle;
-import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.wasCalled;
-
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -33,28 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ArquillianExtension.class)
 public class ClassWithArquillianExtensionAndRepeatedTest {
 
-    @BeforeAll
-    public static void beforeClass() throws Throwable {
-        wasCalled(Cycle.BEFORE_CLASS);
-    }
-
-    @AfterAll
-    public static void afterClass() throws Throwable {
-        wasCalled(Cycle.AFTER_CLASS);
-    }
-
-    @BeforeEach
-    public void before() throws Throwable {
-        wasCalled(Cycle.BEFORE);
-    }
-
-    @AfterEach
-    public void after() throws Throwable {
-        wasCalled(Cycle.AFTER);
-    }
-
     @RepeatedTest(3)
-    public void repeatedTest() throws Throwable {
-        wasCalled(Cycle.TEST);
+    public void repeatedTest() {
     }
 }

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitIntegrationTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitIntegrationTestCase.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 
+import org.jboss.arquillian.junit5.container.fixtures.ClassWithArquillianExtensionWithExtensions;
+import org.jboss.arquillian.junit5.container.fixtures.ExampleSuite;
 import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
 import org.junit.jupiter.api.Assertions;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterParameterizedTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterParameterizedTestCase.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import java.util.Map;
 
 import org.jboss.arquillian.junit5.IdentifiedTestException;
+import org.jboss.arquillian.junit5.container.fixtures.ClassWithArquillianExtensionAndParameterizedTest;
 import org.jboss.arquillian.junit5.extension.RunModeEvent;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterParameterizedTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterParameterizedTestCase.java
@@ -19,35 +19,32 @@ package org.jboss.arquillian.junit5.container;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.lang.reflect.Method;
+import java.util.Map;
 
+import org.jboss.arquillian.junit5.IdentifiedTestException;
 import org.jboss.arquillian.junit5.extension.RunModeEvent;
-import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
 import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
-import org.mockito.invocation.InvocationOnMock;
 
-@Disabled("https://github.com/arquillian/arquillian-core/issues/771")
 public class JUnitJupiterParameterizedTestCase extends JUnitTestBaseClass {
+
+    private static final String EXPECTED_DETAIL_MESSAGE = "expected: <3.14> but was: <2.71>";
+    private static final AssertionError ASSERTION_ERROR = new AssertionError(EXPECTED_DETAIL_MESSAGE);
+    private static final Class<?> FIXTURE_CLASS = ClassWithArquillianExtensionAndParameterizedTest.class;
+    private static final String TEST_METHOD_ID_FORMAT = "[engine:junit-jupiter]"
+            + "/[class:" + FIXTURE_CLASS.getName() + "]"
+            + "/[test-template:parameterizedTest(java.lang.String)]"
+            + "/[test-template-invocation:#%d]";
 
     @Override
     protected void executeAllLifeCycles(TestRunnerAdaptor adaptor) throws Exception {
-        doAnswer(new ExecuteLifecycle()).when(adaptor).beforeClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).afterClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).before(any(Object.class),
-                any(Method.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).after(any(Object.class),
-                any(Method.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new TestExecuteLifecycle()).when(adaptor).test(any(TestMethodExecutor.class));
         doAnswer(invocation -> {
             TestLifecycleEvent event = invocation.getArgument(0);
             if (event instanceof RunModeEvent) {
@@ -58,35 +55,83 @@ public class JUnitJupiterParameterizedTestCase extends JUnitTestBaseClass {
     }
 
     @Test
-    public void shouldExecuteParameterizedTestOnceInContainer() throws Exception {
+    public void shouldPassAllInvocations() throws Exception {
         // given
         TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
         executeAllLifeCycles(adaptor);
+        doAnswer(invocation -> TestResult.passed())
+                .when(adaptor).test(any(TestMethodExecutor.class));
 
         // when
-        TestExecutionSummary result = run(adaptor, ClassWithArquillianExtensionAndParameterizedTest.class);
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
+
+        // then
+        Assertions.assertEquals(3, result.getTestsSucceededCount());
+        Assertions.assertEquals(0, result.getTestsFailedCount());
+        verify(adaptor).test(any(TestMethodExecutor.class));
+    }
+
+    @Test
+    public void shouldFailAllInvocations() throws Exception {
+        // given
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+        // Run 1: ClassWithArquillianExtensionAndParameterizedTest.parameterizedTest:29 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 2: ClassWithArquillianExtensionAndParameterizedTest.parameterizedTest:29 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 3: ClassWithArquillianExtensionAndParameterizedTest.parameterizedTest:29 failed:
+        // expected: <3.14> but was: <2.71>
+        doAnswer(invocation -> TestResult.failed(new IdentifiedTestException(Map.of(
+                uniqueId(1), ASSERTION_ERROR,
+                uniqueId(2), ASSERTION_ERROR,
+                uniqueId(3), ASSERTION_ERROR))))
+                .when(adaptor).test(any(TestMethodExecutor.class));
+
+        // when
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
+
+        // then
+        Assertions.assertEquals(0, result.getTestsSucceededCount());
+        Assertions.assertEquals(3, result.getTestsFailedCount());
+        for (int i = 0; i < result.getFailures().size();) {
+            TestExecutionSummary.Failure failure = result.getFailures().get(i++);
+            Assertions.assertTrue(failure.getTestIdentifier().getDisplayName().contains("[" + i + "]"),
+                    "Run " + i + ": expected the display name to contain [" + i + "]");
+            Assertions.assertTrue(failure.getException().getMessage().contains(EXPECTED_DETAIL_MESSAGE),
+                    "Run " + i + ": expected failure message");
+        }
+        verify(adaptor).test(any(TestMethodExecutor.class));
+    }
+
+    @Test
+    public void shouldFailOnlySecondInvocation() throws Exception {
+        // given
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+        // Run 1: Pass
+        // Run 2: ClassWithArquillianExtensionAndParameterizedTest.parameterizedTest:29 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 3: Pass
+        doAnswer(invocation -> TestResult
+                .failed(new IdentifiedTestException(Map.of(uniqueId(2), ASSERTION_ERROR))))
+                .when(adaptor).test(any(TestMethodExecutor.class));
+
+        // when
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
 
         // then
         Assertions.assertEquals(2, result.getTestsSucceededCount());
-        Assertions.assertEquals(2, result.getTestsFailedCount());
-        Assertions.assertEquals(0, result.getTestsSkippedCount());
-        verify(adaptor).beforeClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        verify(adaptor).afterClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        verify(adaptor, times(4)).before(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
-        verify(adaptor, times(4)).after(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
-        verify(adaptor, times(2)).test(any(TestMethodExecutor.class));
+        Assertions.assertEquals(1, result.getTestsFailedCount());
+        TestExecutionSummary.Failure failure = result.getFailures().get(0);
+        Assertions.assertTrue(failure.getTestIdentifier().getDisplayName().contains("[2]"),
+                "Run 2: expected the 2nd invocation to be the failed one");
+        Assertions.assertTrue(failure.getException().getMessage().contains(EXPECTED_DETAIL_MESSAGE),
+                "Run 2: expected failure message");
+        verify(adaptor).test(any(TestMethodExecutor.class));
     }
 
-    public static class TestExecuteLifecycle extends ExecuteLifecycle {
-
-        @Override
-        public Object answer(InvocationOnMock invocation) throws Throwable {
-            try {
-                super.answer(invocation);
-            } catch (Throwable t) {
-                return TestResult.failed(t);
-            }
-            return TestResult.passed();
-        }
+    private static String uniqueId(int invocation) {
+        return String.format(TEST_METHOD_ID_FORMAT, invocation);
     }
 }

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterRepeatedTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterRepeatedTestCase.java
@@ -16,15 +16,19 @@
  */
 package org.jboss.arquillian.junit5.container;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.lang.reflect.Method;
+import java.util.Map;
 
-import org.jboss.arquillian.test.spi.LifecycleMethodExecutor;
+import org.jboss.arquillian.junit5.IdentifiedTestException;
+import org.jboss.arquillian.junit5.extension.RunModeEvent;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.TestRunnerAdaptor;
+import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
@@ -37,42 +41,102 @@ import org.junit.platform.launcher.listeners.TestExecutionSummary;
  */
 public class JUnitJupiterRepeatedTestCase extends JUnitTestBaseClass {
 
+    private static final String EXPECTED_DETAIL_MESSAGE = "expected: <3.14> but was: <2.71>";
+    private static final AssertionError ASSERTION_ERROR = new AssertionError(EXPECTED_DETAIL_MESSAGE);
+    private static final Class<?> FIXTURE_CLASS = ClassWithArquillianExtensionAndRepeatedTest.class;
+    private static final String TEST_METHOD_ID_FORMAT = "[engine:junit-jupiter]"
+            + "/[class:" + FIXTURE_CLASS.getName() + "]"
+            + "/[test-template:repeatedTest()]"
+            + "/[test-template-invocation:#%d]";
+
     @Override
     protected void executeAllLifeCycles(TestRunnerAdaptor adaptor) throws Exception {
-        doAnswer(new ExecuteLifecycle()).when(adaptor).beforeClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).afterClass(any(Class.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).before(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new ExecuteLifecycle()).when(adaptor).after(any(Object.class), any(Method.class), any(LifecycleMethodExecutor.class));
-        doAnswer(new TestExecuteLifecycle()).when(adaptor).test(any(TestMethodExecutor.class));
+        doAnswer(invocation -> {
+            TestLifecycleEvent event = invocation.getArgument(0);
+            if (event instanceof RunModeEvent) {
+                ((RunModeEvent) event).setRunAsClient(false);
+            }
+            return null;
+        }).when(adaptor).fireCustomLifecycle(any(TestLifecycleEvent.class));
     }
 
     @Test
-    public void shouldExecuteRepeatedTestExactlyThreeTimes() throws Exception {
+    public void shouldPassAllRepetitions() throws Exception {
         // given
         TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
         executeAllLifeCycles(adaptor);
+        doAnswer(invocation -> TestResult.passed())
+                .when(adaptor).test(any(TestMethodExecutor.class));
 
         // when
-        TestExecutionSummary result = run(adaptor, ClassWithArquillianExtensionAndRepeatedTest.class);
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
 
-        // then — @RepeatedTest(3) must run exactly 3 times, not 9
+        // then
         Assertions.assertEquals(3, result.getTestsSucceededCount());
         Assertions.assertEquals(0, result.getTestsFailedCount());
-        Assertions.assertEquals(0, result.getTestsSkippedCount());
-        assertCycle(1, Cycle.BEFORE_CLASS, Cycle.AFTER_CLASS);
-        assertCycle(3, Cycle.BEFORE, Cycle.TEST, Cycle.AFTER);
+        verify(adaptor).test(any(TestMethodExecutor.class));
     }
 
-    public static class TestExecuteLifecycle extends ExecuteLifecycle {
+    @Test
+    public void shouldFailAllRepetitions() throws Exception {
+        // given
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+        // Run 1: ClassWithArquillianExtensionAndRepeatedTest.repeatedTest:30 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 2: ClassWithArquillianExtensionAndRepeatedTest.repeatedTest:30 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 3: ClassWithArquillianExtensionAndRepeatedTest.repeatedTest:30 failed:
+        // expected: <3.14> but was: <2.71>
+        doAnswer(invocation -> TestResult.failed(new IdentifiedTestException(Map.of(
+                uniqueId(1), ASSERTION_ERROR,
+                uniqueId(2), ASSERTION_ERROR,
+                uniqueId(3), ASSERTION_ERROR))))
+                .when(adaptor).test(any(TestMethodExecutor.class));
 
-        @Override
-        public Object answer(org.mockito.invocation.InvocationOnMock invocation) {
-            try {
-                super.answer(invocation);
-            } catch (Throwable t) {
-                return TestResult.failed(t);
-            }
-            return TestResult.passed();
+        // when
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
+
+        // then
+        Assertions.assertEquals(0, result.getTestsSucceededCount());
+        Assertions.assertEquals(3, result.getTestsFailedCount());
+        for (int i = 0; i < result.getFailures().size();) {
+            TestExecutionSummary.Failure failure = result.getFailures().get(i++); // post-increment
+            Assertions.assertEquals("repetition " + i + " of " + result.getTestsFailedCount(),
+                    failure.getTestIdentifier().getDisplayName());
+            Assertions.assertTrue(failure.getException().getMessage().contains(EXPECTED_DETAIL_MESSAGE),
+                    "Run " + i + ": expected failure message");
         }
+        verify(adaptor).test(any(TestMethodExecutor.class));
+    }
+
+    @Test
+    public void shouldFailOnlySecondRepetition() throws Exception {
+        // given
+        TestRunnerAdaptor adaptor = mock(TestRunnerAdaptor.class);
+        executeAllLifeCycles(adaptor);
+        // Run 1: Pass
+        // Run 2: ClassWithArquillianExtensionAndRepeatedTest.repeatedTest:30 failed:
+        // expected: <3.14> but was: <2.71>
+        // Run 3: Pass
+        doAnswer(invocation -> TestResult
+                .failed(new IdentifiedTestException(Map.of(uniqueId(2), ASSERTION_ERROR))))
+                .when(adaptor).test(any(TestMethodExecutor.class));
+
+        // when
+        TestExecutionSummary result = run(adaptor, FIXTURE_CLASS);
+
+        // then
+        Assertions.assertEquals(2, result.getTestsSucceededCount());
+        Assertions.assertEquals(1, result.getTestsFailedCount());
+        TestExecutionSummary.Failure failure = result.getFailures().get(0);
+        Assertions.assertEquals("repetition 2 of 3", failure.getTestIdentifier().getDisplayName());
+        Assertions.assertTrue(failure.getException().getMessage().contains(EXPECTED_DETAIL_MESSAGE),
+                "Run 2: expected failure message");
+        verify(adaptor).test(any(TestMethodExecutor.class));
+    }
+
+    private static String uniqueId(int repetition) {
+        return String.format(TEST_METHOD_ID_FORMAT, repetition);
     }
 }

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterRepeatedTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterRepeatedTestCase.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import java.util.Map;
 
 import org.jboss.arquillian.junit5.IdentifiedTestException;
+import org.jboss.arquillian.junit5.container.fixtures.ClassWithArquillianExtensionAndRepeatedTest;
 import org.jboss.arquillian.junit5.extension.RunModeEvent;
 import org.jboss.arquillian.test.spi.TestMethodExecutor;
 import org.jboss.arquillian.test.spi.TestResult;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunnerTestCase.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/JUnitJupiterTestRunnerTestCase.java
@@ -17,6 +17,7 @@
 package org.jboss.arquillian.junit5.container;
 
 import org.jboss.arquillian.junit5.IdentifiedTestException;
+import org.jboss.arquillian.junit5.container.fixtures.TestScenarios;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionAndParameterizedTest.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionAndParameterizedTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionAndRepeatedTest.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionAndRepeatedTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.junit.jupiter.api.RepeatedTest;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionWithExtensions.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ClassWithArquillianExtensionWithExtensions.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.Cycle;
 import static org.jboss.arquillian.junit5.container.JUnitTestBaseClass.wasCalled;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ExampleSuite.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/ExampleSuite.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import org.junit.platform.suite.api.ExcludeTags;
 import org.junit.platform.suite.api.IncludeTags;

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/TestScenarios.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/TestScenarios.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -83,7 +83,7 @@ public class TestScenarios {
   }
 
   @Nested
-  class NestedTestScenarios {
+  public class NestedTestScenarios {
 
     @Test
     public void shouldPassOnAssumptionInNested() {

--- a/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/TestsWithIncludesExcludes.java
+++ b/junit5/container/src/test/java/org/jboss/arquillian/junit5/container/fixtures/TestsWithIncludesExcludes.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.junit5.container;
+package org.jboss.arquillian.junit5.container.fixtures;
 
 import org.jboss.arquillian.junit5.container.annotation.ArquillianTest;
 import org.junit.jupiter.api.Disabled;

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ArquillianExtension.java
@@ -154,8 +154,13 @@ public class ArquillianExtension implements BeforeAllCallback, AfterAllCallback,
             } else {
                 // Run as container (but only once)
                 if (!contextStore.isRegisteredTemplate(invocationContext.getExecutable())) {
-                    result = interceptInvocation(invocation, extensionContext);
+                    TestResult serverResult = interceptInvocation(invocation, extensionContext);
+                    contextStore.registerTemplateResultMapper(invocationContext.getExecutable(), serverResult);
+                } else {
+                    invocation.skip();
                 }
+                result = contextStore.getTemplateResultMapper(invocationContext.getExecutable())
+                        .resultFor(extensionContext.getUniqueId());
             }
             throwError(result);
         }

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/ContextStore.java
@@ -2,6 +2,7 @@ package org.jboss.arquillian.junit5;
 
 import java.lang.reflect.Method;
 
+import org.jboss.arquillian.test.spi.TestResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 class ContextStore {
@@ -26,17 +27,21 @@ class ContextStore {
     }
 
     private ExtensionContext.Store getTemplateStore() {
-        return context.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, INTERCEPTED_TEMPLATE_NAMESPACE_KEY));
+        ExtensionContext templateContext = context.getParent().orElse(context);
+        return templateContext.getStore(ExtensionContext.Namespace.create(NAMESPACE_KEY, INTERCEPTED_TEMPLATE_NAMESPACE_KEY));
     }
 
     boolean isRegisteredTemplate(Method method) {
-        final ExtensionContext.Store templateStore = getTemplateStore();
+        return getTemplateStore().get(method.toGenericString()) != null;
+    }
 
-        final boolean isRegistered = templateStore.getOrDefault(method.toGenericString(), boolean.class, false);
-        if (!isRegistered) {
-            templateStore.put(method.toGenericString(), true);
-        }
-        return isRegistered;
+    void registerTemplateResultMapper(Method method, TestResult result) {
+        getTemplateStore().put(method.toGenericString(),
+            new TemplateResultMapper(result != null ? result : TestResult.passed()));
+    }
+
+    TemplateResultMapper getTemplateResultMapper(Method method) {
+        return getTemplateStore().get(method.toGenericString(), TemplateResultMapper.class);
     }
 
     /**

--- a/junit5/core/src/main/java/org/jboss/arquillian/junit5/TemplateResultMapper.java
+++ b/junit5/core/src/main/java/org/jboss/arquillian/junit5/TemplateResultMapper.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2026 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.junit5;
+
+import org.jboss.arquillian.test.spi.TestResult;
+
+class TemplateResultMapper {
+
+    private final TestResult aggregatedResult;
+
+    TemplateResultMapper(TestResult aggregatedResult) {
+        this.aggregatedResult = aggregatedResult;
+    }
+
+    TestResult resultFor(String uniqueId) {
+        if (aggregatedResult == null
+                || aggregatedResult.getStatus() == TestResult.Status.PASSED) {
+            return aggregatedResult;
+        }
+
+        if (aggregatedResult.getStatus() == TestResult.Status.FAILED
+            && aggregatedResult.getThrowable() instanceof IdentifiedTestException) {
+            IdentifiedTestException identified = (IdentifiedTestException) aggregatedResult.getThrowable();
+
+            Throwable failure = identified.getCollectedExceptions().get(uniqueId);
+            return failure == null
+                    ? TestResult.passed()
+                    : TestResult.failed(failure);
+        }
+        return aggregatedResult;
+    }
+}

--- a/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGTestRunnerTestCase.java
+++ b/testng/container/src/test/java/org/jboss/arquillian/testng/container/TestNGTestRunnerTestCase.java
@@ -18,6 +18,8 @@ package org.jboss.arquillian.testng.container;
 
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.testng.container.fixtures.ShouldProvideConfigurationFailureToTestRunner;
+import org.jboss.arquillian.testng.container.fixtures.ShouldProvideVariousTestResultsToTestRunner;
 import org.junit.Assert;
 import org.junit.Test;
 import org.testng.SkipException;

--- a/testng/container/src/test/java/org/jboss/arquillian/testng/container/fixtures/ShouldProvideConfigurationFailureToTestRunner.java
+++ b/testng/container/src/test/java/org/jboss/arquillian/testng/container/fixtures/ShouldProvideConfigurationFailureToTestRunner.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.testng.container;
+package org.jboss.arquillian.testng.container.fixtures;
 
 import org.junit.Assert;
 import org.testng.annotations.BeforeClass;

--- a/testng/container/src/test/java/org/jboss/arquillian/testng/container/fixtures/ShouldProvideVariousTestResultsToTestRunner.java
+++ b/testng/container/src/test/java/org/jboss/arquillian/testng/container/fixtures/ShouldProvideVariousTestResultsToTestRunner.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.arquillian.testng.container;
+package org.jboss.arquillian.testng.container.fixtures;
 
 import java.lang.reflect.Method;
 import org.testng.Assert;


### PR DESCRIPTION
Fixes #771

Explanation of the fix I brought here: https://github.com/arquillian/arquillian-core/pull/846#issuecomment-4518917623.

TL;DR: `interceptTestTemplateMethod` is called on every iteration of the template method. If an exception (e.g., `AssertionError`, might be only it) is thrown within its body, it maps which specific run (`Run #N`) failed and which passed, making the execution order important.

`TemplateResultMapper` essentially captures the result of the first fired `TEST` event (other adapter.test are not invoked) and maps the outcomes of the other `interceptTestTemplateMethod` executions (whether they pass or throw an error).


~`TemplateResultMapper` relies on JUnit 5's internal unique ID format for template test methods (`@RepeatedTest` and `@ParameterizedTest`) to dispatch per-invocation test results from aggregated server-side `TestResult` objects.
The mapper uses `matchesInvocationIndex()` to extract the invocation number by matching the tail of the unique ID: `endsWith("#" + invocationIndex + "]")`.~

~For `@ParameterizedTest` Format~
```
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:parameterizedTest(java.lang.String)]/[test-template-invocation:#1]
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:parameterizedTest(java.lang.String)]/[test-template-invocation:#2]
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:parameterizedTest(java.lang.String)]/[test-template-invocation:#3]
```

~For `@RepeatedTest` Format:~
```
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:repeatedTest()]/[test-template-invocation:#1]
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:repeatedTest()]/[test-template-invocation:#2]
[engine:junit-jupiter]/[class:org.example.MyTest]/[test-template:repeatedTest()]/[test-template-invocation:#3]
```

~This unique ID format is a **JUnit 5 implementation** detail that Arquillian cannot control. While the current format has been stable, it could theoretically change in future JUnit versions.~

~I was maybe thinking of adding a simple unit test that would test the output of `IdentifiedTestException#getCollectedExceptions#getKey()` and that it ends with `[test-template-invocation:#N]` for template run errors, but I find the idea of testing a external dependency behavior a bit silly :-).~

EDIT: I used `.get(ExtensionContext.getUniqueId())` instead and that does the trick :)

On top of that:
- moved fixture classes (i.e. test classes for test classes ;-)) to dedicated package (not to be confused with actual test classes).
- removed `Disabled` annotations
- removed unnecessary lifecycles from the unit test (e.g beforeEach, AfterEach, ...)  since they are already tested by IT so they are polluting IMHO (but I can revert this if you wish to).
- for `RepeatedTest` and `ParametrizedTest` I had to properly mock test results from the container 

e.g
```java
doAnswer(invocation -> TestResult.failed(new IdentifiedTestException(Map.of(
                uniqueId(2), ASSERTION_ERROR)))
                .when(adaptor).test(any(TestMethodExecutor.class));
```

## Summary by Sourcery

Restore reliable container-mode execution and failure reporting for JUnit Jupiter repeated and parameterized tests.

Bug Fixes:
- Fix JUnit Jupiter `@RepeatedTest` and `@ParameterizedTest` execution in container mode by correctly mapping aggregated container results to individual template invocations.
- Ensure container-side template skips, unidentifiable failures, and round-trip errors are reported without silently passing invocations or repeatedly contacting the container.

Enhancements:
- Keep container result bookkeeping isolated for each test template, including classes containing multiple templates.
- Reorganize test fixtures into dedicated fixture packages and simplify fixture and lifecycle test setup.

Tests:
- Re-enable integration coverage for repeated and parameterized tests and add scenarios covering passing, fully failing, partially failing, skipped, and unreachable-container outcomes.
- Add coverage verifying independent result mapping for multiple templates in one test class.